### PR TITLE
fix: cast bigint to number

### DIFF
--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -13,7 +13,6 @@ import {
   Delete,
 } from "@tsoa/runtime";
 import { nanoid } from "nanoid";
-import { UpdateResult } from "kysely";
 
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
@@ -128,7 +127,7 @@ export class ApplicationsController extends Controller {
     body: Partial<
       Omit<Application, "id" | "tenantId" | "createdAt" | "modifiedAt">
     >,
-  ): Promise<UpdateResult[]> {
+  ) {
     const { env } = request.ctx;
 
     const db = getDb(env);
@@ -149,7 +148,7 @@ export class ApplicationsController extends Controller {
 
     await updateClientInKV(env, id);
 
-    return results;
+    return Number(results[0].numUpdatedRows);
   }
 
   @Post("")

--- a/src/routes/tsoa/connections.ts
+++ b/src/routes/tsoa/connections.ts
@@ -13,7 +13,6 @@ import {
   Delete,
 } from "@tsoa/runtime";
 import { nanoid } from "nanoid";
-import { UpdateResult } from "kysely";
 
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
@@ -127,7 +126,7 @@ export class ConnectionsController extends Controller {
     body: Partial<
       Omit<Connection, "id" | "tenantId" | "createdAt" | "modifiedAt">
     >,
-  ): Promise<UpdateResult[]> {
+  ) {
     const { env } = request.ctx;
 
     await checkAccess(request.ctx, tenantId, id);
@@ -147,7 +146,7 @@ export class ConnectionsController extends Controller {
 
     await updateTenantClientsInKV(env, tenantId);
 
-    return results;
+    return Number(results[0].numUpdatedRows);
   }
 
   @Post("")


### PR DESCRIPTION
Not really sure why we get an array back for the update.. I'm guessing we could take the first result and just cast it to number for now?