### PR TITLE
fix: check permissions based on tenant id header

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -184,7 +184,7 @@ export async function getUser(
 }
 
 export async function verifyTenantPermissions(ctx: Context<Env>) {
-  const tenantId = ctx.params.tenantId;
+  const tenantId = ctx.params.tenantId || ctx.headers.get("tenant-id");
   if (!tenantId) {
     return;
   }

--- a/src/routes/tsoa/users-mgmt.ts
+++ b/src/routes/tsoa/users-mgmt.ts
@@ -16,7 +16,7 @@ import {
 } from "@tsoa/runtime";
 import { getDb } from "../../services/db";
 import { RequestWithContext } from "../../types/RequestWithContext";
-import { ConflictError, NotFoundError } from "../../errors";
+import { NotFoundError } from "../../errors";
 import { getId } from "../../models";
 import { Profile } from "../../types";
 import { User } from "../../types/sql/User";


### PR DESCRIPTION
As we don't pass the tenenat-id in the params for the users endpoint we need to check the header as well.