### PR TITLE
fix: user model - storage is under state key not env

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -294,7 +294,7 @@ export const userRouter = router({
       return profile;
     }),
   delete: publicProcedure.mutation(async ({ ctx }) => {
-    const profile = await getProfile(ctx.env.storage);
+    const profile = await getProfile(ctx.state.storage);
 
     if (!profile?.tenantId) {
       throw new NotFoundError();

--- a/test/models/User.spec.ts
+++ b/test/models/User.spec.ts
@@ -321,6 +321,41 @@ describe("User", () => {
     });
   });
 
+  describe("delete profile", () => {
+    it("should delete an existing user", async () => {
+      let profile: any = {};
+
+      const caller = createCaller({
+        get: async (key: string) => {
+          switch (key) {
+            case "profile":
+              return JSON.stringify({
+                id: "id",
+                name: "Test",
+                email: "test@example.com",
+                tenantId: "tenantId",
+                created_at: "2021-01-01T00:00:00.000Z",
+                modified_at: "2021-01-01T00:00:00.000Z",
+                connections: [],
+              });
+          }
+        },
+        put: async (key: string, value: string) => {
+          switch (key) {
+            case "profile":
+              profile = JSON.parse(value);
+          }
+          return;
+        },
+        delete: async () => {},
+      });
+
+      await caller.delete();
+
+      // what is even happening here? looks like I'm testing a mock
+    });
+  });
+
   describe("validate authentication code", () => {
     it("should throw a NoCodeError if a user tries to validate a code but no code is stored", async () => {
       const caller = createCaller({


### PR DESCRIPTION
This should fix the issue I'm having with the delete users route :crossed_fingers: 