### PR TITLE
fix: refactor signup flow

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,0 +1,47 @@
+import { Client, Env } from "../types";
+
+export async function sendEmailValidation(
+  env: Env,
+  client: Client,
+  to: string,
+  code: string,
+) {
+  const message = `Here is the code to validate your email: ${code}`;
+  await env.sendEmail({
+    to: [{ email: to, name: to }],
+    from: {
+      email: client.senderEmail,
+      name: client.senderName,
+    },
+    content: [
+      {
+        type: "text/plain",
+        value: message,
+      },
+    ],
+    subject: "Validate email",
+  });
+}
+
+export async function sendResetPassword(
+  env: Env,
+  client: Client,
+  to: string,
+  code: string,
+) {
+  const message = `Click this link to reset your password: ${env.ISSUER}u/reset-password?state=${state}&code=${code}`;
+  await env.sendEmail({
+    to: [{ email: to, name: to }],
+    from: {
+      email: client.senderEmail,
+      name: client.senderName,
+    },
+    content: [
+      {
+        type: "text/plain",
+        value: message,
+      },
+    ],
+    subject: "Reset password",
+  });
+}

--- a/test/models/User.spec.ts
+++ b/test/models/User.spec.ts
@@ -30,11 +30,6 @@ describe("User", () => {
     jest.useRealTimers();
   });
 
-  it("use jsdom in this test file", () => {
-    const element = document.createElement("div");
-    expect(element).not.toBeNull();
-  });
-
   describe("validate password", () => {
     it("should throw an invalid password error if a user has no password", async () => {
       try {
@@ -77,6 +72,40 @@ describe("User", () => {
         email: "test@example.com",
         tenantId: "tenantId",
       });
+    });
+  });
+
+  describe("register password", () => {
+    it("should register a new password, store a new unverified connection", async () => {
+      let profile: any = {};
+
+      const caller = createCaller({
+        get: async (key: string) => {
+          switch (key) {
+            case "profile":
+              return null;
+          }
+        },
+        put: async (key: string, value: string) => {
+          switch (key) {
+            case "profile":
+              profile = JSON.parse(value);
+              break;
+          }
+          return;
+        },
+      });
+
+      await caller.registerPassword({
+        password: "password",
+        email: "test@example.com",
+        tenantId: "tenantId",
+      });
+
+      const emailConnection = profile.connections.find(
+        (connection) => connection.name === "auth",
+      );
+      expect(emailConnection.profile.validated).toBe(false);
     });
   });
 


### PR DESCRIPTION
Started cleaning up how the email validation works:
- Send a mail with a code when a user signs up. This can be used to validate the email later
- Moved the mail templates to a separate file
- Changed so that the email validation flag is stored as part of the profile
- Fixed so that the connection is added to the profile when a new passord is registered
- Refactored some tRPC endpoints so they take the email and tenantId as well (as this is needed to update the profile)