### PR TITLE
feat: clone existing user route but for api/v2

### DIFF
--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -11,16 +11,6 @@ import { Profile } from "../../types";
 // TODO - need security!
 // @Security("oauth2managementApi", [""])
 export class UsersMgmtController extends Controller {
-  @Get("")
-  public async helloHello(
-    @Request() request: RequestWithContext,
-  ): Promise<string> {
-    console.log("in helloHello");
-
-    // nice! this route works
-    return "hello hello";
-  }
-
   @Get("{userId}")
   public async getUser(
     @Request() request: RequestWithContext,

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -16,49 +16,26 @@ export class UsersMgmtController extends Controller {
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
   ): Promise<Profile> {
-    // not actually hitting this! is already 404ing... not getting any log
-    console.log("in getUser");
     const { ctx } = request;
     const { env } = ctx;
 
     const db = getDb(env);
     const dbUser = await db
       .selectFrom("users")
-      // we do not get sent a tenant id
-      // .where("users.tenantId", "=", tenantId)
       .where("users.id", "=", userId)
-      .select("users.email")
+      .selectAll()
       .executeTakeFirst();
 
     if (!dbUser) {
-      console.log("no dbUser");
       throw new NotFoundError();
     }
 
-    // I can find the user by querying the planetscale database
-    // but I need to suffix breakit id for durable object?
-    const tenantId = "JTnV3E4M59SpxiIhhXf6s";
-
-    console.log("dbUser", dbUser);
-    // Fetch the user from durable object
     const user = env.userFactory.getInstanceByName(
-      getId(tenantId, dbUser.email),
-      // userId,
+      getId(dbUser.tenantId, dbUser.email),
     );
-
-    // Invalid Durable Object ID. Durable Object IDs must be 64 hex digits.
-    // const user = env.userFactory.getInstanceById(userId);
-
-    console.log("user", user);
 
     const userResult = user.getProfile.query();
 
-    console.log("userResult", userResult);
-
     return userResult;
-
-    // return "success";
-
-    // return dbUser.email;
   }
 }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -1,0 +1,42 @@
+// not sure what to call this, or where to place it! 8-)
+import { Controller, Get, Request, Route, Tags, Path } from "@tsoa/runtime";
+import { getDb } from "../../services/db";
+import { RequestWithContext } from "../../types/RequestWithContext";
+import { NotFoundError } from "../../errors";
+import { getId } from "../../models";
+import { Profile } from "../../types";
+
+@Route("api/v2/users")
+// @Security("oauth2managementApi", [""])
+@Tags("users-mgmt") // what is tags?
+export class UsersController extends Controller {
+  @Get("")
+  @Get("{userId}")
+  public async getUser(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Path("userId") userId: string,
+  ): Promise<Profile> {
+    const { ctx } = request;
+    const { env } = ctx;
+
+    const db = getDb(env);
+    const dbUser = await db
+      .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
+      .where("users.id", "=", userId)
+      .select("users.email")
+      .executeTakeFirst();
+
+    if (!dbUser) {
+      throw new NotFoundError();
+    }
+
+    // Fetch the user from durable object
+    const user = env.userFactory.getInstanceByName(
+      getId(tenantId, dbUser.email),
+    );
+
+    return user.getProfile.query();
+  }
+}

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -7,7 +7,6 @@ import { getId } from "../../models";
 import { Profile } from "../../types";
 
 @Route("api/v2/users")
-// @Security("oauth2managementApi", [""])
 @Tags("users-mgmt") // what is tags?
 export class UsersMgmtController extends Controller {
   @Get("")
@@ -15,6 +14,8 @@ export class UsersMgmtController extends Controller {
     @Request() request: RequestWithContext,
   ): Promise<string> {
     console.log("in helloHello");
+
+    // nice! this route works
     return "hello hello";
   }
 
@@ -22,7 +23,6 @@ export class UsersMgmtController extends Controller {
   public async getUser(
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
-    // ): Promise<Profile> {
   ): Promise<string> {
     // not actually hitting this! is already 404ing... not getting any log
     console.log("in getUser");
@@ -49,6 +49,8 @@ export class UsersMgmtController extends Controller {
 
     // return user.getProfile.query();
 
-    return "success";
+    // return "success";
+
+    return dbUser.email;
   }
 }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -46,7 +46,8 @@ export class UsersMgmtController extends Controller {
     }
 
     // I can find the user by querying the planetscale database
-    const tenantId = "breakit";
+    // but I need to suffix breakit id for durable object?
+    const tenantId = "JTnV3E4M59SpxiIhhXf6s";
 
     console.log("dbUser", dbUser);
     // Fetch the user from durable object

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -9,13 +9,23 @@ import { Profile } from "../../types";
 @Route("api/v2/users")
 // @Security("oauth2managementApi", [""])
 @Tags("users-mgmt") // what is tags?
-export class UsersController extends Controller {
+export class UsersMgmtController extends Controller {
+  @Get("")
+  public async helloHello(
+    @Request() request: RequestWithContext,
+  ): Promise<string> {
+    console.log("in helloHello");
+    return "hello hello";
+  }
+
   @Get("{userId}")
   public async getUser(
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
     // ): Promise<Profile> {
   ): Promise<string> {
+    // not actually hitting this! is already 404ing... not getting any log
+    console.log("in getUser");
     const { ctx } = request;
     const { env } = ctx;
 

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -10,20 +10,20 @@ import { Profile } from "../../types";
 // @Security("oauth2managementApi", [""])
 @Tags("users-mgmt") // what is tags?
 export class UsersController extends Controller {
-  @Get("")
   @Get("{userId}")
   public async getUser(
     @Request() request: RequestWithContext,
-    @Path("tenantId") tenantId: string,
     @Path("userId") userId: string,
-  ): Promise<Profile> {
+    // ): Promise<Profile> {
+  ): Promise<string> {
     const { ctx } = request;
     const { env } = ctx;
 
     const db = getDb(env);
     const dbUser = await db
       .selectFrom("users")
-      .where("users.tenantId", "=", tenantId)
+      // we do not get sent a tenant id
+      // .where("users.tenantId", "=", tenantId)
       .where("users.id", "=", userId)
       .select("users.email")
       .executeTakeFirst();
@@ -33,10 +33,12 @@ export class UsersController extends Controller {
     }
 
     // Fetch the user from durable object
-    const user = env.userFactory.getInstanceByName(
-      getId(tenantId, dbUser.email),
-    );
+    // const user = env.userFactory.getInstanceByName(
+    //   getId(tenantId, dbUser.email),
+    // );
 
-    return user.getProfile.query();
+    // return user.getProfile.query();
+
+    return "success";
   }
 }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -8,6 +8,8 @@ import { Profile } from "../../types";
 
 @Route("api/v2/users")
 @Tags("users-mgmt") // what is tags?
+// TODO - need security!
+// @Security("oauth2managementApi", [""])
 export class UsersMgmtController extends Controller {
   @Get("")
   public async helloHello(
@@ -23,7 +25,7 @@ export class UsersMgmtController extends Controller {
   public async getUser(
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
-  ): Promise<string> {
+  ): Promise<Profile> {
     // not actually hitting this! is already 404ing... not getting any log
     console.log("in getUser");
     const { ctx } = request;
@@ -39,18 +41,33 @@ export class UsersMgmtController extends Controller {
       .executeTakeFirst();
 
     if (!dbUser) {
+      console.log("no dbUser");
       throw new NotFoundError();
     }
 
-    // Fetch the user from durable object
-    // const user = env.userFactory.getInstanceByName(
-    //   getId(tenantId, dbUser.email),
-    // );
+    // I can find the user by querying the planetscale database
+    const tenantId = "breakit";
 
-    // return user.getProfile.query();
+    console.log("dbUser", dbUser);
+    // Fetch the user from durable object
+    const user = env.userFactory.getInstanceByName(
+      getId(tenantId, dbUser.email),
+      // userId,
+    );
+
+    // Invalid Durable Object ID. Durable Object IDs must be 64 hex digits.
+    // const user = env.userFactory.getInstanceById(userId);
+
+    console.log("user", user);
+
+    const userResult = user.getProfile.query();
+
+    console.log("userResult", userResult);
+
+    return userResult;
 
     // return "success";
 
-    return dbUser.email;
+    // return dbUser.email;
   }
 }


### PR DESCRIPTION
See linked ticket! :smile: 

This is currently pushed up to dev e.g. https://auth2.sesamy.dev/api/v2/users/55yGva-RrwP4GdlhExiDQ


@markusahlstrand you can see this working here https://github.com/sesamyab/auth0-management-api-demo/blob/master/run-auth2.mjs
pull the repo down. it's just ES modules :smile:   I just type `node run-auth2.mjs` into my console :exploding_head: 

![image](https://github.com/sesamyab/auth/assets/8496063/8f443389-535e-4c3c-bc47-7eeee154cac2)

how cool is that