### PR TITLE
feat: fix use client logo on email

### DIFF
--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -160,6 +160,7 @@ export function contextFixture(params?: ContextFixtureParams): Context<Env> {
         kvStorageFixture({
           clientId: JSON.stringify(client),
         }),
+      IMAGE_PROXY_URL: "https://imgproxy.dev.sesamy.cloud",
     },
   } as unknown as Context<Env>;
 }

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -37,7 +37,7 @@ interface stateInput {
   ttl?: number;
 }
 
-const client: Client = {
+export const client: Client = {
   id: "id",
   name: "clientName",
   clientSecret: "clientSecret",

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -10,7 +10,6 @@ describe("Passwordless", () => {
   });
 
   describe("start", () => {
-    // This fails as the fixtures tries to load the code.liquid from the auth-templates folder.
     it("should send a code to the user", async () => {
       const controller = new PasswordlessController();
 
@@ -52,6 +51,31 @@ describe("Passwordless", () => {
 
       expect(mailRequest.subject).toEqual(
         "Welcome to clientName! 123456 is the login code",
+      );
+
+      expect(mailRequest.from).toEqual({
+        email: "senderEmail",
+        name: "senderName",
+      });
+
+      expect(mailRequest.personalizations[0].to).toEqual([
+        {
+          email: "markus@ahlstrand.es",
+          name: "markus@ahlstrand.es",
+        },
+      ]);
+
+      expect(mailRequest.content).toHaveLength(1);
+      expect(mailRequest.content[0].type).toEqual("text/html");
+
+      const emailBody = mailRequest.content[0].value;
+
+      expect(emailBody).toContain('alt="clientName"');
+
+      // nice! notice the undefined here at least! missing env var
+      // how to assert that the image is base64 encoded correctly?  hmmmm
+      expect(emailBody).toContain(
+        'src="undefined/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw=="',
       );
     });
   });

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -98,10 +98,6 @@ describe("Passwordless", () => {
       );
     });
 
-    // TODO - need to do a similar test but assert that the correct logo is entered...
-    // how? base64 the client logo and check it appears in the body!
-    // create a new context with a new client that has Logo set
-    // base64 this and check it appears in the body
     it("should use the client logo if set", async () => {
       const controller = new PasswordlessController();
 

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -1,11 +1,7 @@
 import fetchMock from "jest-fetch-mock";
-import { contextFixture } from "../../fixtures";
+import { contextFixture, client } from "../../fixtures";
 import { PasswordlessController } from "../../../src/routes/tsoa/passwordless";
-import {
-  Client,
-  AuthorizationResponseMode,
-  AuthorizationResponseType,
-} from "../../../src/types";
+import { Client, AuthorizationResponseType } from "../../../src/types";
 import { requestWithContext } from "../../fixtures/requestWithContext";
 import { kvStorageFixture } from "../../fixtures/kv-storage";
 
@@ -131,51 +127,8 @@ describe("Passwordless", () => {
       )}`;
 
       const clientWithLogo: Client = {
-        id: "id",
-        name: "clientName",
-        clientSecret: "clientSecret",
-        tenantId: "tenantId",
-        allowedCallbackUrls: ["http://localhost:3000", "https://example.com"],
-        allowedLogoutUrls: ["http://localhost:3000", "https://example.com"],
-        allowedWebOrigins: ["http://localhost:3000", "https://example.com"],
-        emailValidation: "enabled",
-        audience: "audience",
-        tenant: {
-          senderEmail: "senderEmail",
-          senderName: "senderName",
-        },
+        ...client,
         logo,
-        connections: [
-          {
-            id: "connectionId1",
-            name: "google-oauth2",
-            clientId: "googleClientId",
-            clientSecret: "googleClientSecret",
-            authorizationEndpoint:
-              "https://accounts.google.com/o/oauth2/v2/auth",
-            tokenEndpoint: "https://oauth2.googleapis.com/token",
-            responseMode: AuthorizationResponseMode.QUERY,
-            responseType: AuthorizationResponseType.CODE,
-            scope: "openid profile email",
-            createdAt: "createdAt",
-            modifiedAt: "modifiedAt",
-          },
-          {
-            id: "connectionId2",
-            name: "facebook",
-            clientId: "facebookClientId",
-            clientSecret: "facebookClientSecret",
-            authorizationEndpoint:
-              "https://graph.facebook.com/oauth/access_token",
-            tokenEndpoint: "https://www.facebook.com/dialog/oauth",
-            responseMode: AuthorizationResponseMode.QUERY,
-            responseType: AuthorizationResponseType.CODE,
-            scope: "email public_profile",
-            createdAt: "createdAt",
-            modifiedAt: "modifiedAt",
-          },
-        ],
-        domains: [],
       };
 
       const logs: { subject: string }[] = [];

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -4,24 +4,28 @@ import { PasswordlessController } from "../../../src/routes/tsoa/passwordless";
 import { AuthorizationResponseType } from "../../../src/types";
 import { requestWithContext } from "../../fixtures/requestWithContext";
 
-// TODO - assemble this manually
-const SESAMY_FOOTER_LOGO_URL =
-  "https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D";
-
-const SESAMY_HEADER_LOGO =
+const SESAMY_LOGO =
   "https://assets.sesamy.com/static/images/sesamy/logo-translucent.png";
-const SESAMY_HEADER_LOGO_IMG_PROXY = `https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/${btoa(
-  SESAMY_HEADER_LOGO,
+
+// looks the same to me! hmmmm. why fetch same asset twice
+const SESAMY_FOOTER_LOGO =
+  "https://assets.sesamy.dev/static/images/email/sesamy-logo-translucent.png";
+
+const SESAMY_FOOTER_LOGO_URL = `https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:225/${btoa(
+  SESAMY_FOOTER_LOGO,
+).replace(/=/g, "&#x3D;")}`; // footer logo is html encoded....
+
+const SESAMY_HEADER_LOGO_URL = `https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/${btoa(
+  SESAMY_LOGO,
 )}`;
-// https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw==
 
 describe("Passwordless", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
   });
 
-  describe("start", () => {
-    it.only("should send a code to the user", async () => {
+  describe(".start() should send a code to the user", () => {
+    it("should use the fallback sesamy logo if client does not have a logo set", async () => {
       const controller = new PasswordlessController();
 
       fetchMock.mockResponse(
@@ -85,7 +89,7 @@ describe("Passwordless", () => {
       expect(emailBody).toContain('alt="clientName"');
 
       // assert - default sesamy fallback logo is used because no logo is set for this client
-      expect(emailBody).toContain(`src="${SESAMY_HEADER_LOGO_IMG_PROXY}"`);
+      expect(emailBody).toContain(`src="${SESAMY_HEADER_LOGO_URL}"`);
 
       expect(emailBody).toContain(SESAMY_FOOTER_LOGO_URL);
 
@@ -101,5 +105,6 @@ describe("Passwordless", () => {
     // how? base64 the client logo and check it appears in the body!
     // create a new context with a new client that has Logo set
     // base64 this and check it appears in the body
+    it("should use the client logo if set", async () => {});
   });
 });

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -13,13 +13,13 @@ describe("Passwordless", () => {
   });
 
   describe("start", () => {
-    it("should send a code to the user", async () => {
+    it.only("should send a code to the user", async () => {
       const controller = new PasswordlessController();
 
       fetchMock.mockResponse(
         JSON.stringify({ message: "Queued. Thank you." }),
         {
-          status: 200, // or whatever status you expect for success
+          status: 200,
           headers: { "content-type": "application/json" },
         },
       );
@@ -76,17 +76,10 @@ describe("Passwordless", () => {
       // this is fetching the vendor name
       expect(emailBody).toContain('alt="clientName"');
 
-      // nice! notice the undefined here at least! missing env var
-      // how to assert that the image is base64 encoded correctly?  hmmmm
+      // assert - default sesamy fallback logo is used because no logo is set for this client
       expect(emailBody).toContain(
-        'src="undefined/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw=="',
+        'src="https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw=="',
       );
-
-      // console.log(emailBody)
-
-      // wait why is this here eh?
-      // we must have just hardcoded this... hmmmm. maybe don't need as env var
-      // https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D
 
       expect(emailBody).toContain(SESAMY_FOOTER_LOGO_URL);
 
@@ -100,5 +93,7 @@ describe("Passwordless", () => {
 
     // TODO - need to do a similar test but assert that the correct logo is entered...
     // how? base64 the client logo and check it appears in the body!
+    // create a new context with a new client that has Logo set
+    // base64 this and check it appears in the body
   });
 });

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -4,6 +4,9 @@ import { PasswordlessController } from "../../../src/routes/tsoa/passwordless";
 import { AuthorizationResponseType } from "../../../src/types";
 import { requestWithContext } from "../../fixtures/requestWithContext";
 
+const SESAMY_FOOTER_LOGO_URL =
+  "https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D";
+
 describe("Passwordless", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
@@ -70,6 +73,7 @@ describe("Passwordless", () => {
 
       const emailBody = mailRequest.content[0].value;
 
+      // this is fetching the vendor name
       expect(emailBody).toContain('alt="clientName"');
 
       // nice! notice the undefined here at least! missing env var
@@ -77,6 +81,24 @@ describe("Passwordless", () => {
       expect(emailBody).toContain(
         'src="undefined/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw=="',
       );
+
+      // console.log(emailBody)
+
+      // wait why is this here eh?
+      // we must have just hardcoded this... hmmmm. maybe don't need as env var
+      // https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D
+
+      expect(emailBody).toContain(SESAMY_FOOTER_LOGO_URL);
+
+      expect(emailBody).toContain("123456");
+
+      expect(emailBody).toContain("Välkommen till ditt clientName-konto!");
+      expect(emailBody).toContain(
+        "Skriv in koden i clientName för att slutföra inloggningen.",
+      );
     });
+
+    // TODO - need to do a similar test but assert that the correct logo is entered...
+    // how? base64 the client logo and check it appears in the body!
   });
 });

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -4,8 +4,16 @@ import { PasswordlessController } from "../../../src/routes/tsoa/passwordless";
 import { AuthorizationResponseType } from "../../../src/types";
 import { requestWithContext } from "../../fixtures/requestWithContext";
 
+// TODO - assemble this manually
 const SESAMY_FOOTER_LOGO_URL =
   "https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D";
+
+const SESAMY_HEADER_LOGO =
+  "https://assets.sesamy.com/static/images/sesamy/logo-translucent.png";
+const SESAMY_HEADER_LOGO_IMG_PROXY = `https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/${btoa(
+  SESAMY_HEADER_LOGO,
+)}`;
+// https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw==
 
 describe("Passwordless", () => {
   beforeEach(() => {
@@ -77,9 +85,7 @@ describe("Passwordless", () => {
       expect(emailBody).toContain('alt="clientName"');
 
       // assert - default sesamy fallback logo is used because no logo is set for this client
-      expect(emailBody).toContain(
-        'src="https://imgproxy.dev.sesamy.cloud/unsafe/format:png/rs:fill:166/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmNvbS9zdGF0aWMvaW1hZ2VzL3Nlc2FteS9sb2dvLXRyYW5zbHVjZW50LnBuZw=="',
-      );
+      expect(emailBody).toContain(`src="${SESAMY_HEADER_LOGO_IMG_PROXY}"`);
 
       expect(emailBody).toContain(SESAMY_FOOTER_LOGO_URL);
 


### PR DESCRIPTION
This tests and asserts existing functionality and shows that we're applying the correct client logo *EXCEPT* of course in reality this isn't happening :smile: 

*why?* because the logo is inside the `tenant` key of the `client`, not at the top level! :smile: 


_what I will do_ is fix these types on the next PR, and then the tests, and then it should _just_ work :smile: 