### PR TITLE
fix: use snake cased entities in durable objects

### DIFF
--- a/src/handlers/update-user.ts
+++ b/src/handlers/update-user.ts
@@ -15,8 +15,7 @@ export async function updateUser(env: Env, tenantId: string, email: string) {
   const db = getDb(env);
   const existingUsers = await db
     .selectFrom("users")
-    .where("id", "=", profile.id)
-    .where("tenantId", "=", tenantId)
+    .where("id", "=", userId)
     .selectAll()
     .execute();
 
@@ -27,13 +26,13 @@ export async function updateUser(env: Env, tenantId: string, email: string) {
       .values({
         id: userId,
         email: profile.email,
-        givenName: profile.givenName || "",
-        familyName: profile.familyName || "",
+        givenName: profile.given_name || "",
+        familyName: profile.family_name || "",
         name: profile.name || "",
         nickname: profile.nickname || "",
         picture: profile.picture || "",
-        createdAt: profile.createdAt,
-        modifiedAt: profile.modifiedAt,
+        createdAt: profile.created_at,
+        modifiedAt: profile.modified_at,
         tenantId,
       })
       .execute();
@@ -42,15 +41,14 @@ export async function updateUser(env: Env, tenantId: string, email: string) {
       .updateTable("users")
       .set({
         email: profile.email,
-        givenName: profile.givenName,
-        familyName: profile.familyName,
+        givenName: profile.given_name,
+        familyName: profile.family_name,
         nickname: profile.nickname,
         name: profile.name,
         picture: profile.picture,
         modifiedAt: new Date().toISOString(),
       })
-      .where("id", "=", profile.id)
-      .where("tenantId", "=", tenantId)
+      .where("id", "=", userId)
       .execute();
   }
 }

--- a/src/helpers/generate-auth-response.ts
+++ b/src/helpers/generate-auth-response.ts
@@ -77,8 +77,8 @@ export async function generateAuthResponse({
   const idToken = await tokenFactory.createIDToken({
     clientId: authParams.client_id,
     userId: userId,
-    given_name: profile.givenName,
-    family_name: profile.familyName,
+    given_name: profile.given_name,
+    family_name: profile.family_name,
     nickname: profile.nickname,
     name: profile.name,
     iss: env.ISSUER,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -17,7 +17,7 @@ import { AuthParams } from "../types/AuthParams";
 import { v4 as uuidv4 } from "uuid";
 import { Env } from "../types";
 import { QueueMessage, sendUserEvent, UserEvent } from "../services/events";
-import { User as Profile } from "../types/sql";
+import { Profile } from "../types";
 
 interface Code {
   authParams?: AuthParams;
@@ -74,16 +74,16 @@ async function updateUser(
   if (!existingProfile || !existingProfile.id) {
     existingProfile = {
       id: uuidv4(),
-      modifiedAt: "",
+      modified_at: "",
       connections: [],
-      createdAt: new Date().toISOString(),
+      created_at: new Date().toISOString(),
       ...profile,
     };
   }
 
   const updatedProfile: Profile = {
     ...existingProfile,
-    modifiedAt: new Date().toISOString(),
+    modified_at: new Date().toISOString(),
   };
 
   profile.connections?.forEach((connection) => {
@@ -94,17 +94,12 @@ async function updateUser(
 
     updatedProfile.connections?.push(connection);
 
-    // Set standard fields if allready defined in profile
-    Object.keys(PROFILE_FIELDS)
-      .filter((key) => !updatedProfile[key])
-      .forEach((key) => {
-        updatedProfile[key] = connection.profile?.[key];
-      });
-  });
-
-  // Set standard fields if specified in profile
-  PROFILE_FIELDS.filter((key) => profile[key]).forEach((key) => {
-    updatedProfile[key] = profile[key];
+    // Set standard fields if not allready defined in profile
+    PROFILE_FIELDS.forEach((key) => {
+      if (!updatedProfile[key] && connection.profile?.[key]) {
+        updatedProfile[key] = connection.profile[key];
+      }
+    });
   });
 
   await storage.put(StorageKeys.profile, JSON.stringify(updatedProfile));
@@ -249,10 +244,10 @@ export const userRouter = router({
         email: z.string(),
         tenantId: z.string(),
         id: z.string().optional(),
-        createdAt: z.string().optional(),
-        modifiedAt: z.string().optional(),
-        givenName: z.string().optional(),
-        familyName: z.string().optional(),
+        created_at: z.string().optional(),
+        modified_at: z.string().optional(),
+        given_name: z.string().optional(),
+        family_name: z.string().optional(),
         nickname: z.string().optional(),
         name: z.string().optional(),
         picture: z.string().optional(),
@@ -373,8 +368,8 @@ export const userRouter = router({
           {
             name: "auth",
             profile: {
-              email: input.email
-            }
+              email: input.email,
+            },
           },
         ],
       });

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -74,9 +74,9 @@ export class LoginController extends Controller {
   }
 
   /**
- * Renders a code login form
- * @param request
- */
+   * Renders a code login form
+   * @param request
+   */
   @Get("code")
   public async getLoginWithCode(
     @Request() request: RequestWithContext,
@@ -89,9 +89,9 @@ export class LoginController extends Controller {
   }
 
   /**
-  * Renders a code login form
-  * @param request
-  */
+   * Renders a code login form
+   * @param request
+   */
   @Post("code")
   public async getCode(
     @Request() request: RequestWithContext,
@@ -128,16 +128,19 @@ export class LoginController extends Controller {
       subject: "Login Code",
     });
 
-    this.setHeader(headers.location, `/u/enter-code?state=${state}&username=${params.username}`)
+    this.setHeader(
+      headers.location,
+      `/u/enter-code?state=${state}&username=${params.username}`
+    );
     this.setStatus(302);
 
-    return 'Redirect';
+    return "Redirect";
   }
 
   /**
-* Renders a code submit form
-* @param request
-*/
+   * Renders a code submit form
+   * @param request
+   */
   @Get("enter-code")
   public async getEnterCode(
     @Request() request: RequestWithContext,
@@ -151,9 +154,9 @@ export class LoginController extends Controller {
   }
 
   /**
-* Posts a code
-* @param request
-*/
+   * Posts a code
+   * @param request
+   */
   @Post("enter-code")
   public async postCode(
     @Request() request: RequestWithContext,
@@ -164,7 +167,7 @@ export class LoginController extends Controller {
     const loginState = await getLoginState(env, state);
 
     if (!loginState.authParams.username) {
-      throw new Error('username required in state')
+      throw new Error("username required in state");
     }
 
     const client = await getClient(env, loginState.authParams.client_id);
@@ -176,12 +179,12 @@ export class LoginController extends Controller {
       await user.validateAuthenticationCode.mutate({
         code: params.code,
         email: loginState.authParams.username,
-        tenantId: client.tenantId
-      })
+        tenantId: client.tenantId,
+      });
     } catch (err) {
       return renderEnterCode(env.AUTH_TEMPLATES, this, {
         ...loginState,
-        errorMessage: 'Invalid code'
+        errorMessage: "Invalid code",
       });
     }
 
@@ -221,13 +224,17 @@ export class LoginController extends Controller {
       getId(client.tenantId, loginParams.username)
     );
 
+    if (loginState.authParams.username !== loginParams.username) {
+      loginState.authParams.username = loginParams.username;
+      await setLoginState(env, state, loginState);
+    }
+
     try {
       await user.registerPassword.mutate(loginParams.password);
     } catch (err: any) {
       return renderSignup(env.AUTH_TEMPLATES, this, {
         ...loginState,
         errorMessage: err.message,
-        username: loginParams.username,
       });
     }
 

--- a/src/routes/tsoa/users.ts
+++ b/src/routes/tsoa/users.ts
@@ -15,6 +15,7 @@ import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
 import { NoUserFoundError, NotFoundError } from "../../errors";
 import { getId } from "../../models";
+import { Profile } from "../../types";
 
 @Route("tenants/{tenantId}/users")
 @Tags("users")
@@ -39,7 +40,7 @@ export class UsersController extends Controller {
     @Request() request: RequestWithContext,
     @Path("tenantId") tenantId: string,
     @Path("userId") userId: string
-  ): Promise<User> {
+  ): Promise<Profile> {
     const { env } = request.ctx;
 
     const db = getDb(env);
@@ -47,7 +48,7 @@ export class UsersController extends Controller {
       .selectFrom("users")
       .where("users.tenantId", "=", tenantId)
       .where("users.id", "=", userId)
-      .select('email')
+      .select("email")
       .executeTakeFirst();
 
     if (!dbUser) {
@@ -71,13 +72,14 @@ export class UsersController extends Controller {
     },
     @Path("userId") userId: string,
     @Path("tenantId") tenantId: string
-  ): Promise<User> {
+  ): Promise<Profile> {
     const { env } = request.ctx;
 
     const db = getDb(request.ctx.env);
     const user = await db
       .selectFrom("users")
       .where("users.tenantId", "=", tenantId)
+      .where("users.id", "=", userId)
       .select("email")
       .executeTakeFirst();
 
@@ -103,7 +105,7 @@ export class UsersController extends Controller {
     @Body()
     user: Omit<User, "tenantId" | "createdAt" | "modifiedAt" | "id"> &
       Partial<Pick<User, "createdAt" | "modifiedAt" | "id">>
-  ): Promise<User> {
+  ): Promise<Profile> {
     const { ctx } = request;
 
     const doId = `${tenantId}|${user.email}`;
@@ -111,10 +113,10 @@ export class UsersController extends Controller {
 
     const result = await userInstance.patchProfile.mutate({
       ...user,
-      connections: user.connections || [],
+      connections: [],
       tenantId,
     });
 
-    return result as User;
+    return result as Profile;
   }
 }

--- a/src/templates/render.ts
+++ b/src/templates/render.ts
@@ -88,7 +88,6 @@ export async function renderLogin(
   });
 }
 
-
 export async function renderLoginWithCode(
   bucket: R2Bucket,
   controller: Controller,

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -32,16 +32,23 @@
 //   "family_name": ""
 // }
 
-export interface User {
+interface Connection {
+  name: string;
+  profile?: { [key: string]: string | boolean | number };
+}
+
+export interface Profile {
   id: string;
-  email: string;
+  // TODO: this should probably be snake cased as well. Or maybe stored somewhere else
   tenantId: string;
-  createdAt: string;
-  modifiedAt: string;
-  givenName?: string;
-  familyName?: string;
+  email: string;
+  created_at: string;
+  modified_at: string;
+  given_name?: string;
+  family_name?: string;
   nickname?: string;
   name?: string;
   picture?: string;
   locale?: string;
+  connections: Connection[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,5 +3,6 @@ export * from "./AuthParams";
 export * from "./Token";
 export * from "./LoginState";
 export * from "./Client";
+export * from "./Profile";
 export * from "./Token";
 export * from "./RequestWithContext";

--- a/test/models/User.spec.ts
+++ b/test/models/User.spec.ts
@@ -20,6 +20,16 @@ function createCaller(storage: any) {
 }
 
 describe("User", () => {
+  const date = new Date();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(date);
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it("use jsdom in this test file", () => {
     const element = document.createElement("div");
     expect(element).not.toBeNull();
@@ -94,8 +104,8 @@ describe("User", () => {
       });
 
       expect(profile.name).toEqual("Test");
-      expect(typeof profile.modifiedAt).toBe("string");
-      expect(typeof profile.createdAt).toBe("string");
+      expect(profile.modified_at).toBe(date.toISOString());
+      expect(profile.created_at).toBe(date.toISOString());
       expect(typeof profile.id).toBe("string");
     });
 
@@ -142,8 +152,8 @@ describe("User", () => {
               return JSON.stringify({
                 id: "id",
                 name: "Test",
-                createdAt: "2021-01-01T00:00:00.000Z",
-                modifiedAt: "2021-01-01T00:00:00.000Z",
+                created_at: "2021-01-01T00:00:00.000Z",
+                modified_at: "2021-01-01T00:00:00.000Z",
                 connections: [],
               });
           }
@@ -170,11 +180,10 @@ describe("User", () => {
       });
 
       expect(profile.name).toEqual("Test");
-      expect(typeof profile.modifiedAt).toBe("string");
-      expect(profile.modifiedAt).not.toBe("2021-01-01T00:00:00.000Z");
-      expect(profile.createdAt).toBe("2021-01-01T00:00:00.000Z");
-      expect(profile.givenName).toBe("given_name");
-      expect(profile.familyName).toBe("family_name");
+      expect(profile.modified_at).toBe(date.toISOString());
+      expect(profile.created_at).toBe("2021-01-01T00:00:00.000Z");
+      expect(profile.given_name).toBe("given_name");
+      expect(profile.family_name).toBe("family_name");
       expect(profile.id).toBe("id");
       expect(profile.connections[0].name).toBe("google-oauth2");
     });

--- a/test/routes/tsoa/authenticate.spec.ts
+++ b/test/routes/tsoa/authenticate.spec.ts
@@ -5,7 +5,6 @@ import {
   CodeAuthenticateParams,
   PasswordAuthenticateParams,
 } from "../../../src/routes/tsoa/authenticate";
-import { Env } from "../../../src/types";
 
 describe("Authenticated", () => {
   describe("password", () => {


### PR DESCRIPTION
This fixes some issues with updates to the profile not making it to the sql database. It's a bit nasty now with the durable objects being snake cased so it matches the oauth2-standard, but the sql entities being camel cased which feels more javascript. And then they are once again actually snake cased in the database :)