### PR TITLE
feat: make it possible to store default settings in a env variable

### DIFF
--- a/src/hooks/update-client.ts
+++ b/src/hooks/update-client.ts
@@ -1,4 +1,4 @@
-import { Env, Client } from "../types";
+import { Env, SqlConnectionSchema, PartialClient } from "../types";
 import { getDb } from "../services/db";
 
 export async function updateTenantClientsInKV(env: Env, tenantId: string) {
@@ -59,19 +59,21 @@ export async function updateClientInKV(env: Env, applicationId: string) {
     .select(["domain", "dkimPrivateKey"])
     .execute();
 
-  const client: Client = {
+  const client: PartialClient = {
     id: application.id,
     name: application.name,
     audience: application.audience,
-    connections: connections.map((connection) => ({
-      ...connection,
-      clientSecret: connection.clientSecret ?? undefined,
-      privateKey: connection.privateKey ?? undefined,
-      kid: connection.kid ?? undefined,
-      teamId: connection.teamId ?? undefined,
-      responseType: connection.responseType ?? undefined,
-      responseMode: connection.responseMode ?? undefined,
-    })),
+    connections: connections.map((connection) =>
+      SqlConnectionSchema.parse({
+        ...connection,
+        clientSecret: connection.clientSecret ?? undefined,
+        privateKey: connection.privateKey ?? undefined,
+        kid: connection.kid ?? undefined,
+        teamId: connection.teamId ?? undefined,
+        responseType: connection.responseType ?? undefined,
+        responseMode: connection.responseMode ?? undefined,
+      }),
+    ),
     domains,
     senderEmail: application.senderEmail,
     senderName: application.senderName,

--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { Env, SqlConnectionSchema } from "../types";
+
+const DefaultSettingsSchema = z.object({
+  connections: z
+    .array(
+      z.object({
+        name: z.string(),
+        // All these properties are optional as they only are defaults
+        clientId: z.string().optional(),
+        clientSecret: z.string().optional(),
+        privateKey: z.string().optional(),
+        kid: z.string().optional(),
+        teamId: z.string().optional(),
+        scope: z.string().optional(),
+        authorizationEndpoint: z.string().optional(),
+        tokenEndpoint: z.string().optional(),
+        responseType: z.string().optional(),
+        responseMode: z.string().optional(),
+      }),
+    )
+    .optional(),
+  domains: z
+    .array(
+      z.object({
+        domain: z.string(),
+        dkimPrivateKey: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+export type DefaultSettings = z.infer<typeof DefaultSettingsSchema>;
+
+export function getDefaultSettings(env: Env) {
+  const defaultSettingsString = env.DEFAULT_SETTINGS;
+
+  if (!defaultSettingsString) {
+    return {};
+  }
+
+  try {
+    return DefaultSettingsSchema.parse(JSON.parse(defaultSettingsString));
+  } catch (err: any) {
+    console.log("Failed to load default settings: " + err.message);
+    throw err;
+  }
+}

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  AuthorizationResponseMode,
+  AuthorizationResponseType,
+} from "./AuthParams";
 
 export const ClientSchema = z.object({
   id: z.string(),
@@ -8,6 +12,7 @@ export const ClientSchema = z.object({
   senderName: z.string(),
   connections: z.array(
     z.object({
+      id: z.string(),
       name: z.string(),
       clientId: z.string(),
       clientSecret: z.string().optional(),
@@ -17,8 +22,54 @@ export const ClientSchema = z.object({
       scope: z.string(),
       authorizationEndpoint: z.string(),
       tokenEndpoint: z.string(),
-      responseType: z.string().optional(),
-      responseMode: z.string().optional(),
+      responseType: z.custom<AuthorizationResponseType>(),
+      responseMode: z.custom<AuthorizationResponseMode>(),
+      createdAt: z.string(),
+      modifiedAt: z.string(),
+    }),
+  ),
+  domains: z.array(
+    z.object({
+      domain: z.string(),
+      dkimPrivateKey: z.string(),
+    }),
+  ),
+  allowedCallbackUrls: z.array(z.string()),
+  allowedLogoutUrls: z.array(z.string()),
+  allowedWebOrigins: z.array(z.string()),
+  emailValidation: z.union([
+    z.literal("enabled"),
+    z.literal("disabled"),
+    z.literal("enforced"),
+  ]),
+  tenantId: z.string(),
+  clientSecret: z.string(),
+});
+
+// This can be decorated with default vaules
+export const PartialClientSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  audience: z.string(),
+  senderEmail: z.string(),
+  senderName: z.string(),
+  connections: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      // All these properties are optional as they can use the settings from the default settings
+      clientId: z.string().optional(),
+      clientSecret: z.string().optional(),
+      privateKey: z.string().optional(),
+      kid: z.string().optional(),
+      teamId: z.string().optional(),
+      scope: z.string().optional(),
+      authorizationEndpoint: z.string().optional(),
+      tokenEndpoint: z.string().optional(),
+      responseType: z.custom<AuthorizationResponseType>().optional(),
+      responseMode: z.custom<AuthorizationResponseMode>().optional(),
+      createdAt: z.string(),
+      modifiedAt: z.string(),
     }),
   ),
   domains: z.array(
@@ -40,3 +91,4 @@ export const ClientSchema = z.object({
 });
 
 export type Client = z.infer<typeof ClientSchema>;
+export type PartialClient = z.infer<typeof PartialClientSchema>;

--- a/src/types/Env.ts
+++ b/src/types/Env.ts
@@ -29,6 +29,7 @@ export interface Env {
   AUTH_TEMPLATES: R2Bucket;
   READ_PERMISSION?: string;
   WRITE_PERMISSION?: string;
+  DEFAULT_SETTINGS?: string;
   oauth2ClientFactory: IOAuth2ClientFactory;
   stateFactory: ClientFactory<StateClient>;
   userFactory: ClientFactory<UserClient>;

--- a/src/types/sql/Connection.ts
+++ b/src/types/sql/Connection.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  AuthorizationResponseMode,
+  AuthorizationResponseType,
+} from "../AuthParams";
 
 export const SqlConnectionSchema = z.object({
   id: z.string(),
@@ -7,8 +11,8 @@ export const SqlConnectionSchema = z.object({
   clientId: z.string(),
   clientSecret: z.string().optional(),
   authorizationEndpoint: z.string(),
-  responseType: z.string().optional(),
-  responseMode: z.string().optional(),
+  responseType: z.custom<AuthorizationResponseType>().optional(),
+  responseMode: z.custom<AuthorizationResponseMode>().optional(),
   privateKey: z.string().optional(),
   kid: z.string().optional(),
   teamId: z.string().optional(),

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -25,7 +25,7 @@ type ValidateAuthenticationCodeParams = Parameters<
   typeof caller.validateAuthenticationCode
 >[0];
 
-export interface MockedContextParams {
+export interface ContextFixtureParams {
   stateData?: { [key: string]: string };
   clients?: KVNamespace;
   userData?: { [key: string]: string | boolean };
@@ -51,6 +51,7 @@ const client: Client = {
   audience: "audience",
   connections: [
     {
+      id: "connectionId1",
       name: "google-oauth2",
       clientId: "googleClientId",
       clientSecret: "googleClientSecret",
@@ -59,8 +60,11 @@ const client: Client = {
       responseMode: AuthorizationResponseMode.QUERY,
       responseType: AuthorizationResponseType.CODE,
       scope: "openid profile email",
+      createdAt: "createdAt",
+      modifiedAt: "modifiedAt",
     },
     {
+      id: "connectionId2",
       name: "facebook",
       clientId: "facebookClientId",
       clientSecret: "facebookClientSecret",
@@ -69,12 +73,14 @@ const client: Client = {
       responseMode: AuthorizationResponseMode.QUERY,
       responseType: AuthorizationResponseType.CODE,
       scope: "email public_profile",
+      createdAt: "createdAt",
+      modifiedAt: "modifiedAt",
     },
   ],
   domains: [],
 };
 
-export function contextFixture(params?: MockedContextParams): Context<Env> {
+export function contextFixture(params?: ContextFixtureParams): Context<Env> {
   const { stateData = {}, userData = {}, logs = [], clients } = params || {};
 
   return {

--- a/test/routes/tsoa/token.spec.ts
+++ b/test/routes/tsoa/token.spec.ts
@@ -42,6 +42,7 @@ describe("token", () => {
     audience: "audience",
     connections: [
       {
+        id: "connectionId",
         name: "google-oauth2",
         clientId: "googleClientId",
         clientSecret: "googleClientSecret",
@@ -50,6 +51,8 @@ describe("token", () => {
         responseMode: AuthorizationResponseMode.QUERY,
         responseType: AuthorizationResponseType.CODE,
         scope: "openid email profile",
+        createdAt: "createdAt",
+        modifiedAt: "modifiedAt",
       },
     ],
     domains: [],

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -9,10 +9,6 @@ import {
 import { kvStorageFixture } from "../fixtures/kv-storage";
 
 describe("getClient", () => {
-  afterEach(() => {
-    delete process.env.detaultSettings;
-  });
-
   it("should fallback the connections to the defaultSettings", async () => {
     const clientInKV: PartialClient = {
       id: "id",

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -1,0 +1,95 @@
+import { DefaultSettings } from "../../src/models/DefaultSettings";
+import { getClient } from "../../src/services/clients";
+import { contextFixture } from "../fixtures";
+import {
+  AuthorizationResponseType,
+  AuthorizationResponseMode,
+  PartialClient,
+} from "../../src/types";
+import { kvStorageFixture } from "../fixtures/kv-storage";
+
+describe("getClient", () => {
+  afterEach(() => {
+    delete process.env.detaultSettings;
+  });
+
+  it("should fallback the connections to the defaultSettings", async () => {
+    const clientInKV: PartialClient = {
+      id: "id",
+      name: "clientName",
+      clientSecret: "clientSecret",
+      tenantId: "tenantId",
+      senderEmail: "senderEmail",
+      senderName: "senderName",
+      allowedCallbackUrls: ["http://localhost:3000", "https://example.com"],
+      allowedLogoutUrls: ["http://localhost:3000", "https://example.com"],
+      allowedWebOrigins: ["http://localhost:3000", "https://example.com"],
+      emailValidation: "enabled",
+      audience: "audience",
+      connections: [
+        {
+          id: "connectionId",
+          name: "facebook",
+          createdAt: "createdAt",
+          modifiedAt: "modifiedAt",
+        },
+      ],
+      domains: [],
+    };
+
+    const ctx = contextFixture({
+      clients: kvStorageFixture({
+        clientId: JSON.stringify(clientInKV),
+      }),
+    });
+
+    const defaultSettings: DefaultSettings = {
+      connections: [
+        {
+          name: "facebook",
+          clientId: "facebookClientId",
+          clientSecret: "facebookClientSecret",
+          scope: "email public_profile openid",
+          authorizationEndpoint: "https://www.facebook.com/dialog/oauth",
+          tokenEndpoint: "https://graph.facebook.com/oauth/access_token",
+          responseMode: AuthorizationResponseMode.QUERY,
+          responseType: AuthorizationResponseType.CODE,
+        },
+      ],
+    };
+
+    ctx.env.DEFAULT_SETTINGS = JSON.stringify(defaultSettings);
+
+    const client = await getClient(ctx.env, "clientId");
+    const facebookConnection = client.connections.find(
+      (c) => c.name === "facebook",
+    );
+
+    expect(facebookConnection?.clientId).toBe("facebookClientId");
+  });
+
+  it("should add a domain from the defaultSettings to the client domains", async () => {
+    const ctx = contextFixture();
+
+    const defaultSettings: DefaultSettings = {
+      connections: [],
+      domains: [
+        {
+          domain: "example.com",
+          dkimPrivateKey: "dkimKey",
+        },
+      ],
+    };
+
+    ctx.env.DEFAULT_SETTINGS = JSON.stringify(defaultSettings);
+
+    const client = await getClient(ctx.env, "clientId");
+
+    expect(client.domains).toEqual([
+      {
+        domain: "example.com",
+        dkimPrivateKey: "dkimKey",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This got a bit more messy than I thought.

The idea is that we can store default settings in a env-variable and it will decorate the clients stored in KV-storage in run time. There's a few benefits with this:
- You don't have to type so much.. Just add a empty google-connection and it will use the defaults
- We don't have to persist sensitive data somewhere it can be accessed. The environment variables can be encrypted so there will be no easy way to get hold of private keys and such.