### PR TITLE
fix: make scope optional for client credintials

### DIFF
--- a/src/types/Token.ts
+++ b/src/types/Token.ts
@@ -37,7 +37,7 @@ export interface PKCEAuthorizationCodeGrantTypeParams {
 
 export interface ClientCredentialGrantTypeParams {
   grant_type: GrantType.ClientCredential;
-  scope: string;
+  scope?: string;
   client_secret: string;
   client_id: string;
   audience?: string;


### PR DESCRIPTION
The auth0 library doesn't pass a scope to the client credentials endpoint.