### PR TITLE
feat: add support url to email template

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -63,6 +63,7 @@ export async function sendCode(
   client: Client,
   to: string,
   code: string,
+  magicLink: string,
 ) {
   const response = await env.AUTH_TEMPLATES.get("templates/email/code.liquid");
   if (!response) {
@@ -84,6 +85,8 @@ export async function sendCode(
     code,
     vendorName: client.name,
     logo,
+    supportUrl: client.tenant.support_url,
+    magicLink,
   });
 
   await sendEmail(client, {

--- a/src/email-templates/code.mjml
+++ b/src/email-templates/code.mjml
@@ -110,7 +110,7 @@
           </tr>
         </mj-table>
         <mj-button
-          href="https://support.sesamy.com"
+          href="{{supportUrl}}"
           target="_blank"
           width="100%"
           border-radius="6px"

--- a/src/migrate/migrations/2023-09-21T10:12:15_support-url.ts
+++ b/src/migrate/migrations/2023-09-21T10:12:15_support-url.ts
@@ -1,0 +1,13 @@
+import { Kysely } from "kysely";
+import { Database } from "../../types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("tenants")
+    .addColumn("support_url", "varchar(255)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("tenants").dropColumn("support_url").execute();
+}

--- a/src/migrate/migrations/index.ts
+++ b/src/migrate/migrations/index.ts
@@ -1,6 +1,8 @@
 import * as m1_init from "./2022-12-11T09:17:35_init";
+import * as m2_magicLink from "./2023-09-21T10:12:15_support-url";
 
 // These needs to be in alphabetic order
 export default {
   m1_init,
+  m2_magicLink,
 };

--- a/src/templates/email/code.liquid
+++ b/src/templates/email/code.liquid
@@ -282,7 +282,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#0E0E11" role="presentation" style="border:none;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#0E0E11;" valign="middle">
-                                <a href="https://support.sesamy.com" style="display:inline-block;background:#0E0E11;color:#ffffff;font-family:KHTeka, Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;" target="_blank"> Kontakta oss </a>
+                                <a href="{{supportUrl}}" style="display:inline-block;background:#0E0E11;color:#ffffff;font-family:KHTeka, Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;" target="_blank"> Kontakta oss </a>
                               </td>
                             </tr>
                           </tbody>

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -70,6 +70,7 @@ export const BaseClientSchema = z.object({
     secondary_color: z.string().optional(),
     sender_email: z.string(),
     sender_name: z.string(),
+    support_url: z.string(),
     language: z.string().length(2).optional(),
   }),
 });

--- a/src/types/sql/Tenant.ts
+++ b/src/types/sql/Tenant.ts
@@ -4,6 +4,7 @@ export interface Tenant {
   audience: string;
   sender_email: string;
   sender_name: string;
+  support_url?: string;
   logo?: string;
   primary_color?: string;
   secondary_color?: string;

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -50,6 +50,7 @@ export const client: Client = {
     sender_email: "senderEmail",
     sender_name: "senderName",
     audience: "audience",
+    support_url: "supportUrl",
   },
   connections: [
     {

--- a/test/routes/tsoa/token.spec.ts
+++ b/test/routes/tsoa/token.spec.ts
@@ -42,6 +42,7 @@ describe("token", () => {
       audience: "audience",
       sender_email: "senderEmail",
       sender_name: "senderName",
+      support_url: "supportUrl",
     },
     connections: [
       {

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -24,6 +24,7 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
+        support_url: "supportUrl",
       },
       connections: [
         {
@@ -81,6 +82,7 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
+        support_url: "supportUrl",
       },
       connections: [],
       domains: [],
@@ -130,6 +132,7 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
+        support_url: "supportUrl",
       },
       connections: [],
       domains: [
@@ -190,6 +193,7 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
+        support_url: "supportUrl",
       },
       connections: [
         {


### PR DESCRIPTION
#### TODO
* fix conflix
* assert that support URL appears in email template
* default fallback? the attribute is required though :thinking:  *TBD*
* create/update tenant: *we need to have required field `supportEmail` AND write this to the db*

#### Auth-admin
- add this field to create and edit Tenant views