### PR TITLE
feat: tested to detect linked accounts for code

### DIFF
--- a/src/helpers/account-linking.ts
+++ b/src/helpers/account-linking.ts
@@ -1,0 +1,22 @@
+import { Env, Profile } from "../types";
+
+export async function handleLinkedAccount(env: Env, profile: Profile) {
+  if (!profile.linked_with) {
+    return profile;
+  }
+
+  const linkedWith = env.userFactory.getInstanceByName(
+    `${profile.tenant_id}|${profile.linked_with}`,
+  );
+
+  const { connections, ...profileWithoutConnections } = profile;
+
+  return linkedWith.loginWithConnection.mutate({
+    tenantId: profile.tenant_id,
+    email: profile.linked_with,
+    connection: {
+      name: "linked-user",
+      profile: profileWithoutConnections,
+    },
+  });
+}

--- a/src/helpers/account-linking.ts
+++ b/src/helpers/account-linking.ts
@@ -15,7 +15,7 @@ export async function handleLinkedAccount(env: Env, profile: Profile) {
     tenantId: profile.tenant_id,
     email: profile.linked_with,
     connection: {
-      name: "linked-user",
+      name: `linked-user|${profile.email}`,
       profile: profileWithoutConnections,
     },
   });

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -373,7 +373,7 @@ export const userRouter = router({
         email: input.email,
         connections: [
           {
-            name: "linked-user",
+            name: `linked-user|${input.linkWithEmail}`,
             profile: {
               email: input.linkWithEmail,
             },

--- a/test/models/User.spec.ts
+++ b/test/models/User.spec.ts
@@ -491,7 +491,7 @@ describe("User", () => {
 
       expect(profile.connections.length).toBe(1);
       expect(profile.connections[0]).toEqual({
-        name: "linked-user",
+        name: "linked-user|user2@example.com",
         profile: {
           email: "user2@example.com",
         },


### PR DESCRIPTION
Patched the code flow so it uses handles linked users. It's a bit tricky as we're actually fetching the user and store it in a the state, so there's not a single point where we can handle the linked accounts. Maybe it would be better to keep the state leaner and try to have one point where we fetch the profiles.