### PR TITLE
feat: new breakit logout user route needs adding to hardcoded allowed callback URLs

### DIFF
--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -8,6 +8,8 @@ const ALLOWED_CALLBACK_URLS = [
   "http://localhost:3000/sv/callback",
   "http://localhost:3000/link",
   "http://localhost:3000/sv/link",
+  "http://localhost:3000/breakit-user-not-found",
+  "http://localhost:3000/sv/breakit-user-not-found",
   // login2 dev
   "https://login2.sesamy.dev/",
   "https://login2.sesamy.dev/sv/",
@@ -15,6 +17,8 @@ const ALLOWED_CALLBACK_URLS = [
   "https://login2.sesamy.dev/sv/callback",
   "https://login2.sesamy.dev/link",
   "https://login2.sesamy.dev/sv/link",
+  "https://login2.sesamy.dev/breakit-user-not-found",
+  "https://login2.sesamy.dev/sv/breakit-user-not-found",
   // login2 prod
   "https://login2.sesamy.com/",
   "https://login2.sesamy.com/sv/",
@@ -22,6 +26,8 @@ const ALLOWED_CALLBACK_URLS = [
   "https://login2.sesamy.com/sv/callback",
   "https://login2.sesamy.com/link",
   "https://login2.sesamy.com/sv/link",
+  "https://login2.sesamy.com/breakit-user-not-found",
+  "https://login2.sesamy.com/sv/breakit-user-not-found",
   // vercel preview deploys
   "https://*.vercel.sesamy.dev",
   "https://*.vercel.sesamy.dev/sv",
@@ -29,6 +35,8 @@ const ALLOWED_CALLBACK_URLS = [
   "https://*.vercel.sesamy.dev/sv/callback",
   "https://*.vercel.sesamy.dev/link",
   "https://*.vercel.sesamy.dev/sv/link",
+  "https://*.vercel.sesamy.dev/breakit-user-not-found",
+  "https://*.vercel.sesamy.dev/sv/breakit-user-not-found",
   // example.com
   "http://example.com",
 ];


### PR DESCRIPTION
*OR* @markusahlstrand , we just add these to the breakit clients on auth2 dev & prod

I'll be doing this on dev anyway for `breakit` but we have several client_ids, comments welcome!