### PR TITLE
feat: add permission for managing all tenants

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests.v2",
+      "request": "launch",
+      "args": [
+        "test",
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ],
+      "cwd": "/Users/markusahlstrand/Projects/sesamy/auth",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "runtimeExecutable": "yarn"
+    }
+  ]
+}

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -89,10 +89,10 @@ async function getJwks(env: Env) {
   return (body as any).keys as JwkKey[];
 }
 
-function isValidScopes(token: TokenData, scopes: string[]) {
-  const tokenScopes = token.payload.scope?.split(" ") || [];
+function isPermissionsValid(token: TokenData, permissions: string[]) {
+  const tokenPermissions = token.payload.permissions || [];
 
-  const match = !scopes.some((scope) => !tokenScopes.includes(scope));
+  const match = !permissions.some((permissions) => !tokenPermissions.includes(permissions));
 
   return match;
 }
@@ -128,7 +128,7 @@ export async function getUser(
   ctx: Context<Env>,
   clientId: string,
   bearer: string,
-  scopes: string[],
+  permissions: string[],
 ): Promise<any | null> {
   const token = decodeJwt(bearer);
 
@@ -139,7 +139,7 @@ export async function getUser(
     return null;
   }
 
-  if (!isValidScopes(token, scopes)) {
+  if (!isPermissionsValid(token, permissions)) {
     return null;
   }
 
@@ -155,7 +155,7 @@ export interface Security {
 }
 
 export function authenticationHandler(security: Security[]) {
-  const [scope] = security[0].oauth2;
+  const [permissions] = security[0].oauth2;
   return async function jwtMiddleware(
     ctx: Context<Env>,
     next: Next,
@@ -171,7 +171,7 @@ export function authenticationHandler(security: Security[]) {
       ctx,
       ctx.params.clientId,
       bearer,
-      scope?.split(" ") || [],
+      permissions?.split(" ") || [],
     );
 
     if (!ctx.state.user) {

--- a/src/routes/tsoa/migrations.ts
+++ b/src/routes/tsoa/migrations.ts
@@ -21,6 +21,7 @@ import { updateTenantClientsInKV } from "../../hooks/update-client";
 import { Context } from "cloudworker-router";
 import { Env } from "../../types";
 import { NotFoundError, UnauthorizedError } from "../../errors";
+import { hasReadPermission, hasWritePermission } from "../../utils/permissions";
 
 async function checkAccess(ctx: Context<Env>, tenantId: string, id: string) {
   const db = getDb(ctx.env);
@@ -53,6 +54,14 @@ export class MigrationsController extends Controller {
     const { ctx } = request;
 
     const db = getDb(ctx.env);
+
+    if (hasReadPermission(ctx)) {
+      return await db
+        .selectFrom("migrations")
+        .where("migrations.tenantId", "=", tenantId)
+        .selectAll()
+        .execute();
+    }
     const migrations = await db
       .selectFrom("migrations")
       .innerJoin("tenants", "tenants.id", "migrations.tenantId")
@@ -75,15 +84,27 @@ export class MigrationsController extends Controller {
     const { ctx } = request;
 
     const db = getDb(ctx.env);
-    const migration = await db
-      .selectFrom("migrations")
-      .innerJoin("tenants", "tenants.id", "migrations.tenantId")
-      .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-      .where("admin_users.id", "=", ctx.state.user.sub)
-      .where("tenants.id", "=", tenantId)
-      .where("migrations.id", "=", id)
-      .selectAll("migrations")
-      .executeTakeFirst();
+
+    let migration: Migration | undefined;
+
+    if (hasReadPermission(ctx)) {
+      migration = await db
+        .selectFrom("migrations")
+        .where("migrations.tenantId", "=", tenantId)
+        .where("migrations.id", "=", id)
+        .selectAll()
+        .executeTakeFirst();
+    } else {
+      migration = await db
+        .selectFrom("migrations")
+        .innerJoin("tenants", "tenants.id", "migrations.tenantId")
+        .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
+        .where("admin_users.id", "=", ctx.state.user.sub)
+        .where("tenants.id", "=", tenantId)
+        .where("migrations.id", "=", id)
+        .selectAll("migrations")
+        .executeTakeFirst();
+    }
 
     if (!migration) {
       this.setStatus(404);
@@ -100,18 +121,20 @@ export class MigrationsController extends Controller {
     @Path("id") id: string,
     @Path("tenantId") tenantId: string,
   ): Promise<string> {
-    const { env } = request.ctx;
+    const { ctx } = request;
 
-    await checkAccess(request.ctx, tenantId, id);
+    if (!hasWritePermission) {
+      await checkAccess(request.ctx, tenantId, id);
+    }
 
-    const db = getDb(env);
+    const db = getDb(ctx.env);
     await db
       .deleteFrom("migrations")
       .where("migrations.tenantId", "=", tenantId)
       .where("migrations.id", "=", id)
       .execute();
 
-    await updateTenantClientsInKV(env, tenantId);
+    await updateTenantClientsInKV(ctx.env, tenantId);
 
     return "OK";
   }
@@ -127,24 +150,26 @@ export class MigrationsController extends Controller {
       Omit<Migration, "id" | "tenantId" | "createdAt" | "modifiedAt">
     >,
   ) {
-    const { env } = request.ctx;
+    const { ctx } = request;
 
-    await checkAccess(request.ctx, tenantId, id);
+    if (!hasWritePermission) {
+      await checkAccess(request.ctx, tenantId, id);
+    }
 
-    const db = getDb(env);
     const migration = {
       ...body,
       tenantId,
       modifiedAt: new Date().toISOString(),
     };
 
+    const db = getDb(ctx.env);
     const results = await db
       .updateTable("migrations")
       .set(migration)
       .where("id", "=", id)
       .execute();
 
-    await updateTenantClientsInKV(env, tenantId);
+    await updateTenantClientsInKV(ctx.env, tenantId);
 
     return Number(results[0].numUpdatedRows);
   }
@@ -159,20 +184,20 @@ export class MigrationsController extends Controller {
     body: Omit<Migration, "id" | "tenantId" | "createdAt" | "modifiedAt">,
   ): Promise<Migration> {
     const { ctx } = request;
-    const { env } = ctx;
+    const db = getDb(ctx.env);
 
-    const db = getDb(env);
+    if (!hasWritePermission) {
+      const tenant = await db
+        .selectFrom("tenants")
+        .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
+        .where("admin_users.id", "=", ctx.state.user.sub)
+        .where("tenants.id", "=", tenantId)
+        .select("tenants.id")
+        .executeTakeFirst();
 
-    const tenant = await db
-      .selectFrom("tenants")
-      .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-      .where("admin_users.id", "=", ctx.state.user.sub)
-      .where("tenants.id", "=", tenantId)
-      .select("tenants.id")
-      .executeTakeFirst();
-
-    if (!tenant) {
-      throw new UnauthorizedError();
+      if (!tenant) {
+        throw new UnauthorizedError();
+      }
     }
 
     const migration: Migration = {
@@ -185,7 +210,7 @@ export class MigrationsController extends Controller {
 
     await db.insertInto("migrations").values(migration).execute();
 
-    await updateTenantClientsInKV(env, tenantId);
+    await updateTenantClientsInKV(ctx.env, tenantId);
 
     this.setStatus(201);
     return migration;

--- a/src/types/Env.ts
+++ b/src/types/Env.ts
@@ -16,6 +16,8 @@ export interface ClientFactory<ClientType> {
 export interface Env {
   ISSUER: string;
   DD_API_KEY: string;
+  READ_PERMISSION: string;
+  WRITE_PERMISSION: string;
   JWKS_URL: string;
   OAUTH2_CLIENT_ID: string;
   TOKEN_SERVICE: Fetcher;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,10 @@
+import { Context } from "cloudworker-router";
+import { Env } from "../types";
+
+export function hasReadPermission(ctx: Context<Env>) {
+    return ctx.env.READ_PERMISSION && ctx.state.user.permissions.include(ctx.env.READ_PERMISSION)
+}
+
+export function hasWritePermission(ctx: Context<Env>) {
+    return ctx.env.WRITE_PERMISSION && ctx.state.user.permissions.include(ctx.env.WRITE_PERMISSION)
+}


### PR DESCRIPTION
This PR makes it possible to specify a read and write permissions in env-variables that gives access to all tenants. This would for instance be handy when setting up new tenants for customers.