### PR TITLE
feat: expired link redirect needs i18n

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -25,7 +25,7 @@ export async function sendEmailValidation(
 
   const templateString = await response.text();
 
-  const language = client.tenant.language || "en";
+  const language = client.tenant.language || "sv";
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||
@@ -72,7 +72,7 @@ export async function sendCode(
 
   const templateString = await response.text();
 
-  const language = client.tenant.language || "en";
+  const language = client.tenant.language || "sv";
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||
@@ -124,7 +124,7 @@ export async function sendResetPassword(
 
   const templateString = await response.text();
 
-  const language = client.tenant.language || "en";
+  const language = client.tenant.language || "sv";
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -1,6 +1,6 @@
 export const sv = {
   codeEmailTitle:
-    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
+    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
   codeEmailWelcomeToYourAccount: "Välkommen till ditt {{vendorName}} konto!",
   passwordResetTitle: "Byt lösenord för ditt {{vendorName}} konto",
 };

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -39,6 +39,12 @@ export interface LoginError {
   error_description: string;
 }
 
+function getLocalePath(locale: string) {
+  if (locale === "en") return "";
+
+  return `/${locale}`;
+}
+
 @Route("passwordless")
 @Tags("passwordless")
 export class PasswordlessController extends Controller {
@@ -163,7 +169,11 @@ export class PasswordlessController extends Controller {
       // Ideally here only catch AuthenticationCodeExpiredError
       // redirect here always to login2.sesamy.dev/expired-code
 
-      const login2ExpiredCodeUrl = new URL(`${env.LOGIN2_URL}/expired-code`);
+      const localePath = getLocalePath(client.tenant.language || "sv");
+
+      const login2ExpiredCodeUrl = new URL(
+        `${env.LOGIN2_URL}${localePath}/expired-code`,
+      );
 
       const stateDecoded = new URLSearchParams(state);
 

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -70,7 +70,7 @@ describe("Passwordless", () => {
       );
 
       expect(mailRequest.subject).toEqual(
-        "Welcome to clientName! 123456 is the login code",
+        "Välkommen till clientName! 123456 är koden för att logga in",
       );
 
       expect(mailRequest.from).toEqual({


### PR DESCRIPTION
I tested this on the Commerce deploy and we stay on Swedish -> https://commerce-ds2s9rn6m.vercel.sesamy.dev/

*BUT* I noticed that the `redirecting` page keeps ending up back on English. I can look at that also