### PR TITLE
feat: new template for code emails and send this depending on call to passwordless/start

### DIFF
--- a/scripts/create-mjml-templates.sh
+++ b/scripts/create-mjml-templates.sh
@@ -1,12 +1,13 @@
 export NO_D1_WARNING=true
 cd src
 
-# hardcode just the swedish code email for now
 npx mjml email-templates/code.mjml -o templates/email/code.liquid
+npx mjml email-templates/link.mjml -o templates/email/link.liquid
 npx mjml email-templates/verify-email.mjml -o templates/email/verify-email.liquid
 npx mjml email-templates/password-reset.mjml -o templates/email/password-reset.liquid
 
 # also upload to wrangler in this script for now so we can quickly upload new email templates
 npx wrangler r2 object put auth-templates/templates/email/code.liquid -f templates/email/code.liquid
+npx wrangler r2 object put auth-templates/templates/email/link.liquid -f templates/email/link.liquid
 npx wrangler r2 object put auth-templates/templates/email/verify-email.liquid -f templates/email/verify-email.liquid
 npx wrangler r2 object put auth-templates/templates/email/password-reset.liquid -f templates/email/password-reset.liquid

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -63,6 +63,54 @@ export async function sendCode(
   client: Client,
   to: string,
   code: string,
+) {
+  const response = await env.AUTH_TEMPLATES.get("templates/email/link.liquid");
+  if (!response) {
+    throw new Error("Code template not found");
+  }
+
+  const templateString = await response.text();
+
+  const language = client.tenant.language || "sv";
+
+  const logo = getClientLogoPngGreyBg(
+    client.tenant.logo ||
+      "https://assets.sesamy.com/static/images/sesamy/logo-translucent.png",
+    env.IMAGE_PROXY_URL,
+  );
+
+  const sendCodeTemplate = engine.parse(templateString);
+  const codeEmailBody = await engine.render(sendCodeTemplate, {
+    code,
+    vendorName: client.name,
+    logo,
+    supportUrl: client.tenant.support_url || "https://support.sesamy.com",
+    buttonColor: client.tenant.primary_color || "#7d68f4",
+  });
+
+  await sendEmail(client, {
+    to: [{ email: to, name: to }],
+    from: {
+      email: client.tenant.sender_email,
+      name: client.tenant.sender_name,
+    },
+    content: [
+      {
+        type: "text/html",
+        value: codeEmailBody,
+      },
+    ],
+    subject: translate(language, "codeEmailTitle")
+      .replace("{{vendorName}}", client.name)
+      .replace("{{code}}", code),
+  });
+}
+
+export async function sendLink(
+  env: Env,
+  client: Client,
+  to: string,
+  code: string,
   magicLink: string,
 ) {
   const response = await env.AUTH_TEMPLATES.get("templates/email/code.liquid");

--- a/src/email-templates/code.mjml
+++ b/src/email-templates/code.mjml
@@ -71,23 +71,7 @@
           Välkommen till ditt {{vendorName}}-konto!
         </mj-text>
         <mj-text font-size="16px" line-height="19.2px">
-          Klicka på knappen för att logga in
-        </mj-text>
-        <mj-button
-            href="{{magicLink}}"
-            target="_blank"
-            width="100%"
-            border-radius="6px"
-            background-color="{{buttonColor}}"
-            font-size="16px"
-            css-class="clickable-button"
-            inner-padding="15px 25px"
-            line-height="20px"
-          >
-          Logga in
-        </mj-button>
-        <mj-text font-size="16px" line-height="19.2px">
-          Eller skriv in koden på {{vendorName}} för att slutföra inloggningen.
+          Skriv in koden på {{vendorName}} för att slutföra inloggningen.
         </mj-text>
         <mj-table>
           <tr>

--- a/src/email-templates/link.mjml
+++ b/src/email-templates/link.mjml
@@ -1,0 +1,155 @@
+<mjml>
+  <mj-head>
+    <mj-font name="KHTeka" href="https://assets.sesamy.dev/static/fonts/khteka.css" />
+    <mj-attributes>
+      <mj-text color="#88869F" font-size="14px" line-height="16.8px" font-weight="400" />
+      <mj-all font-family="KHTeka, Helvetica, sans-serif" />
+    </mj-attributes>
+    <mj-style>
+      .custom-table table {
+        width: auto !important;
+        margin: 0 auto !important;
+      }
+      .padding-horizontal > table > tbody > tr > td {
+        padding-left: 4px;
+        padding-right: 4px;
+      }
+      .padding-vertical > table > tbody > tr > td {
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+      .custom-table table img {
+        display: block;
+      }
+      html {
+        -webkit-font-smoothing: antialiased;
+      }
+      .text-style {
+        display: inline-block;
+        font-size: 14px;
+        line-height: 16.8px;
+        font-weight: 400;
+        color: #88869F;
+        font-family: KHTeka, Helvetica, sans-serif;
+      }
+      .clickable-button a {
+        display: block;
+        width: calc(100% - 50px);
+      }
+      a {
+        color: #7D68F4;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #7D68F4;
+        text-decoration: underline;
+      }
+      .purple-link {
+        color: #7D68F4 !important;
+        text-decoration: none !important;
+      }
+      .purple-link:hover {
+        color: #7D68F4 !important;
+        text-decoration: underline !important;
+      }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#F5F5F7">
+    <mj-section>
+      <mj-column>
+        <mj-image
+          alt={{vendorName}}
+          target="_blank"
+          width="166px"
+          src={{logo}}
+        />
+      </mj-column>
+    </mj-section>
+    <mj-section padding="4px">
+      <mj-column padding="16px 0px" border-radius="16px" width="504px" background-color="#fff">
+        <mj-text font-size="18px" line-height="21.6px" font-weight="500" color="#14141A">
+          Välkommen till ditt {{vendorName}}-konto!
+        </mj-text>
+        <mj-text font-size="16px" line-height="19.2px">
+          Klicka på knappen för att logga in
+        </mj-text>
+        <mj-button
+            href="{{magicLink}}"
+            target="_blank"
+            width="100%"
+            border-radius="6px"
+            background-color="{{buttonColor}}"
+            font-size="16px"
+            css-class="clickable-button"
+            inner-padding="15px 25px"
+            line-height="20px"
+          >
+          Logga in
+        </mj-button>
+        <mj-text font-size="16px" line-height="19.2px">
+          Eller skriv in koden på {{vendorName}} för att slutföra inloggningen.
+        </mj-text>
+        <mj-table>
+          <tr>
+            <td style="text-align: center; padding: 10px; border-radius: 8px; background: #F5F5F7;">
+              <div class="text-style" style="font-size: 24px; line-height: 28.8px; font-weight: 500; color: #14141A;">
+                {{code}}
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding-top: 6px;">
+              <div class="text-style" style="font-size: 16px; line-height: 19.2px;">
+                Koden är giltig i 30 minuter
+              </div>
+            </td>
+          </tr>
+        </mj-table>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column width="504px">
+        <mj-table padding="0px 20px 0px 20px" css-class="padding-horizontal">
+          <tr>
+            <td style="vertical-align: top; width: 14px;padding-top:2px;">
+              <img
+                alt=""
+                width="14"
+                height="14"
+                style="width: 14px;border:0;display:block;outline:none;text-decoration:none;height:14px;"
+                src="https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:28:28/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3F1ZXN0aW9uLnBuZw&#x3D;&#x3D;"
+              />
+            </td>
+            <td>
+              <div class="text-style">Om du har frågor eller behöver assistans kan du kontakta vårt supportteam</div>
+            </td>
+          </tr>
+        </mj-table>
+        <mj-button
+          href="{{supportUrl}}"
+          target="_blank"
+          width="100%"
+          border-radius="6px"
+          background-color="#0E0E11"
+          font-size="14px"
+          css-class="clickable-button"
+        >
+          Kontakta oss
+        </mj-button>
+        <mj-spacer height="4px" />
+        <mj-text>Copyright © 2023 SESAMY. Alla rättigheter förbehållna.</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section padding="0px 0px 30px 0px">
+      <mj-column>
+        <mj-image
+          alt=""
+          width="225px"
+          src="https://imgproxy.dev.sesamy.cloud/unsafe/format:png/size:225/aHR0cHM6Ly9hc3NldHMuc2VzYW15LmRldi9zdGF0aWMvaW1hZ2VzL2VtYWlsL3Nlc2FteS1sb2dvLXRyYW5zbHVjZW50LnBuZw&#x3D;&#x3D;"
+          target="_blank"
+          href="https://sesamy.com"
+        />
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/templates/email/link.liquid
+++ b/src/templates/email/link.liquid
@@ -218,7 +218,25 @@
                             </tr>
                             <tr>
                               <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:KHTeka, Helvetica, sans-serif;font-size:16px;font-weight:400;line-height:19.2px;text-align:left;color:#88869F;">Skriv in koden på {{vendorName}} för att slutföra inloggningen.</div>
+                                <div style="font-family:KHTeka, Helvetica, sans-serif;font-size:16px;font-weight:400;line-height:19.2px;text-align:left;color:#88869F;">Klicka på knappen för att logga in</div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="center" vertical-align="middle" class="clickable-button" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
+                                  <tbody>
+                                    <tr>
+                                      <td align="center" bgcolor="{{buttonColor}}" role="presentation" style="border:none;border-radius:6px;cursor:auto;mso-padding-alt:15px 25px;background:{{buttonColor}};" valign="middle">
+                                        <a href="{{magicLink}}" style="display:inline-block;background:{{buttonColor}};color:#ffffff;font-family:KHTeka, Helvetica, sans-serif;font-size:16px;font-weight:normal;line-height:20px;margin:0;text-decoration:none;text-transform:none;padding:15px 25px;mso-padding-alt:0px;border-radius:6px;" target="_blank"> Logga in </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                <div style="font-family:KHTeka, Helvetica, sans-serif;font-size:16px;font-weight:400;line-height:19.2px;text-align:left;color:#88869F;">Eller skriv in koden på {{vendorName}} för att slutföra inloggningen.</div>
                               </td>
                             </tr>
                             <tr>

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -1,6 +1,9 @@
 import fetchMock from "jest-fetch-mock";
 import { contextFixture, client } from "../../fixtures";
-import { PasswordlessController } from "../../../src/routes/tsoa/passwordless";
+import {
+  PasswordlessController,
+  PasswordlessOptions,
+} from "../../../src/routes/tsoa/passwordless";
 import {
   Client,
   AuthorizationResponseType,
@@ -41,7 +44,7 @@ describe("Passwordless", () => {
     it("should use the fallback sesamy logo if client does not have a logo set", async () => {
       const controller = new PasswordlessController();
 
-      const body = {
+      const body: PasswordlessOptions = {
         client_id: "clientId",
         connection: "email",
         send: "code",
@@ -106,7 +109,7 @@ describe("Passwordless", () => {
     it("should use the client logo if set", async () => {
       const controller = new PasswordlessController();
 
-      const body = {
+      const body: PasswordlessOptions = {
         client_id: "clientId",
         connection: "email",
         send: "code",


### PR DESCRIPTION
I'll use the copy provided by @markusahlstrand from the nuked PR https://github.com/sesamyab/auth/pull/172 


---------------------------------------------------------------

@markusahlstrand this is actually quite duplicated. I could have another look tomorrow in how to get logic into the liquid templates, ideally we'd have something testing visually the output of the templates though. Otherwise I'd rather just duplicate and quickly QA both templates...


It could be that instead we extract out common parts into partials... TBD!