### PR TITLE
feat: actually use the logo in the mjml template

### DIFF
--- a/src/email-templates/code.mjml
+++ b/src/email-templates/code.mjml
@@ -58,10 +58,10 @@
     <mj-section>
       <mj-column>
         <mj-image
-          alt={vendorName}
+          alt={{vendorName}}
           target="_blank"
           width="166px"
-          src={logo}
+          src={{logo}}
         />
       </mj-column>
     </mj-section>

--- a/src/email-templates/code.mjml
+++ b/src/email-templates/code.mjml
@@ -58,11 +58,10 @@
     <mj-section>
       <mj-column>
         <mj-image
-          alt="Sesamy"
-          href="https://sesamy.com"
+          alt={vendorName}
           target="_blank"
           width="166px"
-          src="https://assets.sesamy.dev/static/images/email/sesamy-logo.png"
+          src={logo}
         />
       </mj-column>
     </mj-section>

--- a/src/email-templates/verify-email.mjml
+++ b/src/email-templates/verify-email.mjml
@@ -59,10 +59,9 @@
       <mj-column>
         <mj-image
           alt="Sesamy"
-          href="https://sesamy.com"
           target="_blank"
           width="166px"
-          src="https://assets.sesamy.dev/static/images/email/sesamy-logo.png"
+                    src={logo}
         />
       </mj-column>
     </mj-section>

--- a/src/email-templates/verify-email.mjml
+++ b/src/email-templates/verify-email.mjml
@@ -61,7 +61,7 @@
           alt="Sesamy"
           target="_blank"
           width="166px"
-                    src={logo}
+          src={logo}
         />
       </mj-column>
     </mj-section>

--- a/src/email-templates/verify-email.mjml
+++ b/src/email-templates/verify-email.mjml
@@ -57,11 +57,11 @@
   <mj-body background-color="#F5F5F7">
     <mj-section>
       <mj-column>
-        <mj-image
-          alt="Sesamy"
+      <mj-image
+          alt={{vendorName}}
           target="_blank"
           width="166px"
-          src={logo}
+          src={{logo}}
         />
       </mj-column>
     </mj-section>

--- a/src/templates/email/code.liquid
+++ b/src/templates/email/code.liquid
@@ -181,9 +181,7 @@
                           <tbody>
                             <tr>
                               <td style="width:166px;">
-                                <a href="https://sesamy.com" target="_blank">
-                                  <img alt="Sesamy" src="https://assets.sesamy.dev/static/images/email/sesamy-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="166" height="auto" />
-                                </a>
+                                <img alt="{{vendorName}}" src="{{logo}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="166" height="auto" />
                               </td>
                             </tr>
                           </tbody>

--- a/src/templates/email/verify-email.liquid
+++ b/src/templates/email/verify-email.liquid
@@ -181,9 +181,7 @@
                           <tbody>
                             <tr>
                               <td style="width:166px;">
-                                <a href="https://sesamy.com" target="_blank">
-                                  <img alt="Sesamy" src="https://assets.sesamy.dev/static/images/email/sesamy-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="166" height="auto" />
-                                </a>
+                                <img alt="{{vendorName}}" src="{{logo}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="166" height="auto" />
                               </td>
                             </tr>
                           </tbody>


### PR DESCRIPTION
Ooops! I didn't actually use the logo in the template



I can manually test this by pushing up the templates... no luck!

*This PR does the correct task of using the `logo` variable*

I'm trying this with Breakit but it's falling back to the Sesamy logo 

![image](https://github.com/sesamyab/auth/assets/8496063/c76bc4e0-f619-407a-be74-f8a6532a9cda)



