### PR TITLE
fix: added zod for type safe parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "mime": "^3.0.0",
     "trpc-durable-objects": "^1.3.3",
     "tsoa": "^5.1.1",
-    "tsoa-workers": "^1.3.6"
+    "tsoa-workers": "^1.3.6",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230710.1",

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -52,9 +52,7 @@ const PROFILE_FIELDS = [
   "locale",
 ];
 
-async function getProfile(
-  storage: DurableObjectStorage,
-): Promise<Profile | null> {
+async function getProfile(storage: DurableObjectStorage) {
   const jsonData = await storage.get<string>(StorageKeys.profile);
 
   try {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -15,7 +15,7 @@ import {
   NoCodeError,
 } from "../errors";
 import { AuthParams } from "../types/AuthParams";
-import { Env } from "../types";
+import { Env, ProfileSchema } from "../types";
 import { QueueMessage, sendUserEvent, UserEvent } from "../services/events";
 import { Profile } from "../types";
 import { migratePasswordHook } from "../hooks/migrate-password";
@@ -55,12 +55,13 @@ const PROFILE_FIELDS = [
 async function getProfile(
   storage: DurableObjectStorage,
 ): Promise<Profile | null> {
-  const profilesString = await storage.get<string>(StorageKeys.profile);
-  if (!profilesString) {
+  const jsonData = await storage.get<string>(StorageKeys.profile);
+
+  try {
+    return ProfileSchema.parse(JSON.parse(jsonData as string));
+  } catch (err) {
     return null;
   }
-
-  return JSON.parse(profilesString);
 }
 
 // Stores information about the current operation and ensures that the user has an id.

--- a/src/routes/tsoa/users.ts
+++ b/src/routes/tsoa/users.ts
@@ -120,6 +120,25 @@ export class UsersController extends Controller {
     return userInstance.getProfile.query();
   }
 
+  @Patch("{userId}")
+  public async putUser(
+    @Request() request: RequestWithContext,
+    @Body()
+    body: Omit<User, "id" | "createdAt" | "modifiedAt">,
+    @Path("userId") userId: string,
+    @Path("tenantId") tenantId: string,
+  ): Promise<Profile> {
+    const { env } = request.ctx;
+
+    const doId = `${tenantId}|${body.email}`;
+    const userInstance = env.userFactory.getInstanceByName(doId);
+
+    return userInstance.patchProfile.mutate({
+      ...body,
+      tenantId,
+    });
+  }
+
   @Post("")
   @SuccessResponse(201, "Created")
   public async postUser(

--- a/src/routes/tsoa/users.ts
+++ b/src/routes/tsoa/users.ts
@@ -11,6 +11,7 @@ import {
   Path,
   Security,
   Header,
+  Put,
 } from "@tsoa/runtime";
 import { User } from "../../types/sql/User";
 import { getDb } from "../../services/db";
@@ -120,7 +121,7 @@ export class UsersController extends Controller {
     return userInstance.getProfile.query();
   }
 
-  @Patch("{userId}")
+  @Put("{userId}")
   public async putUser(
     @Request() request: RequestWithContext,
     @Body()

--- a/src/routes/tsoa/users.ts
+++ b/src/routes/tsoa/users.ts
@@ -21,6 +21,7 @@ import { getId } from "../../models";
 import { Profile } from "../../types";
 import { parseRange } from "../../helpers/content-range";
 import { headers } from "../../constants";
+import { profile } from "console";
 
 @Route("tenants/{tenantId}/users")
 @Security("oauth2", [])
@@ -84,7 +85,9 @@ export class UsersController extends Controller {
       getId(tenantId, dbUser.email),
     );
 
-    return user.getProfile.query();
+    const profile: Profile = await user.getProfile.query();
+
+    return profile;
   }
 
   @Patch("{userId}")
@@ -156,12 +159,12 @@ export class UsersController extends Controller {
     const doId = `${tenantId}|${user.email}`;
     const userInstance = ctx.env.userFactory.getInstanceByName(doId);
 
-    const result = await userInstance.patchProfile.mutate({
+    const result: Profile = await userInstance.patchProfile.mutate({
       ...user,
       connections: [],
       tenantId,
     });
 
-    return result as Profile;
+    return result;
   }
 }

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 // Entity from auth0
 // {
 //   "email": "jane@exampleco.com",
@@ -32,23 +34,24 @@
 //   "family_name": ""
 // }
 
-interface Connection {
-  name: string;
-  profile?: { [key: string]: string | boolean | number };
-}
+const ConnectionSchema = z.object({
+  name: z.string(),
+  profile: z.record(z.union([z.string(), z.boolean(), z.number()])).optional(),
+});
 
-export interface Profile {
-  id: string;
-  // TODO: this should probably be snake cased as well. Or maybe stored somewhere else
-  tenantId: string;
-  email: string;
-  created_at: string;
-  modified_at: string;
-  given_name?: string;
-  family_name?: string;
-  nickname?: string;
-  name?: string;
-  picture?: string;
-  locale?: string;
-  connections: Connection[];
-}
+export type Profile = z.infer<typeof ProfileSchema>;
+
+export const ProfileSchema = z.object({
+  id: z.string(),
+  tenantId: z.string(),
+  email: z.string(),
+  created_at: z.string(),
+  modified_at: z.string(),
+  given_name: z.string().optional(),
+  family_name: z.string().optional(),
+  nickname: z.string().optional(),
+  name: z.string().optional(),
+  picture: z.string().optional(),
+  locale: z.string().optional(),
+  connections: z.array(ConnectionSchema),
+});

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod'
 
 // Entity from auth0
 // {
@@ -34,12 +34,30 @@ import { z } from "zod";
 //   "family_name": ""
 // }
 
+interface Connection {
+  name: string;
+  profile?: { [key: string]: string | boolean | number };
+}
+
+export interface Profile {
+  id: string;
+  tenantId: string;
+  email: string;
+  created_at: string;
+  modified_at: string;
+  given_name?: string;
+  family_name?: string;
+  nickname?: string;
+  name?: string;
+  picture?: string;
+  locale?: string;
+  connections: Connection[];
+}
+
 const ConnectionSchema = z.object({
   name: z.string(),
   profile: z.record(z.union([z.string(), z.boolean(), z.number()])).optional(),
 });
-
-export type Profile = z.infer<typeof ProfileSchema>;
 
 export const ProfileSchema = z.object({
   id: z.string(),

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from "zod";
 
 // Entity from auth0
 // {

--- a/test/models/User.spec.ts
+++ b/test/models/User.spec.ts
@@ -181,6 +181,8 @@ describe("User", () => {
               return JSON.stringify({
                 id: "id",
                 name: "Test",
+                email: "test@example.com",
+                tenantId: "tenantId",
                 created_at: "2021-01-01T00:00:00.000Z",
                 modified_at: "2021-01-01T00:00:00.000Z",
                 connections: [],


### PR DESCRIPTION
This is freakin cool. Zod finally solves the issue with unsafe types runtime without adding more cruft to the code.

As the durable object storage just handles strings I would really like to have a safe way of getting and storing data there. This is a first POC and the next step would be make a generic wrapper for the storage.