### PR TITLE
feat: just remove user from SQL!

### DIFF
--- a/src/types/auth0/UserResponse.ts
+++ b/src/types/auth0/UserResponse.ts
@@ -32,7 +32,6 @@ export interface PostUsersBody extends BaseUser {
 
 export interface UserResponse extends BaseUser {
   email: string; // Overriding: email is mandatory in GetUserResponse
-  username: string;
   created_at: string;
   updated_at: string;
   identities: Identity[];

--- a/src/types/sql/User.ts
+++ b/src/types/sql/User.ts
@@ -52,9 +52,11 @@ export interface BaseUser {
 }
 
 export interface User extends BaseUser {
-  tags?: UserTag[];
+  // what are these tags field? Not in Auth0 spec
+  // tags?: UserTag[];
 }
 
 export interface SqlUser extends BaseUser {
+  // remove this once have removed the field! Otherwise I think will select it anyway
   tags?: string;
 }


### PR DESCRIPTION
On some of the demo tenants I made a while back I'm simply unable to delete users because they don't exist in durable objects

My idea is to catch any thrown error when selecting a DO by user id, and then just nuke it from SQL

*however* I cannot catch exceptions thrown by whatever is reading the DOs

*and* it doesn't actually look like the User model _is_ removing the User from SQL!  It's removing the state, and adding the event onto a queue... is the queue used somewhere? :thinking: 