### PR TITLE
fix: mgmt API POST create user

### DIFF
--- a/src/adapters/planetscale/users/createUser.ts
+++ b/src/adapters/planetscale/users/createUser.ts
@@ -8,8 +8,10 @@ export function createUser(db: Kysely<Database>) {
     tenantId: string,
     user: PostUsersBody,
   ): Promise<UserResponse> => {
+    // TODO - is POSTing user_id allowed in Auth0 mgmt API?
+    const user_id = user.user_id || nanoid();
     const sqlUser: SqlUser = {
-      id: user.user_id || nanoid(),
+      id: user_id,
       email: user.email || "",
       given_name: user.given_name,
       family_name: user.family_name,
@@ -24,7 +26,7 @@ export function createUser(db: Kysely<Database>) {
 
     await db.insertInto("users").values(sqlUser).execute();
 
-    const { modified_at, ...userWithoutFields } = sqlUser;
+    const { modified_at, id, ...userWithoutFields } = sqlUser;
 
     return {
       ...userWithoutFields,
@@ -32,6 +34,7 @@ export function createUser(db: Kysely<Database>) {
       logins_count: 0,
       username: sqlUser.email,
       identities: [],
+      user_id,
     };
   };
 }

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -140,7 +140,7 @@ export class UsersMgmtController extends Controller {
   ): Promise<UserResponse> {
     const { env } = request.ctx;
 
-    const { id, ...data } = await env.data.users.create(tenantId, user);
+    const data = await env.data.users.create(tenantId, user);
 
     this.setStatus(201);
     return data;

--- a/src/types/auth0/UserResponse.ts
+++ b/src/types/auth0/UserResponse.ts
@@ -13,6 +13,10 @@ interface BaseUser {
   name?: string;
   nickname?: string;
   picture?: string;
+  // I think we should be stricter with this
+  // I need to check the auth0-mgmt-api library
+  // I'm not too sure if it's required from the docs
+  // https://auth0.com/docs/api/management/v2/users/post-users
   user_id?: string;
   blocked?: boolean;
   email_verified?: boolean;
@@ -36,6 +40,7 @@ export interface UserResponse extends BaseUser {
   multifactor?: string[];
   last_ip?: string;
   last_login?: string;
+  user_id: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
This is the response that we get back from the Auth0 mgmt API after creating a user

```
{
  created_at: '2023-10-25T19:00:05.668Z',
  email: 'new-test-user@hey.com',
  email_verified: false,
  identities: [
    {
      connection: 'Username-Password-Authentication',
      user_id: '653965b5922a5416607b4b47',
      provider: 'auth0',
      isSocial: false
    }
  ],
  name: 'new-test-user@hey.com',
  nickname: 'new-test-user',
  picture: 'https://s.gravatar.com/avatar/e9b89abdaf7818d6dcb0bb3cda43c64a?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fne.png',
  updated_at: '2023-10-25T19:00:05.668Z',
  user_id: 'auth0|653965b5922a5416607b4b47',
  user_metadata: {}
}
```

We also need the `user_id` in React Admin