### PR TITLE
feat: annotate next steps to improve error messages

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -101,6 +101,7 @@ export async function sendCode(
         value: codeEmailBody,
       },
     ],
+    // I'm getting breakit emails on dev with a subject in english. Is this correct?
     subject: translate(language, "codeEmailTitle")
       .replace("{{vendorName}}", client.name)
       .replace("{{code}}", code),

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -93,6 +93,8 @@ export class AuthenticationCodeExpiredError extends Error {
 export class InvalidCodeError extends Error {
   status = 401;
 
+  // this is the only instance of 'Invalid Code" I see in the codebase, so we MUST be on this one...
+  // So how come instanceof isn't matching in the the authenticate route?
   constructor(message = "Invalid code") {
     super();
 

--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -128,6 +128,7 @@ export class AuthenticateController extends Controller {
         };
       }
 
+      // this should be beind triggerd though... does instanceOf not work?
       if (err instanceof InvalidCodeError) {
         return {
           error: "access_denied",
@@ -144,6 +145,7 @@ export class AuthenticateController extends Controller {
 
       return {
         error: "access_denied",
+        // this one is always hit... why? surely should be the above one... hmmmm
         error_description: `Server error: ${err.message}`,
       };
     }

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -122,12 +122,22 @@ export class PasswordlessController extends Controller {
     const user = env.userFactory.getInstanceByName(
       `${client.tenant_id}|${email}`,
     );
+
+    // TODO - we need to put this in a try-catch block right and then catch the AuthenticationCodeExpiredError
+    // IF we get this, then we should redirect to login2.sesamy.com/expired-code
+    // BUT we need to also include all the OAUth params AND the email
+    // ! I am not convinced we're throwing AuthenticationCodeExpiredError here ! - I could write a unit test...
+    // but we should manually QA this by setting the access_token expiration time down to way low
+    // ALSO - should we handle other errors?  The code can be expired, BUT the user could click an expired magic link
+    // AFTER we sent them a new one.  So we should handle that case too.
+    // SHOULD we just redirect them to the above login2 URL on any error?
     const profile = await user.validateAuthenticationCode.mutate({
       code: verification_code,
       email,
       tenantId: client.tenant_id,
     });
 
+    // should we display an error message here?  This is just for us developers really to configure the client correctly
     validateRedirectUrl(client.allowed_callback_urls, redirect_uri);
 
     const authParams: AuthParams = {

--- a/test/routes/tsoa/authenticate.spec.ts
+++ b/test/routes/tsoa/authenticate.spec.ts
@@ -143,5 +143,38 @@ describe("Authenticated", () => {
         error_description: "Wrong email or verification code.",
       });
     });
+
+    it("should send an error if the code has expired", async () => {
+      const controller = new AuthenticateController();
+
+      const body: CodeAuthenticateParams = {
+        client_id: "clientId",
+        credential_type: "http://auth0.com/oauth/grant-type/passwordless/otp",
+        otp: "000000",
+        realm: "email",
+        username: "test@example.com",
+      };
+
+      const logs = [];
+
+      const ctx = contextFixture({
+        stateData: {},
+        userData: {
+          validatePassword: "AuthenticationCodeExpiredError",
+        },
+        logs,
+      });
+
+      const actual = await controller.authenticate(body, {
+        ctx,
+      } as RequestWithContext);
+
+      expect(controller.getStatus()).toBe(403);
+      expect(actual).toEqual({
+        error: "access_denied",
+        error_description:
+          "The verification code has expired. Please try to login again.",
+      });
+    });
   });
 });

--- a/test/routes/tsoa/authenticate.spec.ts
+++ b/test/routes/tsoa/authenticate.spec.ts
@@ -137,17 +137,11 @@ describe("Authenticated", () => {
         ctx,
       } as RequestWithContext);
 
-      if (!("error" in actual)) {
-        throw new Error("should return error");
-      }
-
       expect(controller.getStatus()).toBe(403);
-      expect(JSON.stringify(actual)).toBe(
-        JSON.stringify({
-          error: "access_denied",
-          error_description: "Wrong email or verification code.",
-        }),
-      );
+      expect(actual).toEqual({
+        error: "access_denied",
+        error_description: "Wrong email or verification code.",
+      });
     });
   });
 });


### PR DESCRIPTION
See all the comments @markusahlstrand ! I'll paper over this in Login2 for now but we can address this PR when we're less busy.

#### The issues?
* We aren't matching any of the thrown error exceptions so we're always falling back to `server error: ${exception.message}`
* should we be returning different error codes? In the spirit of _not breaking with Auth0_ maybe not, or maybe Auth0 has more error codes... We could try changing the code expiration time and brute force checks to much lower and play around