### PR TITLE
Application id

### DIFF
--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -158,7 +158,9 @@ export class ApplicationsController extends Controller {
     @Request() request: RequestWithContext,
     @Path("tenantId") tenantId: string,
     @Body()
-    body: Omit<Application, "id" | "tenantId" | "createdAt" | "modifiedAt"> & { id?: string },
+    body: Omit<Application, "id" | "tenantId" | "createdAt" | "modifiedAt"> & {
+      id?: string;
+    },
   ): Promise<Application> {
     const { ctx } = request;
     const { env } = ctx;

--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -95,7 +95,7 @@ export class ApplicationsController extends Controller {
 
   @Delete("{id}")
   @Security("oauth2", [])
-  public async deleteConnection(
+  public async deleteApplication(
     @Request() request: RequestWithContext,
     @Path("id") id: string,
     @Path("tenantId") tenantId: string,
@@ -158,7 +158,7 @@ export class ApplicationsController extends Controller {
     @Request() request: RequestWithContext,
     @Path("tenantId") tenantId: string,
     @Body()
-    body: Omit<Application, "id" | "createdAt" | "modifiedAt">,
+    body: Omit<Application, "id" | "tenantId" | "createdAt" | "modifiedAt"> & { id?: string },
   ): Promise<Application> {
     const { ctx } = request;
     const { env } = ctx;
@@ -180,7 +180,7 @@ export class ApplicationsController extends Controller {
     const application: Application = {
       ...body,
       tenantId,
-      id: nanoid(),
+      id: body.id || nanoid(),
       createdAt: new Date().toISOString(),
       modifiedAt: new Date().toISOString(),
     };


### PR DESCRIPTION
It wasn't possible to provide the id when creating the application before which was unpractical.. Now it's optional. Also fixed so the tenantId isn't required as it's passed in the url.