### PR TITLE
feat: support_url fixes tenant CRUD

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -85,7 +85,7 @@ export async function sendCode(
     code,
     vendorName: client.name,
     logo,
-    supportUrl: client.tenant.support_url,
+    supportUrl: client.tenant.support_url || "https://support.sesamy.com",
     magicLink,
   });
 

--- a/src/email-templates/code.mjml
+++ b/src/email-templates/code.mjml
@@ -121,7 +121,7 @@
           Logga in
         </mj-button>
         <mj-button
-          href="https://support.sesamy.com"
+          href="{{supportUrl}}"
           target="_blank"
           width="100%"
           border-radius="6px"

--- a/src/templates/email/code.liquid
+++ b/src/templates/email/code.liquid
@@ -295,7 +295,7 @@
                           <tbody>
                             <tr>
                               <td align="center" bgcolor="#0E0E11" role="presentation" style="border:none;border-radius:6px;cursor:auto;mso-padding-alt:10px 25px;background:#0E0E11;" valign="middle">
-                                <a href="https://support.sesamy.com" style="display:inline-block;background:#0E0E11;color:#ffffff;font-family:KHTeka, Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;" target="_blank"> Kontakta oss </a>
+                                <a href="{{supportUrl}}" style="display:inline-block;background:#0E0E11;color:#ffffff;font-family:KHTeka, Helvetica, sans-serif;font-size:14px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:6px;" target="_blank"> Kontakta oss </a>
                               </td>
                             </tr>
                           </tbody>

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -70,7 +70,7 @@ export const BaseClientSchema = z.object({
     secondary_color: z.string().optional(),
     sender_email: z.string(),
     sender_name: z.string(),
-    support_url: z.string(),
+    support_url: z.string().optional(),
     language: z.string().length(2).optional(),
   }),
 });

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -50,7 +50,6 @@ export const client: Client = {
     sender_email: "senderEmail",
     sender_name: "senderName",
     audience: "audience",
-    support_url: "supportUrl",
   },
   connections: [
     {

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -24,7 +24,6 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
-        support_url: "supportUrl",
       },
       connections: [
         {
@@ -179,7 +178,7 @@ describe("getClient", () => {
     ]);
   });
 
-  it("should use the connection settings form the defaultSettins and the clientId from envDefaultSettings", async () => {
+  it("should use the connection settings form the defaultSettings and the clientId from envDefaultSettings", async () => {
     const clientInKV: PartialClient = {
       id: "testClient",
       name: "clientName",
@@ -193,7 +192,6 @@ describe("getClient", () => {
         sender_email: "senderEmail",
         sender_name: "senderName",
         audience: "audience",
-        support_url: "supportUrl",
       },
       connections: [
         {


### PR DESCRIPTION
On this PR
* support URL is *not* required in nested `tenant` object in `client`
* if does not exist fallback to our default - https://support.sesamy.com

:question: _anything else needed for CRUD_ :question: 

Check all types could have `support_url`