### PR TITLE
feat: require tenant-id header in management API routes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const headers = {
   contentRange: "content-range",
   location: "location",
   setCookie: "set-cookie",
+  tenantId: "tenant-id",
 };
 
 export const contentTypes = {

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -19,9 +19,17 @@ export class UsersMgmtController extends Controller {
     const { ctx } = request;
     const { env } = ctx;
 
+    // get tenantId from header tenant-id
+    const tenantId = request.headers["tenant-id"];
+    // headers is of type any! 8-0  - can I fix this?
+    // should be string | string[] | undefined - like Nextjs
+
+    if (!tenantId) throw new Error("tenant-id header is required");
+
     const db = getDb(env);
     const dbUser = await db
       .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
       .where("users.id", "=", userId)
       .selectAll()
       .executeTakeFirst();
@@ -31,7 +39,7 @@ export class UsersMgmtController extends Controller {
     }
 
     const user = env.userFactory.getInstanceByName(
-      getId(dbUser.tenantId, dbUser.email),
+      getId(tenantId, dbUser.email),
     );
 
     const userResult = user.getProfile.query();

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -19,10 +19,7 @@ export class UsersMgmtController extends Controller {
     const { ctx } = request;
     const { env } = ctx;
 
-    // get tenantId from header tenant-id
     const tenantId = request.headers["tenant-id"];
-    // headers is of type any! 8-0  - can I fix this?
-    // should be string | string[] | undefined - like Nextjs
 
     if (!tenantId) throw new Error("tenant-id header is required");
 

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -1,5 +1,13 @@
 // not sure what to call this, or where to place it! 8-)
-import { Controller, Get, Request, Route, Tags, Path } from "@tsoa/runtime";
+import {
+  Controller,
+  Get,
+  Request,
+  Route,
+  Tags,
+  Path,
+  Header,
+} from "@tsoa/runtime";
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
 import { NotFoundError } from "../../errors";
@@ -15,13 +23,10 @@ export class UsersMgmtController extends Controller {
   public async getUser(
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
+    @Header("tenant-id") tenantId: string,
   ): Promise<Profile> {
     const { ctx } = request;
     const { env } = ctx;
-
-    const tenantId = request.headers["tenant-id"];
-
-    if (!tenantId) throw new Error("tenant-id header is required");
 
     const db = getDb(env);
     const dbUser = await db


### PR DESCRIPTION
As discussed, this seems like the best way to support having multiple tenants under one Auth domain