### PR TITLE
Ma/redirect validation

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -251,7 +251,7 @@ export function authenticationHandler(
   const securitySchemeName: SecuritySchemeName =
     "oauth2" in authProvider
       ? SecuritySchemeName.oauth2
-      : SecuritySchemeName.oauth2managmentApi;
+      : SecuritySchemeName.oauth2managementApi;
 
   const [scope] = authProvider[securitySchemeName];
   return async function jwtMiddleware(

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -130,12 +130,12 @@ function isValidScopes(token: TokenData, scopes: string[]) {
 async function isValidJwtSignature(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
-  token: TokenData
+  token: TokenData,
 ) {
   const encoder = new TextEncoder();
   const data = encoder.encode([token.raw.header, token.raw.payload].join("."));
   const signature = new Uint8Array(
-    Array.from(token.signature).map((c) => c.charCodeAt(0))
+    Array.from(token.signature).map((c) => c.charCodeAt(0)),
   );
   const jwksKeys = await getJwks(ctx.env, securitySchemeName);
 
@@ -151,7 +151,7 @@ async function isValidJwtSignature(
     jwksKey,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
-    ["verify"]
+    ["verify"],
   );
 
   return crypto.subtle.verify("RSASSA-PKCS1-v1_5", key, signature, data);
@@ -161,7 +161,7 @@ export async function getUser(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
   bearer: string,
-  scopes: string[]
+  scopes: string[],
 ): Promise<any> {
   const token = decodeJwt(bearer);
 
@@ -191,7 +191,7 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
 
   if (
     !["POST", "PATCH", "PUT", "DELETE", "GET", "HEAD"].includes(
-      ctx.request.method
+      ctx.request.method,
     )
   ) {
     // Don't bother about OPTIONS requests
@@ -251,7 +251,7 @@ export interface ManagementApiSecurity {
 }
 
 export function authenticationHandler(
-  security: (Security | ManagementApiSecurity)[]
+  security: (Security | ManagementApiSecurity)[],
 ) {
   const authProvider = security[0];
   const securitySchemeName: SecuritySchemeName =
@@ -262,7 +262,7 @@ export function authenticationHandler(
   const [scope] = authProvider[securitySchemeName];
   return async function jwtMiddleware(
     ctx: Context<Env>,
-    next: Next
+    next: Next,
   ): Promise<Response | undefined> {
     const authHeader = ctx.headers.get("authorization");
     if (!authHeader || !authHeader.toLowerCase().startsWith("bearer")) {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -107,7 +107,9 @@ async function getJwks(env: Env, securitySchemeName: SecuritySchemeName) {
         throw new Error("Failed to fetch jwks");
       }
 
-      const responseBody = JwksKeysSchema.parse(await response.json());
+      const responseBody: { keys: JwksKey[] } = await response.json();
+
+      console.log("Body: " + JSON.stringify(responseBody));
 
       jwksUrls[jwksUrl] = responseBody.keys;
     }

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -131,12 +131,12 @@ function isValidScopes(token: TokenData, scopes: string[]) {
 async function isValidJwtSignature(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
-  token: TokenData
+  token: TokenData,
 ) {
   const encoder = new TextEncoder();
   const data = encoder.encode([token.raw.header, token.raw.payload].join("."));
   const signature = new Uint8Array(
-    Array.from(token.signature).map((c) => c.charCodeAt(0))
+    Array.from(token.signature).map((c) => c.charCodeAt(0)),
   );
   const jwksKeys = await getJwks(ctx.env, securitySchemeName);
 
@@ -152,7 +152,7 @@ async function isValidJwtSignature(
     jwksKey,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
-    ["verify"]
+    ["verify"],
   );
 
   return crypto.subtle.verify("RSASSA-PKCS1-v1_5", key, signature, data);
@@ -162,7 +162,7 @@ export async function getUser(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
   bearer: string,
-  scopes: string[]
+  scopes: string[],
 ): Promise<any> {
   const token = decodeJwt(bearer);
 
@@ -192,7 +192,7 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
 
   if (
     !["POST", "PATCH", "PUT", "DELETE", "GET", "HEAD"].includes(
-      ctx.request.method
+      ctx.request.method,
     )
   ) {
     // Don't bother about OPTIONS requests
@@ -252,7 +252,7 @@ export interface ManagementApiSecurity {
 }
 
 export function authenticationHandler(
-  security: (Security | ManagementApiSecurity)[]
+  security: (Security | ManagementApiSecurity)[],
 ) {
   const authProvider = security[0];
   const securitySchemeName: SecuritySchemeName =
@@ -263,7 +263,7 @@ export function authenticationHandler(
   const [scope] = authProvider[securitySchemeName];
   return async function jwtMiddleware(
     ctx: Context<Env>,
-    next: Next
+    next: Next,
   ): Promise<Response | undefined> {
     const authHeader = ctx.headers.get("authorization");
     if (!authHeader || !authHeader.toLowerCase().startsWith("bearer")) {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -131,28 +131,28 @@ function isValidScopes(token: TokenData, scopes: string[]) {
 async function isValidJwtSignature(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
-  token: TokenData,
+  token: TokenData
 ) {
   const encoder = new TextEncoder();
   const data = encoder.encode([token.raw.header, token.raw.payload].join("."));
   const signature = new Uint8Array(
-    Array.from(token.signature).map((c) => c.charCodeAt(0)),
+    Array.from(token.signature).map((c) => c.charCodeAt(0))
   );
   const jwksKeys = await getJwks(ctx.env, securitySchemeName);
 
-  const jwkKey = jwksKeys.find((key) => key.kid === token.header.kid);
+  const jwksKey = jwksKeys.find((key) => key.kid === token.header.kid);
 
-  if (!jwkKey) {
+  if (!jwksKey) {
     console.log("No matching kid found");
     return false;
   }
 
   const key = await crypto.subtle.importKey(
     "jwk",
-    jwkKey,
+    jwksKey,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
-    ["verify"],
+    ["verify"]
   );
 
   return crypto.subtle.verify("RSASSA-PKCS1-v1_5", key, signature, data);
@@ -162,7 +162,7 @@ export async function getUser(
   ctx: Context<Env>,
   securitySchemeName: SecuritySchemeName,
   bearer: string,
-  scopes: string[],
+  scopes: string[]
 ): Promise<any> {
   const token = decodeJwt(bearer);
 
@@ -192,7 +192,7 @@ export async function verifyTenantPermissions(ctx: Context<Env>) {
 
   if (
     !["POST", "PATCH", "PUT", "DELETE", "GET", "HEAD"].includes(
-      ctx.request.method,
+      ctx.request.method
     )
   ) {
     // Don't bother about OPTIONS requests
@@ -252,7 +252,7 @@ export interface ManagementApiSecurity {
 }
 
 export function authenticationHandler(
-  security: (Security | ManagementApiSecurity)[],
+  security: (Security | ManagementApiSecurity)[]
 ) {
   const authProvider = security[0];
   const securitySchemeName: SecuritySchemeName =
@@ -263,7 +263,7 @@ export function authenticationHandler(
   const [scope] = authProvider[securitySchemeName];
   return async function jwtMiddleware(
     ctx: Context<Env>,
-    next: Next,
+    next: Next
   ): Promise<Response | undefined> {
     const authHeader = ctx.headers.get("authorization");
     if (!authHeader || !authHeader.toLowerCase().startsWith("bearer")) {

--- a/src/routes/tsoa/authorize.ts
+++ b/src/routes/tsoa/authorize.ts
@@ -21,6 +21,7 @@ import {
   socialAuth,
   universalAuth,
 } from "../../authentication-flows";
+import { validateRedirectUrl } from "../../utils/validate-redirect-url";
 
 export interface AuthorizeParams {
   request: RequestWithContext;
@@ -108,6 +109,9 @@ export class AuthorizeController extends Controller {
       code_challenge,
       code_challenge_method,
     };
+
+    // TODO: Should we check the origin here as well?
+    validateRedirectUrl(client.allowedCallbackUrls, authParams.redirect_uri);
 
     // Silent authentication
     if (prompt == "none") {

--- a/src/routes/tsoa/authorize.ts
+++ b/src/routes/tsoa/authorize.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Query,
+  Header,
   Request,
   Route,
   Tags,
@@ -93,6 +94,7 @@ export class AuthorizeController extends Controller {
     @Query("code_challenge_method") code_challenge_method?: CodeChallengeMethod,
     @Query("code_challenge") code_challenge?: string,
     @Query("realm") realm?: string,
+    @Header("referer") referer?: string,
   ): Promise<string> {
     const { ctx } = request;
     const { env } = ctx;
@@ -110,7 +112,10 @@ export class AuthorizeController extends Controller {
       code_challenge_method,
     };
 
-    // TODO: Should we check the origin here as well?
+    if (referer) {
+      validateRedirectUrl(client.allowedWebOrigins, authParams.redirect_uri);
+    }
+
     validateRedirectUrl(client.allowedCallbackUrls, authParams.redirect_uri);
 
     // Silent authentication

--- a/src/routes/tsoa/logout.ts
+++ b/src/routes/tsoa/logout.ts
@@ -11,6 +11,7 @@ import {
 import { getClient } from "../../services/clients";
 import { serializeClearCookie } from "../../services/cookies";
 import { headers } from "../../constants";
+import { validateRedirectUrl } from "../../utils/validate-redirect-url";
 
 @Route("v2/logout")
 @Tags("logout")
@@ -32,14 +33,7 @@ export class LogoutController extends Controller {
       throw new Error("No return to url found");
     }
 
-    if (
-      !client.allowedCallbackUrls.some((callbackUrl) => {
-        const regex = new RegExp(callbackUrl, "i");
-        return regex.test(redirectUri);
-      })
-    ) {
-      throw new Error("Invalid return to url");
-    }
+    validateRedirectUrl(client.allowedCallbackUrls, redirectUri);
 
     this.setStatus(302);
     serializeClearCookie().forEach((cookie) => {

--- a/src/routes/tsoa/userinfo.ts
+++ b/src/routes/tsoa/userinfo.ts
@@ -10,7 +10,7 @@ export class UserinfoController extends Controller {
   @Get("userinfo")
   @Security("oauth2", ["openid profile"])
   public async getUser(
-    @Request() request: RequestWithContext
+    @Request() request: RequestWithContext,
   ): Promise<{ id: string }> {
     const { ctx } = request;
     const { env } = ctx;
@@ -28,7 +28,7 @@ export class UserinfoController extends Controller {
 
     // Fetch the user from durable object
     const user = env.userFactory.getInstanceByName(
-      getId(dbUser.tenantId, dbUser.email)
+      getId(dbUser.tenantId, dbUser.email),
     );
 
     return user.getProfile.query();

--- a/src/routes/tsoa/userinfo.ts
+++ b/src/routes/tsoa/userinfo.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Request, Route, Security, Tags } from "@tsoa/runtime";
 import { RequestWithContext } from "../../types/RequestWithContext";
 import { getDb } from "../../services/db";
-import { NotFoundError } from "src/errors";
-import { getId } from "src/models";
+import { NotFoundError } from "../../errors";
+import { getId } from "../../models";
 
 @Route("")
 @Tags("userinfo")
@@ -10,7 +10,7 @@ export class UserinfoController extends Controller {
   @Get("userinfo")
   @Security("oauth2", ["openid profile"])
   public async getUser(
-    @Request() request: RequestWithContext,
+    @Request() request: RequestWithContext
   ): Promise<{ id: string }> {
     const { ctx } = request;
     const { env } = ctx;
@@ -28,7 +28,7 @@ export class UserinfoController extends Controller {
 
     // Fetch the user from durable object
     const user = env.userFactory.getInstanceByName(
-      getId(dbUser.tenantId, dbUser.email),
+      getId(dbUser.tenantId, dbUser.email)
     );
 
     return user.getProfile.query();

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -1,0 +1,27 @@
+export function validateRedirectUrl(
+  logoutUrls: string[],
+  redirectUri?: string,
+) {
+  if (!redirectUri) {
+    return;
+  }
+
+  const url = new URL(redirectUri);
+  const urlToCompare = `${url.protocol}//${url.host}`;
+
+  const regexes = logoutUrls.map(
+    // This replaces * with .* but not if there's already a regex wildcard
+    (url) =>
+      new RegExp(
+        url
+          .replace(/\./g, "\\.")
+          .replace(/\//g, "\\/")
+          .replace(/(?<!\.)\*/g, ".*"),
+        "i",
+      ),
+  );
+
+  if (!regexes.some((regex) => regex.test(urlToCompare))) {
+    throw new Error("Invalid redirectUri");
+  }
+}

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -113,7 +113,10 @@ export function contextFixture(params?: MockedContextParams): Context<Env> {
             tenantId: "tenantId",
             senderEmail: "senderEmail",
             senderName: "senderName",
-            allowedCallbackUrls: ["http://localhost:3000"],
+            allowedCallbackUrls: [
+              "http://localhost:3000",
+              "https://example.com",
+            ],
             connections: [
               {
                 name: "google-oauth2",

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -1,0 +1,43 @@
+import { validateRedirectUrl } from "../../src/utils/validate-redirect-url";
+
+describe("validateRedirectUrl", () => {
+  it("should allow valid redirectUri", () => {
+    const logoutUrls = ["https://*.example.com"];
+    const redirectUri = "https://sub.example.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
+  });
+
+  it("should disallow invalid redirectUri", () => {
+    const logoutUrls = ["https://*.example.com"];
+    const redirectUri = "https://notexample.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
+      "Invalid redirectUri",
+    );
+  });
+
+  it("should be case insensitive", () => {
+    const logoutUrls = ["https://*.EXAMPLE.com"];
+    const redirectUri = "https://sub.example.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
+  });
+
+  it("should handle URLs without wildcards", () => {
+    const logoutUrls = ["https://sub.example.com"];
+    const redirectUri = "https://sub.example.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
+  });
+
+  it("should handle exact matches of urls with ports", () => {
+    const logoutUrls = ["http://localhost:3000"];
+    const redirectUri = "http://localhost:3000";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
+  });
+
+  it("should throw error for URLs that don't exactly match", () => {
+    const logoutUrls = ["https://sub.example.com"];
+    const redirectUri = "https://sub2.example.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
+      "Invalid redirectUri",
+    );
+  });
+});

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -3,13 +3,19 @@ import { validateRedirectUrl } from "../../src/utils/validate-redirect-url";
 describe("validateRedirectUrl", () => {
   it("should allow valid redirectUri", () => {
     const logoutUrls = ["https://*.example.com"];
+    const redirectUri = "https://sub.example.com";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
+  });
+
+  it("should allow valid redirectUri with a path", () => {
+    const logoutUrls = ["https://*.example.com/path"];
     const redirectUri = "https://sub.example.com/path";
     expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
   });
 
   it("should disallow invalid redirectUri", () => {
     const logoutUrls = ["https://*.example.com"];
-    const redirectUri = "https://notexample.com/path";
+    const redirectUri = "https://notexample.com";
     expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
       "Invalid redirectUri",
     );
@@ -17,13 +23,13 @@ describe("validateRedirectUrl", () => {
 
   it("should be case insensitive", () => {
     const logoutUrls = ["https://*.EXAMPLE.com"];
-    const redirectUri = "https://sub.example.com/path";
+    const redirectUri = "https://sub.example.com";
     expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
   });
 
   it("should handle URLs without wildcards", () => {
     const logoutUrls = ["https://sub.example.com"];
-    const redirectUri = "https://sub.example.com/path";
+    const redirectUri = "https://sub.example.com";
     expect(() => validateRedirectUrl(logoutUrls, redirectUri)).not.toThrow();
   });
 
@@ -35,7 +41,23 @@ describe("validateRedirectUrl", () => {
 
   it("should throw error for URLs that don't exactly match", () => {
     const logoutUrls = ["https://sub.example.com"];
-    const redirectUri = "https://sub2.example.com/path";
+    const redirectUri = "https://sub2.example.com";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
+      "Invalid redirectUri",
+    );
+  });
+
+  it("should throw if the path isn't matching", () => {
+    const logoutUrls = ["https://example.com"];
+    const redirectUri = "https://example.com/path";
+    expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
+      "Invalid redirectUri",
+    );
+  });
+
+  it("should not accept wildcards in the path", () => {
+    const logoutUrls = ["https://example.com/*"];
+    const redirectUri = "https://example.com/path";
     expect(() => validateRedirectUrl(logoutUrls, redirectUri)).toThrow(
       "Invalid redirectUri",
     );


### PR DESCRIPTION
Did a refactor of the redirect validation. Now it supports the default auth0 way of for instance `http://*.sesamy.dev`. But it's also possible to pass any valid regex.