### PR TITLE
feat: created migration script to remove locale field BUT...

### DIFF
--- a/src/migrate/migrations/2023-10-26T07:53:00_remove-locale-field.ts
+++ b/src/migrate/migrations/2023-10-26T07:53:00_remove-locale-field.ts
@@ -1,0 +1,13 @@
+import { Kysely } from "kysely";
+import { Database } from "../../types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("users").dropColumn("locale").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("users")
+    .addColumn("locale", "varchar(255)")
+    .execute();
+}


### PR DESCRIPTION
Am I missing something @markusahlstrand ? 

This comes from this comment  https://github.com/sesamyab/auth-admin/pull/52#discussion_r1372232406

*BUT* I don't see this column in the db

![image](https://github.com/sesamyab/auth/assets/8496063/80a2e99e-f861-4b7a-bd1b-8759687e75d3)


Does it exist on production? :thinking: 