### PR TITLE
Members

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,4 +1,6 @@
 import { Context, Next } from "cloudworker-router";
+import { UnauthorizedError } from "./errors";
+import { getDb } from "./services/db";
 import { Env } from "./types/Env";
 
 interface TokenData {
@@ -126,7 +128,6 @@ async function isValidJwtSignature(ctx: Context<Env>, token: TokenData) {
 
 export async function getUser(
   ctx: Context<Env>,
-  clientId: string,
   bearer: string,
   scopes: string[],
 ): Promise<any | null> {
@@ -150,6 +151,60 @@ export async function getUser(
   return token.payload;
 }
 
+export async function verifyTenantPermissions(ctx: Context<Env>) {
+  if (
+    !["POST", "PATCH", "PUT", "DELETE", "GET", "HEAD"].includes(
+      ctx.request.method,
+    )
+  ) {
+    // Don't bother about OPTIONS requests
+    return;
+  }
+
+  // Check token permissions first
+  if (["GET", "HEAD"].includes(ctx.request.method)) {
+    // Read requets
+    if (ctx.state.user.permissions.include(ctx.env.READ_PERMISSION)) {
+      return true;
+    }
+  } else {
+    // Write requests
+    if (ctx.state.user.permissions.include(ctx.env.WRITE_PERMISSION)) {
+      return true;
+    }
+  }
+
+  // Check db permissions
+  const tenantId = ctx.params.tenantId;
+
+  const db = getDb(ctx.env);
+  const adminUser = await db
+    .selectFrom("admin_users")
+    .where("admin_users.id", "=", ctx.state.user.sub)
+    .where("admin_users.tenantId", "=", tenantId)
+    .where("admin_users.status", "=", "active")
+    .select("admin_users.role")
+    .executeTakeFirst();
+
+  if (!adminUser?.role) {
+    throw new UnauthorizedError();
+  }
+
+  if (["GET", "HEAD"].includes(ctx.request.method)) {
+    // Read requets
+    if (["admin", "viewer"].includes(adminUser.role)) {
+      return true;
+    }
+  } else {
+    // Write requests
+    if (["admin"].includes(adminUser.role)) {
+      return true;
+    }
+  }
+
+  throw new UnauthorizedError();
+}
+
 export interface Security {
   oauth2: string[];
 }
@@ -167,12 +222,9 @@ export function authenticationHandler(security: Security[]) {
       });
     }
     const bearer = authHeader.slice(7);
-    ctx.state.user = await getUser(
-      ctx,
-      ctx.params.clientId,
-      bearer,
-      scope?.split(" ") || [],
-    );
+    ctx.state.user = await getUser(ctx, bearer, scope?.split(" ") || []);
+
+    await verifyTenantPermissions(ctx);
 
     if (!ctx.state.user) {
       return new Response("Not Authorized", {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -152,6 +152,11 @@ export async function getUser(
 }
 
 export async function verifyTenantPermissions(ctx: Context<Env>) {
+  const tenantId = ctx.params.tenantId;
+  if (!tenantId) {
+    return;
+  }
+
   if (
     !["POST", "PATCH", "PUT", "DELETE", "GET", "HEAD"].includes(
       ctx.request.method,
@@ -162,21 +167,21 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
   }
 
   // Check token permissions first
+  const permissions: string[] = ctx.state.user.permissions || [];
+
   if (["GET", "HEAD"].includes(ctx.request.method)) {
     // Read requets
-    if (ctx.state.user.permissions.include(ctx.env.READ_PERMISSION)) {
+    if (permissions.includes(ctx.env.READ_PERMISSION as string)) {
       return;
     }
   } else {
     // Write requests
-    if (ctx.state.user.permissions.include(ctx.env.WRITE_PERMISSION)) {
+    if (permissions.includes(ctx.env.WRITE_PERMISSION as string)) {
       return;
     }
   }
 
   // Check db permissions
-  const tenantId = ctx.params.tenantId;
-
   const db = getDb(ctx.env);
   const adminUser = await db
     .selectFrom("admin_users")

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -165,12 +165,12 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
   if (["GET", "HEAD"].includes(ctx.request.method)) {
     // Read requets
     if (ctx.state.user.permissions.include(ctx.env.READ_PERMISSION)) {
-      return true;
+      return;
     }
   } else {
     // Write requests
     if (ctx.state.user.permissions.include(ctx.env.WRITE_PERMISSION)) {
-      return true;
+      return;
     }
   }
 
@@ -193,12 +193,12 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
   if (["GET", "HEAD"].includes(ctx.request.method)) {
     // Read requets
     if (["admin", "viewer"].includes(adminUser.role)) {
-      return true;
+      return;
     }
   } else {
     // Write requests
     if (["admin"].includes(adminUser.role)) {
-      return true;
+      return;
     }
   }
 

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -185,7 +185,7 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
   const db = getDb(ctx.env);
   const member = await db
     .selectFrom("members")
-    .where("members.id", "=", ctx.state.user.sub)
+    .where("members.sub", "=", ctx.state.user.sub)
     .where("members.tenantId", "=", tenantId)
     .where("members.status", "=", "active")
     .select("members.role")

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -183,26 +183,26 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
 
   // Check db permissions
   const db = getDb(ctx.env);
-  const adminUser = await db
-    .selectFrom("admin_users")
-    .where("admin_users.id", "=", ctx.state.user.sub)
-    .where("admin_users.tenantId", "=", tenantId)
-    .where("admin_users.status", "=", "active")
-    .select("admin_users.role")
+  const member = await db
+    .selectFrom("members")
+    .where("members.id", "=", ctx.state.user.sub)
+    .where("members.tenantId", "=", tenantId)
+    .where("members.status", "=", "active")
+    .select("members.role")
     .executeTakeFirst();
 
-  if (!adminUser?.role) {
+  if (!member?.role) {
     throw new UnauthorizedError();
   }
 
   if (["GET", "HEAD"].includes(ctx.request.method)) {
     // Read requets
-    if (["admin", "viewer"].includes(adminUser.role)) {
+    if (["admin", "viewer"].includes(member.role)) {
       return;
     }
   } else {
     // Write requests
-    if (["admin"].includes(adminUser.role)) {
+    if (["admin"].includes(member.role)) {
       return;
     }
   }

--- a/src/migrate/migrations/2023-07-26T11:33:12_members.ts
+++ b/src/migrate/migrations/2023-07-26T11:33:12_members.ts
@@ -1,0 +1,23 @@
+import { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable("members")
+    .addColumn("id", "varchar", (col) => col.notNull().primaryKey())
+    .addColumn("tenant_id", "varchar", (col) =>
+      col.references("tenants.id").onDelete("cascade").notNull(),
+    )
+    .addColumn("sub", "varchar")
+    .addColumn("email", "varchar")
+    .addColumn("name", "varchar")
+    .addColumn("status", "varchar")
+    .addColumn("role", "varchar")
+    .addColumn("picture", "varchar")
+    .addColumn("created_at", "varchar")
+    .addColumn("modified_at", "varchar")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("members").execute();
+}

--- a/src/migrate/migrations/index.ts
+++ b/src/migrate/migrations/index.ts
@@ -1,5 +1,6 @@
 import * as init from "./2022-12-11T09:17:35_init";
 import * as migrations from "./2023-06-20T12:07:25_migrations";
-import * as members from "./2023-07-26T11:33:12_members";
+import * as n1 from "./2023-07-26T11:33:12_members";
 
-export default { init, migrations, members };
+// These needs to be in alphabetic order
+export default { init, migrations, n1 };

--- a/src/migrate/migrations/index.ts
+++ b/src/migrate/migrations/index.ts
@@ -1,4 +1,5 @@
 import * as init from "./2022-12-11T09:17:35_init";
 import * as migrations from "./2023-06-20T12:07:25_migrations";
+import * as members from "./2023-07-26T11:33:12_members";
 
-export default { init, migrations };
+export default { init, migrations, members };

--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -140,10 +140,11 @@ export class ApplicationsController extends Controller {
   public async postApplications(
     @Request() request: RequestWithContext,
     @Path("tenantId") tenantId: string,
-    @Body() body: Partial<
+    @Body()
+    body: Partial<
       Omit<Application, "tenantId" | "createdAt" | "modifiedAt">
     > & {
-      name: string
+      name: string;
     },
   ): Promise<Application> {
     const { ctx } = request;
@@ -152,9 +153,9 @@ export class ApplicationsController extends Controller {
     const db = getDb(env);
 
     const application: Application = {
-      allowedWebOrigins: '',
-      allowedCallbackUrls: '',
-      allowedLogoutUrls: '',
+      allowedWebOrigins: "",
+      allowedCallbackUrls: "",
+      allowedLogoutUrls: "",
       clientSecret: nanoid(),
       id: nanoid(),
       ...body,

--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -19,30 +19,9 @@ import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
 import { Application } from "../../types/sql";
 import { updateClientInKV } from "../../hooks/update-client";
-import { NotFoundError, UnauthorizedError } from "../../errors";
-import { Context } from "cloudworker-router";
-import { Env } from "../../types";
+import { UnauthorizedError } from "../../errors";
 import { parseRange } from "../../helpers/content-range";
 import { headers } from "../../constants";
-
-async function checkAccess(ctx: Context<Env>, tenantId: string, id: string) {
-  const db = getDb(ctx.env);
-
-  const application = await db
-    .selectFrom("applications")
-    .innerJoin("tenants", "tenants.id", "applications.tenantId")
-    .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-    .where("admin_users.id", "=", ctx.state.user.sub)
-    .where("tenants.id", "=", tenantId)
-    .where("applications.id", "=", id)
-    .select("applications.id")
-    .executeTakeFirst();
-
-  if (!application) {
-    // Application not found. Could be that the user has no access
-    throw new NotFoundError();
-  }
-}
 
 @Route("tenants/{tenantId}/applications")
 @Tags("applications")
@@ -61,11 +40,8 @@ export class ApplicationsController extends Controller {
     const db = getDb(ctx.env);
     const applications = await db
       .selectFrom("applications")
-      .innerJoin("tenants", "tenants.id", "applications.tenantId")
-      .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-      .where("admin_users.id", "=", ctx.state.user.sub)
-      .where("tenants.id", "=", tenantId)
-      .selectAll("applications")
+      .where("applications.tenantId", "=", tenantId)
+      .selectAll()
       .offset(parsedRange.from)
       .limit(parsedRange.limit)
       .execute();
@@ -92,12 +68,8 @@ export class ApplicationsController extends Controller {
     const db = getDb(ctx.env);
     const application = await db
       .selectFrom("applications")
-      .innerJoin("tenants", "tenants.id", "applications.tenantId")
-      .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-      .where("admin_users.id", "=", ctx.state.user.sub)
-      .where("tenants.id", "=", tenantId)
-      .where("applications.id", "=", id)
-      .selectAll("applications")
+      .where("applications.tenantId", "=", tenantId)
+      .selectAll()
       .executeTakeFirst();
 
     if (!application) {
@@ -118,8 +90,6 @@ export class ApplicationsController extends Controller {
     const { env } = request.ctx;
 
     const db = getDb(env);
-
-    await checkAccess(request.ctx, tenantId, id);
 
     await db
       .deleteFrom("applications")
@@ -147,8 +117,6 @@ export class ApplicationsController extends Controller {
 
     const db = getDb(env);
 
-    await checkAccess(request.ctx, tenantId, id);
-
     const application = {
       ...body,
       tenantId,
@@ -172,9 +140,10 @@ export class ApplicationsController extends Controller {
   public async postApplications(
     @Request() request: RequestWithContext,
     @Path("tenantId") tenantId: string,
-    @Body()
-    body: Omit<Application, "id" | "tenantId" | "createdAt" | "modifiedAt"> & {
-      id?: string;
+    @Body() body: Partial<
+      Omit<Application, "tenantId" | "createdAt" | "modifiedAt">
+    > & {
+      name: string
     },
   ): Promise<Application> {
     const { ctx } = request;
@@ -182,22 +151,14 @@ export class ApplicationsController extends Controller {
 
     const db = getDb(env);
 
-    const tenant = await db
-      .selectFrom("tenants")
-      .innerJoin("admin_users", "tenants.id", "admin_users.tenantId")
-      .where("admin_users.id", "=", ctx.state.user.sub)
-      .where("tenants.id", "=", tenantId)
-      .select("tenants.id")
-      .executeTakeFirst();
-
-    if (!tenant) {
-      throw new UnauthorizedError();
-    }
-
     const application: Application = {
+      allowedWebOrigins: '',
+      allowedCallbackUrls: '',
+      allowedLogoutUrls: '',
+      clientSecret: nanoid(),
+      id: nanoid(),
       ...body,
       tenantId,
-      id: body.id || nanoid(),
       createdAt: new Date().toISOString(),
       modifiedAt: new Date().toISOString(),
     };

--- a/src/routes/tsoa/members.ts
+++ b/src/routes/tsoa/members.ts
@@ -1,0 +1,157 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Path,
+  Request,
+  Route,
+  Tags,
+  Body,
+  SuccessResponse,
+  Security,
+  Delete,
+  Header,
+} from "@tsoa/runtime";
+import { nanoid } from "nanoid";
+
+import { getDb } from "../../services/db";
+import { RequestWithContext } from "../../types/RequestWithContext";
+import { AdminUser } from "../../types/sql";
+import { parseRange } from "../../helpers/content-range";
+import { headers } from "../../constants";
+
+@Route("tenants/{tenantId}/members")
+@Tags("members")
+export class MigrationsController extends Controller {
+  @Get("")
+  @Security("oauth2", [])
+  public async listMembers(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Header("range") range?: string,
+  ): Promise<AdminUser[]> {
+    const { ctx } = request;
+
+    const parsedRange = parseRange(range);
+
+    const db = getDb(ctx.env);
+    const members = await db
+      .selectFrom("admin_users")
+      .where("admin_users.tenantId", "=", tenantId)
+      .selectAll()
+      .offset(parsedRange.from)
+      .limit(parsedRange.limit)
+      .execute();
+
+    if (parsedRange.entity) {
+      this.setHeader(
+        headers.contentRange,
+        `${parsedRange.entity}=${parsedRange.from}-${parsedRange.to}/${parsedRange.limit}`,
+      );
+    }
+
+    return members;
+  }
+
+  @Get("{id}")
+  @Security("oauth2", [])
+  public async getMember(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+  ): Promise<AdminUser | string> {
+    const { ctx } = request;
+
+    const db = getDb(ctx.env);
+    const member = await db
+      .selectFrom("admin_users")
+      .where("admin_users.id", "=", ctx.state.user.sub)
+      .where("admin_users.tenantId", "=", tenantId)
+      .selectAll()
+      .executeTakeFirst();
+
+    if (!member) {
+      this.setStatus(404);
+      return "Not found";
+    }
+
+    return member;
+  }
+
+  @Delete("{id}")
+  @Security("oauth2", [])
+  public async deleteMember(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+  ): Promise<string> {
+    const { env } = request.ctx;
+
+    const db = getDb(env);
+    await db
+      .deleteFrom("admin_users")
+      .where("admin_users.tenantId", "=", tenantId)
+      .where("admin_users.id", "=", id)
+      .execute();
+
+    return "OK";
+  }
+
+  @Patch("{id}")
+  @Security("oauth2", [])
+  public async patchMember(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+    @Body()
+    body: Partial<
+      Omit<AdminUser, "id" | "tenantId" | "createdAt" | "modifiedAt">
+    >,
+  ) {
+    const { env } = request.ctx;
+
+    const db = getDb(env);
+    const member = {
+      ...body,
+      tenantId,
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const results = await db
+      .updateTable("admin_users")
+      .set(member)
+      .where("id", "=", id)
+      .execute();
+
+    return Number(results[0].numUpdatedRows);
+  }
+
+  @Post("")
+  @Security("oauth2", [])
+  @SuccessResponse(201, "Created")
+  public async postMember(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Body()
+    body: Omit<AdminUser, "id" | "tenantId" | "createdAt" | "modifiedAt">,
+  ): Promise<AdminUser> {
+    const { ctx } = request;
+    const { env } = ctx;
+
+    const db = getDb(env);
+
+    const member: AdminUser = {
+      ...body,
+      tenantId,
+      id: nanoid(),
+      createdAt: new Date().toISOString(),
+      modifiedAt: new Date().toISOString(),
+    };
+
+    await db.insertInto("admin_users").values(member).execute();
+
+    this.setStatus(201);
+    return member;
+  }
+}

--- a/src/routes/tsoa/members.ts
+++ b/src/routes/tsoa/members.ts
@@ -66,7 +66,7 @@ export class MigrationsController extends Controller {
     const db = getDb(ctx.env);
     const member = await db
       .selectFrom("admin_users")
-      .where("admin_users.id", "=", ctx.state.user.sub)
+      .where("admin_users.id", "=", id)
       .where("admin_users.tenantId", "=", tenantId)
       .selectAll()
       .executeTakeFirst();

--- a/src/routes/tsoa/members.ts
+++ b/src/routes/tsoa/members.ts
@@ -23,7 +23,7 @@ import { headers } from "../../constants";
 
 @Route("tenants/{tenantId}/members")
 @Tags("members")
-export class MigrationsController extends Controller {
+export class MembersController extends Controller {
   @Get("")
   @Security("oauth2", [])
   public async listMembers(

--- a/src/types/sql/Member.ts
+++ b/src/types/sql/Member.ts
@@ -1,6 +1,6 @@
-// Deprecated
-export interface AdminUser {
+export interface Member {
   id: string;
+  sub?: string;
   email?: string;
   tenantId: string;
   createdAt: string;

--- a/src/types/sql/db.ts
+++ b/src/types/sql/db.ts
@@ -4,6 +4,7 @@ import {
   User,
   Connection,
   AdminUser,
+  Member,
   Migration,
 } from "./";
 
@@ -11,6 +12,7 @@ import {
 export interface Database {
   users: User;
   admin_users: AdminUser;
+  members: Member;
   applications: Application;
   connections: Connection;
   migrations: Migration;

--- a/src/types/sql/index.ts
+++ b/src/types/sql/index.ts
@@ -3,5 +3,6 @@ export * from "./Connection";
 export * from "./Tenant";
 export * from "./User";
 export * from "./AdminUser";
+export * from "./Member";
 export * from "./Migration";
 export * from "./db";


### PR DESCRIPTION
This adds new endpoints for managing members (aka admin-users..). I still haven't renamed the entities in the database, but think that members is closer to what they call them in auth0.

So a member is a user that can read or update the tenant. In this case we're using the token-service for members so the user id's won't match any of the users in auth2 (probably better).

I haven't really figured out how to add new members as you need to have the userId of the user. I'm thinking that we could create an invite that is sent by email, and once that invite is accepted we add the user id to the member. Then we can also validate that the email matches. I guess this is functionality we can use for adding new users to for instance Insights in the future?

I also did a refactor of the permissions, but so far only use it on the members endpoint: Basically I just check the method of the request and which tenant they are using. This way we don't need to care about permissions in the controller code. Might be to simplistic in the long run, but much cleaner right now.