### PR TITLE
fix: remove dkim migration

### DIFF
--- a/src/migrate/migrations/2023-08-22T15:06:26_dkim.ts
+++ b/src/migrate/migrations/2023-08-22T15:06:26_dkim.ts
@@ -4,15 +4,15 @@ import { Database } from "../../types";
 export async function up(db: Kysely<Database>): Promise<void> {
   await db.schema
     .alterTable("domains")
-    .addColumn("dkimPrivateKey", "varchar(2048)")
-    .addColumn("dkimPublicKey", "varchar(2048)")
+    .addColumn("dkim_private_key", "varchar(2048)")
+    .addColumn("dkim_public_key", "varchar(2048)")
     .execute();
 }
 
 export async function down(db: Kysely<Database>): Promise<void> {
   await db.schema
     .alterTable("domains")
-    .dropColumn("dkimPrivateKey")
-    .dropColumn("dkimPrivateKey")
+    .dropColumn("dkim_private_key")
+    .dropColumn("dkim_public_key")
     .execute();
 }

--- a/src/migrate/migrations/2023-08-31T13:50:12_mailgun.ts
+++ b/src/migrate/migrations/2023-08-31T13:50:12_mailgun.ts
@@ -6,11 +6,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .alterTable("domains")
     .addColumn("email_service", "varchar(255)")
     .addColumn("email_api_key", "varchar(255)")
-    // Fix casing
-    .addColumn("dkim_private_key", "varchar(2048)")
-    .addColumn("dkim_public_key", "varchar(2048)")
-    .dropColumn("dkimPrivateKey")
-    .dropColumn("dkimPrivateKey")
     .execute();
 }
 
@@ -19,9 +14,5 @@ export async function down(db: Kysely<Database>): Promise<void> {
     .alterTable("domains")
     .dropColumn("email_service")
     .dropColumn("email_api_key")
-    .dropColumn("dkim_private_key")
-    .dropColumn("dkim_public_key")
-    .addColumn("dkimPrivateKey", "varchar(2048)")
-    .addColumn("dkimPublicKey", "varchar(2048)")
     .execute();
 }


### PR DESCRIPTION
So, it seem the kysely handles the casing in the migration.. Tried to run the latest migration and got this error:
   "message": "target: auth2-dev.-.primary: vttablet: rpc error: code = FailedPrecondition desc = Can't DROP 'dkim_private_key'; check that column/key exists (errno 1091) (sqlstate 42000) (CallerID: 4vcjzvar8vbfzhh2ted8): Sql: \"alter table domains add column email_service varchar(255), add column email_api_key varchar(255), add column dkim_private_key varchar(2048), add column dkim_public_key varchar(2048), drop column dkim_private_key, drop column dkim_private_key\", BindVars: {REDACTED}"