### PR TITLE
feat: hardcoded list of allowed callback URL

### DIFF
--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -1,5 +1,40 @@
 import { InvalidRedirectError } from "../errors";
 
+const ALLOWED_CALLBACK_URLS = [
+  // localhost
+  "http://localhost:3000",
+  "http://localhost:3000/sv",
+  "http://localhost:3000/callback",
+  "http://localhost:3000/sv/callback",
+  "http://localhost:3000/link",
+  "http://localhost:3000/sv/link",
+  // login2 dev
+  "https://login2.sesamy.dev/",
+  "https://login2.sesamy.dev/sv/",
+  "https://login2.sesamy.dev/callback",
+  "https://login2.sesamy.dev/sv/callback",
+  "https://login2.sesamy.dev/link",
+  "https://login2.sesamy.dev/sv/link",
+  // login2 prod
+  "https://login2.sesamy.com/",
+  "https://login2.sesamy.com/sv/",
+  "https://login2.sesamy.com/callback",
+  "https://login2.sesamy.com/sv/callback",
+  "https://login2.sesamy.com/link",
+  "https://login2.sesamy.com/sv/link",
+  // vercel preview deploys
+  "https://*.vercel.sesamy.dev",
+  "https://*.vercel.sesamy.dev/sv",
+  "https://*.vercel.sesamy.dev/callback",
+  "https://*.vercel.sesamy.dev/sv/callback",
+  "https://*.vercel.sesamy.dev/link",
+  "https://*.vercel.sesamy.dev/sv/link",
+  // example.com
+  "http://example.com",
+];
+// ALSO! we need the token-service. I think this is defined in the hidden DEFAULT_ENV_VARS on cloudflare
+// would be good to remove all those opaque ones so we can se what is happening her
+
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
 }
@@ -8,12 +43,14 @@ function escapeRegExp(string) {
 const urlPattern: RegExp = /^((?:http[s]?:\/\/)?[^\/]+)([^?]*)(\?.*)?$/;
 
 export function validateRedirectUrl(
-  allowedUrls: string[],
+  allowedUrlsClient: string[], // should this param now be optional?
   redirectUri?: string,
 ) {
   if (!redirectUri) {
     return;
   }
+
+  const allowedUrls = [...ALLOWED_CALLBACK_URLS, ...allowedUrlsClient];
 
   const regexes = allowedUrls.map((allowedUrl) => {
     // This doesn't work in cloudflare workers for whatever reason

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -74,4 +74,23 @@ describe("validateRedirectUrl", () => {
     const redirectUri = "http://example.com?foo=bar";
     expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
   });
+
+  describe("should read values from ALLOWED_CALLBACK_URLS", () => {
+    test("example.com", () => {
+      const allowedUrls = [];
+      const redirectUri = "http://example.com";
+      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    });
+    test("http://localhost:3000#auth_token=foo-bar", () => {
+      const allowedUrls = [];
+      const redirectUri = "http://localhost:3000/sv";
+      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    });
+    test("A Vercel preview domain in Swedish", () => {
+      const allowedUrls = [];
+      const redirectUri =
+        "https://test-test.vercel.sesamy.dev/sv/callback?auth_token=foo-bar";
+      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
This _should_ fix everything we need for a release across all `client_id`s :crossed_fingers: 

_If we merge this then all the cron job tests should pass again_ :checkered_flag: 