### PR TITLE
feat: add emailService to use mailgun

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,6 +1,7 @@
 import { Liquid } from "liquidjs";
 import { translate } from "../utils/i18n";
 import { Client, Env } from "../types";
+import sendEmail from "../services/email";
 
 const engine = new Liquid();
 
@@ -15,9 +16,9 @@ export async function sendEmailValidation(
   }
 
   const message = `Here is the code to validate your email: ${code}`;
-  await env.sendEmail({
+  await sendEmail(client, {
     to: [{ email: to, name: to }],
-    dkim: client.domains[0],
+    dkim: client.domains[0]?.dkimPrivateKey,
     from: {
       email: client.senderEmail,
       name: client.senderName,
@@ -60,9 +61,9 @@ export async function sendCode(
       "https://assets.sesamy.com/static/images/sesamy/logo-translucent.png",
   });
 
-  await env.sendEmail({
+  await sendEmail(client, {
     to: [{ email: to, name: to }],
-    dkim: client.domains[0],
+    dkim: client.domains[0]?.dkimPrivateKey,
     from: {
       email: client.senderEmail,
       name: client.senderName,
@@ -87,9 +88,9 @@ export async function sendResetPassword(
   state: string,
 ) {
   const message = `Click this link to reset your password: ${env.ISSUER}u/reset-password?state=${state}&code=${code}`;
-  await env.sendEmail({
+  await sendEmail(client, {
     to: [{ email: to, name: to }],
-    dkim: client.domains[0],
+    dkim: client.domains[0]?.dkimPrivateKey,
     from: {
       email: client.senderEmail,
       name: client.senderName,

--- a/src/migrate/migrations/2023-08-31T13:50:12_mailgun.ts
+++ b/src/migrate/migrations/2023-08-31T13:50:12_mailgun.ts
@@ -1,0 +1,27 @@
+import { Kysely } from "kysely";
+import { Database } from "../../types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("domains")
+    .addColumn("email_service", "varchar(255)")
+    .addColumn("email_api_key", "varchar(255)")
+    // Fix casing
+    .addColumn("dkim_private_key", "varchar(2048)")
+    .addColumn("dkim_public_key", "varchar(2048)")
+    .dropColumn("dkimPrivateKey")
+    .dropColumn("dkimPrivateKey")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("domains")
+    .dropColumn("email_service")
+    .dropColumn("email_api_key")
+    .dropColumn("dkim_private_key")
+    .dropColumn("dkim_public_key")
+    .addColumn("dkimPrivateKey", "varchar(2048)")
+    .addColumn("dkimPublicKey", "varchar(2048)")
+    .execute();
+}

--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Env, SqlConnectionSchema } from "../types";
+import { Env } from "../types";
 
 const DefaultSettingsSchema = z.object({
   connections: z
@@ -24,7 +24,11 @@ const DefaultSettingsSchema = z.object({
     .array(
       z.object({
         domain: z.string(),
-        dkimPrivateKey: z.string(),
+        dkimPrivateKey: z.string().optional(),
+        emailService: z
+          .union([z.literal("mailchannels"), z.literal("mailgun")])
+          .optional(),
+        emailApiKey: z.string().optional(),
       }),
     )
     .optional(),

--- a/src/services/email/EmailOptions.ts
+++ b/src/services/email/EmailOptions.ts
@@ -3,17 +3,13 @@ export interface EmailUser {
   name: string;
 }
 
-export interface DKIM {
-  domain: string;
-  dkimPrivateKey: string;
-}
-
 export interface EmailOptions {
   to: EmailUser[];
   from: EmailUser;
   subject: string;
-  dkim?: DKIM;
+  dkim?: string;
   apiKey?: string;
+  emailService?: "mailgun" | "mailchannels";
   content: {
     type: "text/plain" | "text/html";
     value: string;

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -1,0 +1,28 @@
+import { getDomainFromEmail } from "../../utils/email";
+import { Client } from "../../types";
+import { EmailOptions } from "./EmailOptions";
+
+import sendWithMailchannels from "./mailchannels";
+import sendWithMailgun from "./mailgun";
+
+export default async function sendEmail(
+  client: Client,
+  emailOptions: EmailOptions,
+) {
+  const domainName = getDomainFromEmail(emailOptions.from.email);
+
+  const domain = client.domains.find((d) => d.domain === domainName) || {};
+
+  const emailOptionsWithDefaults = {
+    ...domain,
+    ...emailOptions,
+  };
+
+  switch (emailOptionsWithDefaults.emailService) {
+    case "mailgun":
+      return sendWithMailgun(emailOptions);
+    case "mailchannels":
+    default:
+      return sendWithMailchannels(emailOptions);
+  }
+}

--- a/src/services/email/mailchannels.ts
+++ b/src/services/email/mailchannels.ts
@@ -1,7 +1,10 @@
+import { getDomainFromEmail } from "../../utils/email";
 import { EmailOptions } from "./EmailOptions";
 
 export default async function send(emailOptions: EmailOptions) {
   const { to, from, dkim, subject, content } = emailOptions;
+
+  const domain = getDomainFromEmail(from.email);
 
   const body = JSON.stringify({
     personalizations: [
@@ -10,9 +13,9 @@ export default async function send(emailOptions: EmailOptions) {
         // Add dkim if configured
         ...(dkim
           ? {
-              dkim_domain: dkim.domain,
+              dkim_domain: domain,
               dkim_selector: "mailchannels",
-              dkim_private_key: dkim.dkimPrivateKey,
+              dkim_private_key: dkim,
             }
           : {}),
       },

--- a/src/services/email/mailgun.ts
+++ b/src/services/email/mailgun.ts
@@ -1,9 +1,5 @@
+import { getDomainFromEmail } from "../../utils/email";
 import { EmailOptions } from "./EmailOptions";
-
-function getDomainFromEmail(email: string): string {
-  const domainMatch = email.match(/@([\w.-]+)/);
-  return domainMatch ? domainMatch[1] : "";
-}
 
 export default async function send(emailOptions: EmailOptions) {
   const API_URL = `https://api.mailgun.net/v3/${getDomainFromEmail(

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -4,6 +4,16 @@ import {
   AuthorizationResponseType,
 } from "./AuthParams";
 
+export const ClientDomainSchema = z.object({
+  domain: z.string(),
+  dkimPrivateKey: z.string().optional(),
+  dkimPublicKey: z.string().optional(),
+  apiKey: z.string().optional(),
+  mailService: z
+    .union([z.literal("mailgun"), z.literal("mailchannels")])
+    .optional(),
+});
+
 export const PartialConnectionSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -49,12 +59,7 @@ export const BaseClientSchema = z.object({
   logo: z.string().optional(),
   primaryColor: z.string().optional(),
   secondaryColor: z.string().optional(),
-  domains: z.array(
-    z.object({
-      domain: z.string(),
-      dkimPrivateKey: z.string(),
-    }),
-  ),
+  domains: z.array(ClientDomainSchema),
   allowedCallbackUrls: z.array(z.string()),
   allowedLogoutUrls: z.array(z.string()),
   allowedWebOrigins: z.array(z.string()),

--- a/src/types/Env.ts
+++ b/src/types/Env.ts
@@ -1,7 +1,6 @@
 import { IOAuth2ClientFactory } from "../services/oauth2-client";
 import { StateClient, UserClient } from "../models";
 import { QueueMessage } from "../services/events";
-import { SendEmail } from "../services/email/EmailOptions";
 
 export interface StateRouterFactory {
   (name: string): StateClient;
@@ -34,5 +33,4 @@ export interface Env {
   oauth2ClientFactory: IOAuth2ClientFactory;
   stateFactory: ClientFactory<StateClient>;
   userFactory: ClientFactory<UserClient>;
-  sendEmail: SendEmail;
 }

--- a/src/types/sql/Domain.ts
+++ b/src/types/sql/Domain.ts
@@ -4,6 +4,8 @@ export interface SqlDomain {
   createdAt: string;
   modifiedAt: string;
   domain: string;
-  dkimPrivateKey: string;
-  dkimPublicKey: string;
+  dkimPrivateKey?: string;
+  dkimPublicKey?: string;
+  apiKey?: string;
+  mailService?: "mailgun" | "mailchannels";
 }

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,4 @@
+export function getDomainFromEmail(email: string): string {
+  const domainMatch = email.match(/@([\w.-]+)/);
+  return domainMatch ? domainMatch[1] : "";
+}

--- a/test/services/email/mailgun.spec.ts
+++ b/test/services/email/mailgun.spec.ts
@@ -2,11 +2,11 @@ import send from "../../../src/services/email/mailgun";
 import { EmailOptions } from "../../../src/services/email/EmailOptions";
 import fetchMock from "jest-fetch-mock";
 
-beforeEach(() => {
-  fetchMock.resetMocks();
-});
-
 describe("send", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
   it("should correctly call Mailgun API", async () => {
     const testEmailOptions: EmailOptions = {
       to: [{ email: "test@example.com", name: "Test User" }],


### PR DESCRIPTION
This PR adds a migration so you can specify an email service for a domain and pass an apiKey in the case of mailgun. It adds this information to the client as well, so it can be pulled from there when sending emails.

I switched to use the jest-mock for the emails as well so we don't need to have that nasty sendEmail function on the context.