### PR TITLE
fix: put email into idtoken

### DIFF
--- a/src/helpers/generate-auth-response.ts
+++ b/src/helpers/generate-auth-response.ts
@@ -66,14 +66,14 @@ export async function generateCode({
 export async function generateTokens(
   params:
     | GenerateAuthResponseParamsForToken
-    | GenerateAuthResponseParamsForIdToken
+    | GenerateAuthResponseParamsForIdToken,
 ) {
   const { env, authParams, userId, state, responseType, sid, nonce } = params;
 
   const certificate = await getCertificate(env);
   const tokenFactory = new TokenFactory(
     certificate.privateKey,
-    certificate.kid
+    certificate.kid,
   );
 
   const accessToken = await tokenFactory.createAccessToken({

--- a/src/helpers/generate-auth-response.ts
+++ b/src/helpers/generate-auth-response.ts
@@ -66,14 +66,14 @@ export async function generateCode({
 export async function generateTokens(
   params:
     | GenerateAuthResponseParamsForToken
-    | GenerateAuthResponseParamsForIdToken,
+    | GenerateAuthResponseParamsForIdToken
 ) {
   const { env, authParams, userId, state, responseType, sid, nonce } = params;
 
   const certificate = await getCertificate(env);
   const tokenFactory = new TokenFactory(
     certificate.privateKey,
-    certificate.kid,
+    certificate.kid
   );
 
   const accessToken = await tokenFactory.createAccessToken({
@@ -101,6 +101,7 @@ export async function generateTokens(
       iss: env.ISSUER,
       sid,
       nonce: nonce || authParams.nonce,
+      email: user.email,
     });
   }
 

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -116,6 +116,9 @@ describe("authorize", () => {
         c20e9b02adc8f69944f036aeff415335c63ede250696a606ae73c5d4db016217:
           JSON.stringify({
             userId: "tenantId|test@example.com",
+            user: {
+              email: "test@example.com",
+            },
             authParams: {
               redirect_uri: "https://example.com",
               scope: "openid profile email",


### PR DESCRIPTION
I did this PR this morning but as there's no test to assert that the email is included in the id token... we lost it

It would be amazing to actually parse out the id & access tokens from the iframe and then assert on them :thinking: 