### PR TITLE
feat: add linked user connection

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -113,7 +113,7 @@ export class NoCodeError extends Error {
 export class NoUserFoundError extends Error {
   status = 404;
 
-  constructor(message = "No user found") {
+  constructor(message = "No User Found") {
     super();
 
     this.message = message;

--- a/src/hooks/migrate-password.ts
+++ b/src/hooks/migrate-password.ts
@@ -116,28 +116,33 @@ export async function migratePasswordHook(
 
   console.log("Start migration");
 
-  const migrations = await db
-    .selectFrom("migrations")
-    .where("migrations.tenantId", "=", tenantId)
-    .selectAll()
-    .execute();
+  try {
+    const migrations = await db
+      .selectFrom("migrations")
+      .where("migrations.tenantId", "=", tenantId)
+      .selectAll()
+      .execute();
 
-  for (const migration of migrations) {
-    let profile;
+    for (const migration of migrations) {
+      let profile;
 
-    switch (migration.provider) {
-      case "auth0":
-        profile = await auth0login(migration, username, password);
-        break;
-      case "connectId":
-        profile = await connectIdLogin(migration, username, password);
-        break;
+      switch (migration.provider) {
+        case "auth0":
+          profile = await auth0login(migration, username, password);
+          break;
+        case "connectId":
+          profile = await connectIdLogin(migration, username, password);
+          break;
+      }
+
+      if (profile) {
+        return profile;
+      }
     }
 
-    if (profile) {
-      return profile;
-    }
+    return false;
+  } catch (err) {
+    console.log("Failed to fetch migrations");
+    return false;
   }
-
-  return false;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -319,6 +319,40 @@ export const userRouter = router({
 
     return profile;
   }),
+  linkWithUser: publicProcedure
+    .input(
+      z.object({
+        email: z.string(),
+        linkWithEmail: z.string(),
+        tenantId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const existingProfile = await getProfile(ctx.state.storage);
+      if (!existingProfile) {
+        throw new NotFoundError();
+      }
+
+      const profile = await updateProfile(ctx, {
+        tenantId: input.tenantId,
+        email: input.email,
+        connections: [
+          {
+            name: "linked-user",
+            profile: {
+              email: input.linkWithEmail,
+            },
+          },
+        ],
+      });
+
+      await writeLog(ctx.state.storage, {
+        category: "link",
+        message: `Link with ${input.linkWithEmail}`,
+      });
+
+      return profile;
+    }),
   loginWithConnection: publicProcedure
     .input(
       z.object({

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -24,6 +24,12 @@ import { headers } from "../../constants";
 import { FilterSchema } from "../../types/Filter";
 import { executeQuery } from "../../helpers/sql";
 
+export interface LinkBodyParams {
+  provider?: string;
+  connection_id?: string;
+  link_with: string;
+}
+
 @Route("api/v2")
 @Tags("management-api")
 // TODO - check with NPM lib auth0/node @ https://github.com/sesamyab/auth0-management-api-demo/ - that this can create the correct token
@@ -194,5 +200,47 @@ export class UsersMgmtController extends Controller {
       tenantId,
     });
     return result;
+  }
+
+  @Post("users/{userId}/identities")
+  public async linkUserAccount(
+    @Request() request: RequestWithContext,
+    @Header("tenant-id") tenantId: string,
+    @Body() body: LinkBodyParams,
+  ): Promise<Profile> {
+    const { env } = request.ctx;
+
+    const db = getDb(env);
+    const currentDbUser = await db
+      .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
+      .where("users.id", "=", request.ctx.state.sub)
+      .select(["users.email"])
+      .executeTakeFirst();
+
+    if (!currentDbUser) {
+      throw new NotFoundError("Current user not found");
+    }
+
+    const linkedDbUser = await db
+      .selectFrom("users")
+      .where("users.tenantId", "=", tenantId)
+      .where("users.id", "=", body.link_with)
+      .select(["users.email"])
+      .executeTakeFirst();
+
+    if (!linkedDbUser) {
+      throw new NotFoundError("Linked user not found");
+    }
+
+    const currentUser = env.userFactory.getInstanceByName(
+      getId(tenantId, currentDbUser.email),
+    );
+
+    const linkeUser = env.userFactory.getInstanceByName(
+      getId(tenantId, linkedDbUser.email),
+    );
+
+    return currentUser.getProfile.query();
   }
 }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -237,7 +237,7 @@ export class UsersMgmtController extends Controller {
       getId(tenantId, currentDbUser.email),
     );
 
-    const linkeUser = env.userFactory.getInstanceByName(
+    const linkedUser = env.userFactory.getInstanceByName(
       getId(tenantId, linkedDbUser.email),
     );
 

--- a/test/fixtures/do-storage.ts
+++ b/test/fixtures/do-storage.ts
@@ -1,0 +1,29 @@
+// TODO: this should really implement DurableObjectStorage, but for now we'll do a unsafe casting
+export class DOStorageFixture {
+  data = new Map<string, string>();
+
+  async get<T = unknown>(key: string) {
+    return this.data.get(key) ?? null;
+  }
+
+  // This is only available in the fixture and not in the actual storage. Only use in tests
+  getSync(key: string) {
+    if (!this.data.has(key)) {
+      throw new Error("Key not set");
+    }
+
+    return this.data.get(key) as string;
+  }
+
+  async put<T = unknown>(key: string, value: string) {
+    this.data.set(key, value);
+  }
+
+  async delete(key: string) {
+    this.data.delete(key);
+  }
+
+  async deleteAll() {
+    this.data.clear();
+  }
+}


### PR DESCRIPTION
Added a function that adds a linked user as a connection, which is the first step of linking users. This way a user that has a linked user show up with the linked-user tag in the auth-admin.
It does not yet store information in the linked user so it won't change the login flow yet.

When writing the test I realized that we should have a fixture for the storage so I added that and refactored the other model tests.