### PR TITLE
feat: added sql support for domains

### DIFF
--- a/scripts/init-production.sh
+++ b/scripts/init-production.sh
@@ -1,0 +1,4 @@
+wrangler kv:namespace create auth_certificates --env production
+wrangler r2 bucket create auth-templates --env production
+wrangler queues create users --env production
+wrangler d1 create auth --env production

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,2 +1,4 @@
-wrangler kv:namespace create auth-certificates
+wrangler kv:namespace create auth_certificates
 wrangler r2 bucket create auth-templates
+wrangler queues create users
+wrangler d1 create auth

--- a/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
+++ b/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
@@ -1,0 +1,19 @@
+import { Kysely } from "kysely";
+import { Database } from "../../types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .createTable("domains")
+    .addColumn("id", "varchar(255)", (col) => col.notNull().primaryKey())
+    .addColumn("tenant_id", "varchar(255)", (col) =>
+      col.references("tenants.id").onDelete("cascade").notNull(),
+    )
+    .addColumn("domain", "varchar(255)")
+    .addColumn("created_at", "varchar(255)")
+    .addColumn("modified_at", "varchar(255)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.dropTable("domains").execute();
+}

--- a/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
+++ b/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
@@ -8,7 +8,7 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("tenant_id", "varchar(255)", (col) =>
       col.references("tenants.id").onDelete("cascade").notNull(),
     )
-    .addColumn("domain", "varchar(255)")
+    .addColumn("domain", "varchar(255)", , (col) => col.notNull().unique())
     .addColumn("created_at", "varchar(255)")
     .addColumn("modified_at", "varchar(255)")
     .execute();

--- a/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
+++ b/src/migrate/migrations/2023-08-15T09:17:35_domains.ts
@@ -8,7 +8,7 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("tenant_id", "varchar(255)", (col) =>
       col.references("tenants.id").onDelete("cascade").notNull(),
     )
-    .addColumn("domain", "varchar(255)", , (col) => col.notNull().unique())
+    .addColumn("domain", "varchar(255)", (col) => col.notNull().unique())
     .addColumn("created_at", "varchar(255)")
     .addColumn("modified_at", "varchar(255)")
     .execute();

--- a/src/migrate/migrations/index.ts
+++ b/src/migrate/migrations/index.ts
@@ -1,4 +1,5 @@
 import * as m1_init from "./2022-12-11T09:17:35_init";
+import * as m2_domains from "./2023-08-15T09:17:35_domains";
 
 // These needs to be in alphabetic order
-export default { m1_init };
+export default { m1_init, m2_domains };

--- a/src/routes/swagger-ui.ts
+++ b/src/routes/swagger-ui.ts
@@ -61,7 +61,7 @@ function getSwaggerHtml(env: Env) {
 
 
         if (ui.hasOwnProperty("initOAuth")) {
-          ui.initOAuth({"clientId":"${env.OAUTH2_CLIENT_ID}","appName":"sesamy"})
+          ui.initOAuth({"clientId":"auth-admin","appName":"sesamy"})
         }
 
         window.ui = ui;

--- a/src/routes/tsoa/domains.ts
+++ b/src/routes/tsoa/domains.ts
@@ -1,0 +1,201 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Path,
+  Request,
+  Route,
+  Tags,
+  Body,
+  SuccessResponse,
+  Security,
+  Delete,
+  Header,
+  Put,
+} from "@tsoa/runtime";
+import { nanoid } from "nanoid";
+
+import { getDb } from "../../services/db";
+import { RequestWithContext } from "../../types/RequestWithContext";
+import { updateTenantClientsInKV } from "../../hooks/update-client";
+import { parseRange } from "../../helpers/content-range";
+import { headers } from "../../constants";
+import { SqlDomain } from "../../types/sql/Domain";
+
+@Route("tenants/{tenantId}/domains")
+@Tags("domains")
+export class DomainsController extends Controller {
+  @Get("")
+  @Security("oauth2", [])
+  public async listDomains(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Header("range") range?: string,
+  ): Promise<SqlDomain[]> {
+    const { ctx } = request;
+
+    const parsedRange = parseRange(range);
+
+    const db = getDb(ctx.env);
+    const domains = await db
+      .selectFrom("domains")
+      .where("domains.tenantId", "=", tenantId)
+      .selectAll()
+      .offset(parsedRange.from)
+      .limit(parsedRange.limit)
+      .execute();
+
+    if (parsedRange.entity) {
+      this.setHeader(
+        headers.contentRange,
+        `${parsedRange.entity}=${parsedRange.from}-${parsedRange.to}/${parsedRange.limit}`,
+      );
+    }
+
+    return domains;
+  }
+
+  @Get("{id}")
+  @Security("oauth2", [])
+  public async getDomain(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+  ): Promise<SqlDomain | string> {
+    const { ctx } = request;
+
+    const db = getDb(ctx.env);
+    const domain = await db
+      .selectFrom("domains")
+      .where("domains.id", "=", id)
+      .where("domains.tenantId", "=", tenantId)
+      .selectAll()
+      .executeTakeFirst();
+
+    if (!domain) {
+      this.setStatus(404);
+      return "Not found";
+    }
+
+    return domain;
+  }
+
+  @Delete("{id}")
+  @Security("oauth2", [])
+  public async deleteDomain(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+  ): Promise<string> {
+    const { env } = request.ctx;
+
+    const db = getDb(env);
+    await db
+      .deleteFrom("domains")
+      .where("domains.tenantId", "=", tenantId)
+      .where("domains.id", "=", id)
+      .execute();
+
+    return "OK";
+  }
+
+  @Patch("{id}")
+  @Security("oauth2", [])
+  public async patchDomain(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+    @Body()
+    body: Partial<
+      Omit<SqlDomain, "id" | "tenantId" | "createdAt" | "modifiedAt">
+    >,
+  ) {
+    const { env } = request.ctx;
+
+    const db = getDb(env);
+    const domain = {
+      ...body,
+      tenantId,
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const results = await db
+      .updateTable("domains")
+      .set(domain)
+      .where("id", "=", id)
+      .execute();
+
+    return Number(results[0].numUpdatedRows);
+  }
+
+  @Post("")
+  @Security("oauth2", [])
+  @SuccessResponse(201, "Created")
+  public async postDomain(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Body()
+    body: Omit<SqlDomain, "id" | "tenantId" | "createdAt" | "modifiedAt">,
+  ): Promise<SqlDomain> {
+    const { ctx } = request;
+    const { env } = ctx;
+
+    const db = getDb(env);
+
+    const domain: SqlDomain = {
+      ...body,
+      tenantId,
+      id: nanoid(),
+      createdAt: new Date().toISOString(),
+      modifiedAt: new Date().toISOString(),
+    };
+
+    await db.insertInto("domains").values(domain).execute();
+
+    this.setStatus(201);
+    return domain;
+  }
+
+  @Put("{id}")
+  @Security("oauth2", [])
+  @SuccessResponse(201, "Created")
+  public async putDomain(
+    @Request() request: RequestWithContext,
+    @Path("id") id: string,
+    @Path("tenantId") tenantId: string,
+    @Body()
+    body: Omit<SqlDomain, "id" | "tenantId" | "createdAt" | "modifiedAt">,
+  ): Promise<SqlDomain> {
+    const { ctx } = request;
+    const { env } = ctx;
+
+    const db = getDb(env);
+
+    const domain: SqlDomain = {
+      ...body,
+      tenantId,
+      id,
+      createdAt: new Date().toISOString(),
+      modifiedAt: new Date().toISOString(),
+    };
+
+    try {
+      await db.insertInto("domains").values(domain).execute();
+    } catch (err: any) {
+      if (!err.message.includes("AlreadyExists")) {
+        throw err;
+      }
+
+      const { id, createdAt, tenantId, ...domainUpdate } = domain;
+      await db
+        .updateTable("domains")
+        .set(domainUpdate)
+        .where("id", "=", domain.id)
+        .execute();
+    }
+
+    this.setStatus(200);
+    return domain;
+  }
+}

--- a/src/types/Domain.ts
+++ b/src/types/Domain.ts
@@ -1,0 +1,56 @@
+export interface Domain {
+  hostname: string;
+  id: string;
+  ssl: {
+    bundle_method: string;
+    certificate_authority: string;
+    custom_certificate: string;
+    custom_csr_id: string;
+    custom_key: string;
+    expires_on: string;
+    hosts: string[];
+    id: string;
+    issuer: string;
+    method: string;
+    serial_number: string;
+    settings: {
+      ciphers: string[];
+      early_hints: string;
+      http2: string;
+      min_tls_version: string;
+      tls_1_3: string;
+    };
+    signature: string;
+    status: string;
+    type: string;
+    uploaded_on: string;
+    validation_errors: {
+      message: string;
+    }[];
+    validation_records: {
+      emails: string[];
+      http_body: string;
+      http_url: string;
+      txt_name: string;
+      txt_value: string;
+    }[];
+    wildcard: boolean;
+  };
+  created_at: string;
+  custom_metadata: {
+    [key: string]: string;
+  };
+  custom_origin_server: string;
+  custom_origin_sni: string;
+  ownership_verification: {
+    name: string;
+    type: string;
+    value: string;
+  };
+  ownership_verification_http: {
+    http_body: string;
+    http_url: string;
+  };
+  status: string;
+  verification_errors: string[];
+}

--- a/src/types/Env.ts
+++ b/src/types/Env.ts
@@ -17,7 +17,6 @@ export interface Env {
   ISSUER: string;
   DD_API_KEY: string;
   JWKS_URL: string;
-  OAUTH2_CLIENT_ID: string;
   DATABASE_HOST: string;
   DATABASE_PASSWORD: string;
   DATABASE_USERNAME: string;

--- a/src/types/sql/Domain.ts
+++ b/src/types/sql/Domain.ts
@@ -1,0 +1,7 @@
+export interface SqlDomain {
+  id: string;
+  tenantId: string;
+  createdAt: string;
+  modifiedAt: string;
+  domain: string;
+}

--- a/src/types/sql/db.ts
+++ b/src/types/sql/db.ts
@@ -5,10 +5,12 @@ import {
   Member,
   Migration,
   SqlUser,
+  SqlDomain,
 } from "./";
 
 // Keys of this interface are table names.
 export interface Database {
+  domains: SqlDomain;
   users: SqlUser;
   members: Member;
   applications: Application;

--- a/src/types/sql/index.ts
+++ b/src/types/sql/index.ts
@@ -4,4 +4,5 @@ export * from "./Tenant";
 export * from "./User";
 export * from "./Member";
 export * from "./Migration";
+export * from "./Domain";
 export * from "./db";

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,19 +7,16 @@ account_id = "0c8c22bdcd98c3dc6a35190650ef7906"
 
 kv_namespaces = [
     { binding = "CERTIFICATES", id = "2a5901d369d441bba149bb236af71c27", preview_id = "2a5901d369d441bba149bb236af71c27" },
-    { binding = "CLIENTS", id = "7e3153d8585547fdb67ee342c8592de0", preview_id = "7e3153d8585547fdb67ee342c8592de0" }    
+    { binding = "CLIENTS", id = "7e3153d8585547fdb67ee342c8592de0", preview_id = "7e3153d8585547fdb67ee342c8592de0" },
 ]
 
-services = [  
-    { binding = "TOKEN_SERVICE", service = "token-service-dev" }
-]
+services = [{ binding = "TOKEN_SERVICE", service = "token-service-dev" }]
 
 route = { pattern = "auth2.sesamy.dev/*", zone_id = "b56a76d859fe2ed6a8d77270cd2e8ba8" }
 
 [vars]
 ISSUER = "https://auth2.sesamy.dev/"
 JWKS_URL = "https://token.sesamy.dev/.well-known/jwks.json"
-OAUTH2_CLIENT_ID = '0N0wUHXFl0TMTY2L9aDJYvwX7Xy84HkW'
 READ_PERMISSION = 'auth:read'
 WRITE_PERMISSION = 'auth:write'
 
@@ -34,7 +31,10 @@ database_name = "auth2"
 database_id = "872f055e-d401-46a3-a0d0-fa00e66868b5"
 
 [durable_objects]
-bindings = [{name = "USER", class_name = "User"}, {name = "STATE", class_name = "State"}]
+bindings = [
+    { name = "USER", class_name = "User" },
+    { name = "STATE", class_name = "State" },
+]
 
 [[queues.producers]]
 queue = "users"
@@ -48,5 +48,47 @@ max_retries = 10
 dead_letter_queue = "users-dlq"
 
 [[migrations]]
+tag = "v1"
+new_classes = ["User", "State"]
+
+[env.production]
+account_id = "d684d0f34602a66c97de230566a2fa87"
+workers_dev = true
+route = "auth2.sesamy.com/*"
+
+[env.production.vars]
+ISSUER = "https://auth2.sesamy.com/"
+JWKS_URL = "https://token.sesamy.com/.well-known/jwks.json"
+READ_PERMISSION = 'auth:read'
+WRITE_PERMISSION = 'auth:write'
+
+[[env.production.r2_buckets]]
+binding = 'AUTH_TEMPLATES'
+preview_bucket_name = 'auth-templates'
+bucket_name = 'auth-templates'
+
+[[env.production.d1_databases]]
+binding = "AUTH_DB"
+database_name = "auth2"
+database_id = "921e31d7-63d0-441d-b60c-df2d6756db44"
+
+[env.production.durable_objects]
+bindings = [
+    { name = "USER", class_name = "User" },
+    { name = "STATE", class_name = "State" },
+]
+
+[[env.production.queues.producers]]
+queue = "users"
+binding = "USERS_QUEUE"
+
+[[env.production.queues.consumers]]
+queue = "users"
+max_batch_size = 10
+max_batch_timeout = 30
+max_retries = 10
+dead_letter_queue = "users-dlq"
+
+[[env.production.migrations]]
 tag = "v1"
 new_classes = ["User", "State"]


### PR DESCRIPTION
Ok, got 2 things in here.. The main thing is adding the basic sql models to handle domains. Currently it's just the sql stuff so we know which tenant has which custom domains connected to it. The next step is to integrate with the cloudflare api so we can manage the custom domains there.

I also did some prepping to make it possible to deploy this to prod. I added a small script to create the infra needed and added the config variables to the toml file. 