### PR TITLE
fix: delete user

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,10 @@
 export class NotFoundError extends Error {
+  constructor(message = "Not Found") {
+    super();
+
+    this.message = message;
+  }
+
   status = 404;
 }
 

--- a/src/handlers/update-user.ts
+++ b/src/handlers/update-user.ts
@@ -7,32 +7,24 @@ export async function handleUserEvent(
   env: Env,
   tenantId: string,
   email: string,
+  userId: string,
   event: UserEvent,
 ) {
   switch (event) {
     case UserEvent.userDeleted:
-      return deleteUser(env, tenantId, email);
+      return deleteUser(env, tenantId, userId);
     default:
       return updateUser(env, tenantId, email);
   }
 }
 
-async function deleteUser(env: Env, tenantId: string, email: string) {
-  const userId = getId(tenantId, email);
-  const userInstance = User.getInstanceByName(env.USER, userId);
-  const profile = await userInstance.getProfile.query();
-
-  if (!profile || !profile.email) {
-    console.log("No profile found for user", userId);
-    return;
-  }
-
+async function deleteUser(env: Env, tenantId: string, userId: string) {
   const db = getDb(env);
 
   await db
     .deleteFrom("users")
     .where("tenantId", "=", tenantId)
-    .where("email", "=", email)
+    .where("id", "=", userId)
     .execute();
 }
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -189,6 +189,7 @@ async function updateProfile(
   await sendUserEvent(
     ctx.env,
     `${profile.tenantId}|${profile.email}`,
+    updatedProfile.id,
     existingProfile ? UserEvent.userUpdated : UserEvent.userCreated,
   );
 
@@ -305,6 +306,7 @@ export const userRouter = router({
     await sendUserEvent(
       ctx.env,
       `${profile.tenantId}|${profile.email}`,
+      profile.id,
       UserEvent.userDeleted,
     );
   }),

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -12,24 +12,31 @@ export enum UserEvent {
 export interface UserMessage {
   queueName: "users";
   email: string;
+  userId: string;
   event: UserEvent;
 }
 
 export type QueueMessage = { tenantId: string } & UserMessage;
 
-export async function sendUserEvent(env: Env, doId: string, event: UserEvent) {
+export async function sendUserEvent(
+  env: Env,
+  doId: string,
+  userId: string,
+  event: UserEvent,
+) {
   const [tenantId, email] = doId.split("|");
 
   if (env.USERS_QUEUE) {
     const message: QueueMessage = {
       email,
       tenantId,
+      userId,
       queueName: "users",
       event,
     };
 
     await env.USERS_QUEUE.send(message);
   } else {
-    await handleUserEvent(env, tenantId, email, event);
+    await handleUserEvent(env, tenantId, email, userId, event);
   }
 }


### PR DESCRIPTION
An interesting situation where the DO was cleared first before triggering the delete event to sql. Changed so we're passing the userId back so we don't need to query the DO for the id.
Added a fallback so that we can delete any users out of sync which should never happen.. 