### PR TITLE
fix: password reset emails

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -81,7 +81,7 @@ export class NoUserFoundError extends Error {
 export class UserConflictError extends Error {
   status = 404;
 
-  constructor(message = "User Alredy Exists") {
+  constructor(message = "User Already Exists") {
     super();
 
     this.message = message;

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -297,7 +297,7 @@ export class LoginController extends Controller {
 
     const { code } = await user.createPasswordResetCode.mutate();
 
-    const message = `Click this link to reset your password: ${env.ISSUER}u / reset - password ? state = ${state} & code=${code}`;
+    const message = `Click this link to reset your password: ${env.ISSUER}u/reset-password?state=${state}&code=${code}`;
     await env.sendEmail({
       to: [{ email: params.username, name: "" }],
       from: {

--- a/src/templates/reset-password.liquid
+++ b/src/templates/reset-password.liquid
@@ -28,7 +28,7 @@
         </div>
         <div class="text-center flex-col-m p-t-20">
             <span class="txt1 p-b-17">
-                Allready have an account?
+                Already have an account?
             </span>
             <a href="/u/login?state={{state}}" class="txt2">
                 Login


### PR DESCRIPTION
I saw this in a previous PR. Prettier must have done this

Currently emails are busted like this

![image](https://github.com/markusahlstrand/cloudworker-auth/assets/8496063/153a6a07-0559-4185-96a9-e5f79d4c807b)
