### PR TITLE
feat: id not required in user PUT route

### DIFF
--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -183,8 +183,10 @@ export class UsersMgmtController extends Controller {
   public async putUser(
     @Request() request: RequestWithContext,
     @Header("tenant-id") tenantId: string,
+    // should we be using this userId in the path?
+    @Path("userId") userId: string,
     @Body()
-    user: Omit<User, "tenant_id" | "created_at" | "modified_at"> &
+    user: Omit<User, "id" | "tenant_id" | "created_at" | "modified_at"> &
       Partial<Pick<User, "created_at" | "modified_at">>,
   ): Promise<Profile> {
     const { ctx } = request;

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -16,7 +16,7 @@ import {
 } from "@tsoa/runtime";
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
-import { ConflictError, NotFoundError } from "../../errors";
+import { NotFoundError } from "../../errors";
 import { getId } from "../../models";
 import { Profile } from "../../types";
 import { User } from "../../types/sql/User";
@@ -186,8 +186,7 @@ export class UsersMgmtController extends Controller {
     // should we be using this userId in the path?
     @Path("userId") userId: string,
     @Body()
-    user: Omit<User, "id" | "tenant_id" | "created_at" | "modified_at"> &
-      Partial<Pick<User, "created_at" | "modified_at">>,
+    user: Omit<User, "id" | "tenant_id" | "created_at" | "modified_at">,
   ): Promise<Profile> {
     const { ctx } = request;
 

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -34,7 +34,7 @@ import { z } from "zod";
 //   "family_name": ""
 // }
 
-interface Connection {
+export interface Connection {
   name: string;
   profile?: { [key: string]: string | boolean | number };
 }

--- a/src/types/sql/User.ts
+++ b/src/types/sql/User.ts
@@ -51,9 +51,13 @@ export interface BaseUser {
   name?: string;
   picture?: string;
   locale?: string;
-  // adding this for consistency - why do we have User & Profile?
+  // why do we have this in Profile but not in  User?
   // seems to be some duplication here... Also in the DOs
-  connections: Connection[];
+  // connections: Connection[];
+  // TODO
+  // - check planet scale SQL db - what do we have here?
+  // - checkout auth0 mgmt API! - what can we send up there?
+  // - also check other Auth0 profile types - SURELY we just copy them 8-0
 }
 
 export interface User extends BaseUser {

--- a/src/types/sql/User.ts
+++ b/src/types/sql/User.ts
@@ -32,6 +32,8 @@
 //   "family_name": ""
 // }
 
+import type { Connection } from "../Profile";
+
 export interface UserTag {
   name: string;
   category: string;
@@ -49,6 +51,9 @@ export interface BaseUser {
   name?: string;
   picture?: string;
   locale?: string;
+  // adding this for consistency - why do we have User & Profile?
+  // seems to be some duplication here... Also in the DOs
+  connections: Connection[];
 }
 
 export interface User extends BaseUser {


### PR DESCRIPTION
This is as far as I've got

The issue is we have `User` types and `Profile` types and also a `User` SQL type and I'm not sure which types we should be accepting :thinking: 


Given we want backwards compatibility with Auth0, I was going to look at what they do 