### PR TITLE
fix: audience optional on client schema

### DIFF
--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -64,7 +64,7 @@ export const BaseClientSchema = z.object({
   tenantId: z.string(),
   clientSecret: z.string(),
   tenant: z.object({
-    audience: z.string(),
+    audience: z.string().optional(),
     logo: z.string().optional(),
     primaryColor: z.string().optional(),
     secondaryColor: z.string().optional(),


### PR DESCRIPTION
This fixes https://auth2.sesamy.dev/oauth/token so we don't get a `zod` type error

I don't know if we want to allow this or force `DEFAULT_SETTINGS` and the client settings to have this field 

Does `DEFAULT_SETTINGS` need updating? (it's encrypted of course so we'd have to recreate it)