### PR TITLE
fix: skip queues if not defined

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ const server = {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
+    ctx: ExecutionContext
   ): Promise<Response> {
     return app.handle(
       request,
@@ -27,7 +27,7 @@ const server = {
         stateFactory: State.getFactory(env.STATE, env),
         userFactory: User.getFactory(env.USER, env),
       },
-      ctx,
+      ctx
     );
   },
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
@@ -36,7 +36,7 @@ const server = {
   async queue(
     batch: MessageBatch<QueueMessage>,
     env: Env,
-    ctx: ExecutionContext,
+    ctx: ExecutionContext
   ) {
     for (const message of batch.messages) {
       const { body } = message;
@@ -44,7 +44,7 @@ const server = {
 
       switch (body.queueName) {
         case "users":
-          await updateUser(env, body.tenantId, body.userId);
+          await updateUser(env, body.tenantId, body.email);
           break;
         default:
           console.log(`Unknown message: ${JSON.stringify(message.body)}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ const server = {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext
+    ctx: ExecutionContext,
   ): Promise<Response> {
     return app.handle(
       request,
@@ -27,7 +27,7 @@ const server = {
         stateFactory: State.getFactory(env.STATE, env),
         userFactory: User.getFactory(env.USER, env),
       },
-      ctx
+      ctx,
     );
   },
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
@@ -36,7 +36,7 @@ const server = {
   async queue(
     batch: MessageBatch<QueueMessage>,
     env: Env,
-    ctx: ExecutionContext
+    ctx: ExecutionContext,
   ) {
     for (const message of batch.messages) {
       const { body } = message;

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,3 +1,4 @@
+import { updateUser } from "../handlers/update-user";
 import { Env } from "../types/Env";
 
 export enum UserEvent {
@@ -9,25 +10,25 @@ export enum UserEvent {
 
 export interface UserMessage {
   queueName: "users";
-  userId: string;
+  email: string;
   event: UserEvent;
 }
 
 export type QueueMessage = { tenantId: string } & UserMessage;
 
-export async function sendUserEvent(
-  queue: Queue<QueueMessage>,
-  doId: string,
-  event: UserEvent,
-) {
-  const [tenantId, userId] = doId.split("|");
+export async function sendUserEvent(env: Env, doId: string, event: UserEvent) {
+  const [tenantId, email] = doId.split("|");
 
-  const message: QueueMessage = {
-    userId,
-    tenantId,
-    queueName: "users",
-    event,
-  };
+  if (env.USERS_QUEUE) {
+    const message: QueueMessage = {
+      email,
+      tenantId,
+      queueName: "users",
+      event,
+    };
 
-  await queue.send(message);
+    await env.USERS_QUEUE.send(message);
+  } else {
+    await updateUser(env, tenantId, email);
+  }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,16 +36,16 @@ bindings = [
     { name = "STATE", class_name = "State" },
 ]
 
-[[queues.producers]]
-queue = "users"
-binding = "USERS_QUEUE"
+# [[queues.producers]]
+# queue = "users"
+# binding = "USERS_QUEUE"
 
-[[queues.consumers]]
-queue = "users"
-max_batch_size = 10
-max_batch_timeout = 30
-max_retries = 10
-dead_letter_queue = "users-dlq"
+# [[queues.consumers]]
+# queue = "users"
+# max_batch_size = 10
+# max_batch_timeout = 30
+# max_retries = 10
+# dead_letter_queue = "users-dlq"
 
 [[migrations]]
 tag = "v1"
@@ -85,16 +85,16 @@ bindings = [
     { name = "STATE", class_name = "State" },
 ]
 
-[[env.production.queues.producers]]
-queue = "users"
-binding = "USERS_QUEUE"
+# [[env.production.queues.producers]]
+# queue = "users"
+# binding = "USERS_QUEUE"
 
-[[env.production.queues.consumers]]
-queue = "users"
-max_batch_size = 10
-max_batch_timeout = 30
-max_retries = 10
-dead_letter_queue = "users-dlq"
+# [[env.production.queues.consumers]]
+# queue = "users"
+# max_batch_size = 10
+# max_batch_timeout = 30
+# max_retries = 10
+# dead_letter_queue = "users-dlq"
 
 [[env.production.migrations]]
 tag = "v1"


### PR DESCRIPTION
If the queue isn't defined in the toml-file it will call the updateUser directly instead. This way we can run the project remotely which will make the DX much better.