### PR TITLE
feat: tag route as management-api

### DIFF
--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -19,7 +19,7 @@ import { Profile } from "../../types";
 import { User } from "../../types/sql/User";
 
 @Route("api/v2")
-@Tags("users-mgmt") // what is tags?
+@Tags("management-api")
 // TODO - need security!
 // @Security("oauth2managementApi", [""])
 export class UsersMgmtController extends Controller {


### PR DESCRIPTION
As discussed, for now all the new management API routes can appear under the same label on the docs