### PR TITLE
fix: added test for iframe with idtoken

### DIFF
--- a/src/authentication-flows/silent.ts
+++ b/src/authentication-flows/silent.ts
@@ -66,51 +66,26 @@ export async function silentAuth({
         controller.setHeader(headers.setCookie, cookie);
       });
 
-      try {
-        switch (response_type) {
-          case AuthorizationResponseType.CODE:
-            const codeResponse = await generateCode({
-              env,
-              state,
-              nonce,
-              userId: superState.userId,
-              authParams: {
-                ...superState.authParams,
-                code_challenge_method,
-                code_challenge,
-              },
-              user: superState.user as Profile,
-              sid: tokenState,
-              responseType: AuthorizationResponseType.CODE,
-            });
+      const tokenResponse = await generateAuthResponse({
+        env,
+        state,
+        nonce,
+        userId: superState.userId,
+        authParams: {
+          ...superState.authParams,
+          code_challenge_method,
+          code_challenge,
+        },
+        user: superState.user as Profile,
+        sid: tokenState,
+        responseType: response_type,
+      });
 
-            return renderAuthIframe(
-              controller,
-              `${redirectURL.protocol}//${redirectURL.host}`,
-              JSON.stringify(codeResponse),
-            );
-          case AuthorizationResponseType.TOKEN_ID_TOKEN:
-            const tokenResponse = await generateAuthResponse({
-              env,
-              userId: superState.userId,
-              state,
-              nonce,
-              authParams: superState.authParams,
-              sid: tokenState,
-              responseType: AuthorizationResponseType.TOKEN,
-            });
-
-            return renderAuthIframe(
-              controller,
-              `${redirectURL.protocol}//${redirectURL.host}`,
-              JSON.stringify(tokenResponse),
-            );
-          default:
-            throw new Error("Response type not supported");
-        }
-      } catch (error: any) {
-        console.log(`Failed to generate token: ${error.message}`);
-      }
+      return renderAuthIframe(
+        controller,
+        `${redirectURL.protocol}//${redirectURL.host}`,
+        JSON.stringify(tokenResponse),
+      );
     }
   }
 

--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -45,7 +45,9 @@ export function applyTokenResponseAsQuery(
     );
   }
 
+  controller.setStatus(302);
   controller.setHeader(headers.location, redirectUri.href);
+  return "Redirecting";
 }
 
 export function applyTokenResponseAsFragment(
@@ -84,7 +86,9 @@ export function applyTokenResponseAsFragment(
 
   redirectUri.hash = anchorLinks.toString();
 
+  controller.setStatus(302);
   controller.setHeader(headers.location, redirectUri.href);
+  return "Redirecting";
 }
 
 export function applyTokenResponse(
@@ -94,15 +98,13 @@ export function applyTokenResponse(
 ) {
   switch (authParams.response_mode) {
     case AuthorizationResponseMode.FRAGMENT:
-      applyTokenResponseAsFragment(controller, tokenResponse, authParams);
-      break;
+      return applyTokenResponseAsFragment(
+        controller,
+        tokenResponse,
+        authParams,
+      );
     case AuthorizationResponseMode.QUERY:
     default:
-      applyTokenResponseAsQuery(controller, tokenResponse, authParams);
-      break;
+      return applyTokenResponseAsQuery(controller, tokenResponse, authParams);
   }
-
-  controller.setStatus(302);
-
-  return "Redirecting";
 }

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -96,6 +96,69 @@ describe("authorize", () => {
       });
     });
 
+    it("should return an iframe document with a new access and id-token", async () => {
+      // https://auth2.sesamy.dev/authorize
+      //     ? client_id = VQy2yYCA9rIBJerZrUN0T
+      //     & scope=openid+profile+email
+      //     & redirect_uri=http://localhost:3000
+      //     & prompt=none
+      //     & response_type=token id_token
+      //     & response_mode=web_message
+      //     & state=state
+      //     & nonce=cUdmMWo1eFgubzdjMU9xSmhiS0pYdmpJME1GbFpJcllyWnBTU1FnWXQzTA % 3D % 3D
+      //     & code_challenge=CA6jwqDHtqZIzs9dcmTNBavFDQHPkfuBIO2Q8XRvWGA
+      //     & code_challenge_method=S256
+      //     & auth0Client=eyJuYW1lIjoiYXV0aDAtcmVhY3QiLCJ2ZXJzaW9uIjoiMi4xLjAifQ % 3D % 3D
+      const controller = new AuthorizeController();
+
+      const stateData: { [key: string]: any } = {
+        // This id corresponds to the base64 token below
+        c20e9b02adc8f69944f036aeff415335c63ede250696a606ae73c5d4db016217:
+          JSON.stringify({
+            userId: "tenantId|test@example.com",
+            authParams: {
+              redirect_uri: "https://example.com",
+              scope: "openid profile email",
+              state:
+                "Rk1BbzJYSEFEVU9fTGd4cGdidGh0OHJnRHIwWTFrWFdOYlNySDMuU3YxMw==",
+              client_id: "clientId",
+              nonce:
+                "Y0QuU09HRDB3TGszTX41QmlvM1BVTWRSWDA0WFpJdkZoMUwtNmJqYlFDdg==",
+            },
+          }),
+      };
+
+      const ctx = contextFixture({
+        stateData,
+      });
+
+      ctx.headers.set(
+        "cookie",
+        "auth-token=wg6bAq3I9plE8Dau_0FTNcY-3iUGlqYGrnPF1NsBYhc",
+      );
+
+      const actual = await controller.authorizeWithParams({
+        request: { ctx } as RequestWithContext,
+        client_id: "clientId",
+        redirect_uri: "https://example.com",
+        scope: "openid+profile+email",
+        state: "state",
+        response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
+        response_mode: AuthorizationResponseMode.WEB_MESSAGE,
+        audience: "audience",
+        nonce: "nonce",
+        code_challenge_method: CodeChallengeMethod.S265,
+        // When using PKCE the client generates a random code challenge
+        code_challenge: "Aci0drFQuKXZ5KU4uqEfzSOWzNKqIOM2hNfLYA8qfJo",
+        prompt: "none",
+      });
+
+      expect(actual).toContain('response: {"access_token');
+      expect(actual).toContain("id_token");
+
+      expect(actual).toContain('var targetOrigin = "https://example.com";');
+    });
+
     it("should redirect to the login form and pass the nonce an web_response in the state", async () => {
       const controller = new AuthorizeController();
 


### PR DESCRIPTION
We explicitly requested a token without id token. Switched to use the generateAuthResponse helper instead.

Wanted to use the applyTokenReply as well, but it got a bit messy. Would be nice to add later.