### PR TITLE
fix: audience is sent as part of client credential

### DIFF
--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -40,6 +40,7 @@ export interface ClientCredentialGrantTypeParams {
   scope: string;
   client_secret: string;
   client_id: string;
+  audience?: string;
 }
 
 export interface PasswordlessGrantTypeParams {


### PR DESCRIPTION
this fixes the types used for TSOA :smile: 

*BUT* it still doesn't work of course, we'll just get a meaningful error back :sunglasses: 