### PR TITLE
feat: react-admin read user management API endpoints

### DIFF
--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -20,6 +20,9 @@ export default async function corsMiddleware<Env>(
     "Content-Type, Auth0-Client, Authorization, Range, tenant-id",
   );
   response?.headers.set(headers.accessControlExposeHeaders, "Content-Range");
-
+  response?.headers.set(
+    headers.accessControlAllowMethod,
+    "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+  );
   return response;
 }

--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -17,11 +17,7 @@ export default async function corsMiddleware<Env>(
   response?.headers.set(headers.accessControlAllowCredentials, "true");
   response?.headers.set(
     headers.accessControlAllowHeaders,
-    "Content-Type, Auth0-Client, Authorization, Range",
-  );
-  response?.headers.set(
-    headers.accessControlAllowHeaders,
-    "Content-Type, Auth0-Client, Authorization, Range",
+    "Content-Type, Auth0-Client, Authorization, Range, tenant-id",
   );
   response?.headers.set(headers.accessControlExposeHeaders, "Content-Range");
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -295,25 +295,13 @@ export const userRouter = router({
       return profile;
     }),
   delete: publicProcedure.mutation(async ({ ctx }) => {
-    console.log("delete user mutation called ok");
     const profile = await getProfile(ctx.state.storage);
 
-    console.log("profile returned ok - ", profile);
-
     if (!profile?.tenantId) {
-      console.log("no tenant id found");
       throw new NotFoundError();
     }
 
-    console.log("tenant id found ok - ", profile.tenantId);
-
-    console.log("trying to delete all");
-
     await ctx.state.storage.deleteAll();
-
-    console.log("all deleted ok");
-
-    console.log("sending user event next");
 
     await sendUserEvent(
       ctx.env,
@@ -321,8 +309,6 @@ export const userRouter = router({
       profile.id,
       UserEvent.userDeleted,
     );
-
-    console.log("user event sent ok");
   }),
   getLogs: publicProcedure.query(async ({ ctx }) => getLogs(ctx.state.storage)),
   getProfile: publicProcedure.query(async ({ ctx }) => {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -295,13 +295,25 @@ export const userRouter = router({
       return profile;
     }),
   delete: publicProcedure.mutation(async ({ ctx }) => {
+    console.log("delete user mutation called ok");
     const profile = await getProfile(ctx.state.storage);
 
+    console.log("profile returned ok - ", profile);
+
     if (!profile?.tenantId) {
+      console.log("no tenant id found");
       throw new NotFoundError();
     }
 
+    console.log("tenant id found ok - ", profile.tenantId);
+
+    console.log("trying to delete all");
+
     await ctx.state.storage.deleteAll();
+
+    console.log("all deleted ok");
+
+    console.log("sending user event next");
 
     await sendUserEvent(
       ctx.env,
@@ -309,6 +321,8 @@ export const userRouter = router({
       profile.id,
       UserEvent.userDeleted,
     );
+
+    console.log("user event sent ok");
   }),
   getLogs: publicProcedure.query(async ({ ctx }) => getLogs(ctx.state.storage)),
   getProfile: publicProcedure.query(async ({ ctx }) => {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,7 +4,7 @@ import { initTRPC } from "@trpc/server";
 import { z, ZodSchema } from "zod";
 import { Context } from "trpc-durable-objects";
 import { nanoid } from "nanoid";
-
+import { ContextWithBody } from "cloudworker-router";
 import generateOTP from "../utils/otp";
 import {
   UnauthenticatedError,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,7 +4,7 @@ import { initTRPC } from "@trpc/server";
 import { z, ZodSchema } from "zod";
 import { Context } from "trpc-durable-objects";
 import { nanoid } from "nanoid";
-import { ContextWithBody } from "cloudworker-router";
+
 import generateOTP from "../utils/otp";
 import {
   UnauthenticatedError,

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -18,6 +18,7 @@ import { NotFoundError } from "../../errors";
 import { getId } from "../../models";
 import { Profile } from "../../types";
 import { User } from "../../types/sql/User";
+import { headers } from "../../constants";
 
 @Route("api/v2")
 @Tags("management-api")
@@ -61,6 +62,9 @@ export class UsersMgmtController extends Controller {
     //   ...user,
     //   tags: JSON.parse(user.tags || "[]"),
     // }));
+
+    // this is to stop react-admin complaining
+    this.setHeader(headers.contentRange, "users=0-9/1362");
 
     const dbUsersList = await db
       .selectFrom("users")

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -217,8 +217,8 @@ export class UsersMgmtController extends Controller {
     @Request() request: RequestWithContext,
     @Header("tenant-id") tenantId: string,
     @Body()
-    user: Omit<User, "tenantId" | "createdAt" | "modifiedAt" | "id"> &
-      Partial<Pick<User, "createdAt" | "modifiedAt" | "id">>,
+    user: Omit<User, "tenantId" | "createdAt" | "modifiedAt"> &
+      Partial<Pick<User, "createdAt" | "modifiedAt">>,
   ): Promise<Profile> {
     const { ctx } = request;
 
@@ -226,7 +226,9 @@ export class UsersMgmtController extends Controller {
       getId(tenantId, user.email),
     );
 
-    const result: Profile = await userInstance.createUser.mutate({
+    // I'm assuming that patchProfile isn't actually tested...
+    // is it even what we want here? let's see...
+    const result: Profile = await userInstance.patchProfile.mutate({
       ...user,
       tenantId,
     });

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -28,7 +28,7 @@ export class UsersMgmtController extends Controller {
   @Get("users")
   public async listUsers(
     @Request() request: RequestWithContext,
-    @Path("tenantId") tenantId: string,
+    @Header("tenant-id") tenantId: string,
     @Header("range") rangeRequest?: string,
     @Query("filter") filterQuerystring?: string,
   ): Promise<User[]> {

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -11,6 +11,7 @@ import {
   SuccessResponse,
   Body,
   Delete,
+  Put,
 } from "@tsoa/runtime";
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
@@ -209,5 +210,26 @@ export class UsersMgmtController extends Controller {
       connections: [],
       tenantId,
     });
+  }
+
+  @Put("users")
+  public async putUser(
+    @Request() request: RequestWithContext,
+    @Header("tenant-id") tenantId: string,
+    @Body()
+    user: Omit<User, "tenantId" | "createdAt" | "modifiedAt" | "id"> &
+      Partial<Pick<User, "createdAt" | "modifiedAt" | "id">>,
+  ): Promise<Profile> {
+    const { ctx } = request;
+
+    const userInstance = ctx.env.userFactory.getInstanceByName(
+      getId(tenantId, user.email),
+    );
+
+    const result: Profile = await userInstance.createUser.mutate({
+      ...user,
+      tenantId,
+    });
+    return result;
   }
 }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -80,13 +80,12 @@ export class UsersMgmtController extends Controller {
   }
 
   @Delete("users/{userId}")
-  @SuccessResponse(201, "Delete")
+  @SuccessResponse(200, "Delete")
   public async deleteUser(
     @Request() request: RequestWithContext,
     @Path("userId") userId: string,
     @Header("tenant-id") tenantId: string,
   ): Promise<Profile> {
-    console.log("deleteUser", userId, tenantId);
     const { ctx } = request;
     const { env } = ctx;
 
@@ -98,19 +97,13 @@ export class UsersMgmtController extends Controller {
       .select("users.email")
       .executeTakeFirst();
 
-    console.log("dbUser", dbUser);
-
     if (!dbUser) {
       throw new NotFoundError();
     }
 
-    console.log("dbUser.email", dbUser.email);
-
     const user = env.userFactory.getInstanceByName(
       getId(tenantId, dbUser.email),
     );
-
-    console.log("user", user);
 
     return user.delete.mutate();
   }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -79,6 +79,35 @@ export class UsersMgmtController extends Controller {
     return user.delete.mutate();
   }
 
+  @Delete("users/{userId}")
+  @SuccessResponse(201, "Delete")
+  public async deleteUser(
+    @Request() request: RequestWithContext,
+    @Path("userId") userId: string,
+    @Header("tenant-id") tenantId: string,
+  ): Promise<Profile> {
+    const { ctx } = request;
+    const { env } = ctx;
+
+    const db = getDb(env);
+    const dbUser = await db
+      .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
+      .where("users.id", "=", userId)
+      .select("users.email")
+      .executeTakeFirst();
+
+    if (!dbUser) {
+      throw new NotFoundError();
+    }
+
+    const user = env.userFactory.getInstanceByName(
+      getId(tenantId, dbUser.email),
+    );
+
+    return user.delete.mutate();
+  }
+
   @Get("users-by-email")
   public async getUserByEmail(
     @Request() request: RequestWithContext,

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -86,6 +86,7 @@ export class UsersMgmtController extends Controller {
     @Path("userId") userId: string,
     @Header("tenant-id") tenantId: string,
   ): Promise<Profile> {
+    console.log("deleteUser", userId, tenantId);
     const { ctx } = request;
     const { env } = ctx;
 
@@ -97,13 +98,19 @@ export class UsersMgmtController extends Controller {
       .select("users.email")
       .executeTakeFirst();
 
+    console.log("dbUser", dbUser);
+
     if (!dbUser) {
       throw new NotFoundError();
     }
 
+    console.log("dbUser.email", dbUser.email);
+
     const user = env.userFactory.getInstanceByName(
       getId(tenantId, dbUser.email),
     );
+
+    console.log("user", user);
 
     return user.delete.mutate();
   }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -24,6 +24,56 @@ import { User } from "../../types/sql/User";
 // TODO - need security!
 // @Security("oauth2managementApi", [""])
 export class UsersMgmtController extends Controller {
+  @Get("users")
+  public async listUsers(
+    @Request() request: RequestWithContext,
+    @Path("tenantId") tenantId: string,
+    @Header("range") rangeRequest?: string,
+    @Query("filter") filterQuerystring?: string,
+  ): Promise<User[]> {
+    const { ctx } = request;
+
+    const db = getDb(ctx.env);
+
+    let query = db.selectFrom("users").where("users.tenantId", "=", tenantId);
+
+    // TODO - implement this?
+    // if (filterQuerystring) {
+    //   const filter = FilterSchema.parse(JSON.parse(filterQuerystring));
+
+    //   if (filter.q) {
+    //     query = query.where((eb) =>
+    //       eb.or([
+    //         eb("name", "like", `%${filter.q}%`),
+    //         eb("email", "like", `%${filter.q}%`),
+    //       ]),
+    //     );
+    //   }
+    // }
+
+    // const { data, range } = await executeQuery(query, rangeRequest);
+
+    // if (range) {
+    //   this.setHeader(headers.contentRange, range);
+    // }
+
+    // return data.map((user) => ({
+    //   ...user,
+    //   tags: JSON.parse(user.tags || "[]"),
+    // }));
+
+    const dbUsersList = await db
+      .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
+      .selectAll()
+      .execute();
+
+    return dbUsersList.map((user) => ({
+      ...user,
+      tags: JSON.parse(user.tags || "[]"),
+    }));
+  }
+
   @Get("users/{userId}")
   public async getUser(
     @Request() request: RequestWithContext,

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -134,35 +134,6 @@ export class UsersMgmtController extends Controller {
     return user.delete.mutate();
   }
 
-  @Delete("users/{userId}")
-  @SuccessResponse(200, "Delete")
-  public async deleteUser(
-    @Request() request: RequestWithContext,
-    @Path("userId") userId: string,
-    @Header("tenant-id") tenantId: string,
-  ): Promise<Profile> {
-    const { ctx } = request;
-    const { env } = ctx;
-
-    const db = getDb(env);
-    const dbUser = await db
-      .selectFrom("users")
-      .where("users.tenantId", "=", tenantId)
-      .where("users.id", "=", userId)
-      .select("users.email")
-      .executeTakeFirst();
-
-    if (!dbUser) {
-      throw new NotFoundError();
-    }
-
-    const user = env.userFactory.getInstanceByName(
-      getId(tenantId, dbUser.email),
-    );
-
-    return user.delete.mutate();
-  }
-
   @Get("users-by-email")
   public async getUserByEmail(
     @Request() request: RequestWithContext,

--- a/src/types/sql/User.ts
+++ b/src/types/sql/User.ts
@@ -52,9 +52,9 @@ export interface BaseUser {
 }
 
 export interface User extends BaseUser {
-  tags: UserTag[];
+  tags?: UserTag[];
 }
 
 export interface SqlUser extends BaseUser {
-  tags: string;
+  tags?: string;
 }


### PR DESCRIPTION
Quite a few changes are needed if we're going to use the management API endpoints to control the users in auth-admin

*BUT* The existing user pages do not work, so I suppose we need some way to edit users, and this isn't time wasted :thinking: 