### PR TITLE
fix: cloudflare and url wildcards

### DIFF
--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -30,10 +30,7 @@ function matchHostnameWithWildcards(
       continue;
     }
 
-    if (
-      allowedHostnamePart.toLocaleLowerCase() !==
-      redirectHostnamePart.toLocaleLowerCase()
-    ) {
+    if (allowedHostnamePart !== redirectHostnamePart) {
       return false;
     }
   }
@@ -117,7 +114,7 @@ export function matchUrlWithAllowedUrl(
 
   const { protocol, host, port = "", path = "/" } = match.groups;
 
-  const redirectUrl = new URL(redirectUrlStr);
+  const redirectUrl = new URL(redirectUrlStr.toLocaleLowerCase());
 
   if (protocol !== redirectUrl.protocol) {
     return false;

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -103,7 +103,9 @@ export function matchUrlWithAllowedUrl(
   allowedUrlStr: string,
   redirectUrlStr: string,
 ) {
-  const match = urlPattern.exec(allowedUrlStr) as RegExpExecArray & {
+  const match = urlPattern.exec(
+    allowedUrlStr.toLocaleLowerCase(),
+  ) as RegExpExecArray & {
     groups: { protocol: string; host: string; port?: string; path?: string };
   };
 
@@ -114,7 +116,7 @@ export function matchUrlWithAllowedUrl(
 
   const { protocol, host, port = "", path = "/" } = match.groups;
 
-  const redirectUrl = new URL(redirectUrlStr.toLocaleLowerCase());
+  const redirectUrl = new URL(redirectUrlStr);
 
   if (protocol !== redirectUrl.protocol) {
     return false;

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -30,7 +30,10 @@ function matchHostnameWithWildcards(
       continue;
     }
 
-    if (allowedHostnamePart !== redirectHostnamePart) {
+    if (
+      allowedHostnamePart.toLocaleLowerCase() !==
+      redirectHostnamePart.toLocaleLowerCase()
+    ) {
       return false;
     }
   }
@@ -95,23 +98,40 @@ const ALLOWED_CALLBACK_URLS = [
   "http://example.com",
 ];
 
-function matchUrlWithAllowedUrl(allowedUrlStr: string, redirectUrlStr: string) {
-  const allowedUrl = new URL(allowedUrlStr);
+// Regular expression to extract protocol + host and path (without query string) from a URL
+const urlPattern: RegExp =
+  /^(?<protocol>[a-z]+:)\/\/(?<host>[^\/:\s]+)(?::(?<port>\d+))?(?<path>\/.*)?$/;
+
+export function matchUrlWithAllowedUrl(
+  allowedUrlStr: string,
+  redirectUrlStr: string,
+) {
+  const match = urlPattern.exec(allowedUrlStr) as RegExpExecArray & {
+    groups: { protocol: string; host: string; port?: string; path?: string };
+  };
+
+  if (!match) {
+    console.log(`Invalid URL: ${allowedUrlStr}`);
+    return false;
+  }
+
+  const { protocol, host, port = "", path = "/" } = match.groups;
+
   const redirectUrl = new URL(redirectUrlStr);
 
-  if (allowedUrl.protocol !== redirectUrl.protocol) {
+  if (protocol !== redirectUrl.protocol) {
     return false;
   }
 
-  if (!matchHostnameWithWildcards(allowedUrl.hostname, redirectUrl.hostname)) {
+  if (!matchHostnameWithWildcards(host, redirectUrl.hostname)) {
     return false;
   }
 
-  if (allowedUrl.port !== redirectUrl.port) {
+  if (port !== redirectUrl.port) {
     return false;
   }
 
-  if (allowedUrl.pathname !== redirectUrl.pathname) {
+  if (path !== redirectUrl.pathname) {
     return false;
   }
 

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -1,46 +1,49 @@
-import { validateRedirectUrl } from "../../src/utils/validate-redirect-url";
+import {
+  validateRedirectUrl,
+  validateUrl,
+} from "../../src/utils/validate-redirect-url";
 
-describe("validateRedirectUrl", () => {
+describe("validateUrl", () => {
   it("should allow valid redirectUri with wildcard", () => {
     const allowedUrls = ["https://*.example.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
   });
 
   it("should allow valid redirectUri with a wildcard and a path", () => {
     const allowedUrls = ["https://*.example.com/path"];
     const redirectUri = "https://sub.example.com/path";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
   });
 
   it("should not allow wildcard to span multiple subdomains", () => {
     const allowedUrls = ["https://*.example.com/path"];
     const redirectUri = "https://sub.sub.example.com/path";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should not allow domain wildcards", () => {
     const allowedUrls = ["https://*.com"];
     const redirectUri = "https://anything.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should not allow wildcard for full URL", () => {
     const allowedUrls = ["https://*"];
     const redirectUri = "https://*";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should not allow bad URLs with just wildcards", () => {
     const allowedUrls = ["*"];
     const redirectUri = "*";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should disallow redirectUri with wildcard subdomain specified but not existing", () => {
     const allowedUrls = ["https://*.example.com"];
     const redirectUri = "https://notexample.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow(
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow(
       "Invalid redirectUri",
     );
   });
@@ -48,37 +51,37 @@ describe("validateRedirectUrl", () => {
   it("should be case insensitive", () => {
     const allowedUrls = ["https://*.EXAMPLE.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
   });
 
   it("should handle URLs without wildcards", () => {
     const allowedUrls = ["https://sub.example.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
   });
 
   it("should handle bad URLs without wildcards", () => {
     const allowedUrls = ["https://sub.example.com"];
     const redirectUri = "https://bad.example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should handle exact matches of urls with ports", () => {
     const allowedUrls = ["http://localhost:3000"];
     const redirectUri = "http://localhost:3000";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
   });
 
   it("should fail when no exact match of urls with ports", () => {
     const allowedUrls = ["http://localhost:3000"];
     const redirectUri = "http://localhost:3001";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
   });
 
   it("should throw error for URLs that don't exactly match", () => {
     const allowedUrls = ["https://sub.example.com"];
     const redirectUri = "https://sub2.example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow(
+    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow(
       "Invalid redirectUri",
     );
   });


### PR DESCRIPTION
It seems the cloudflare indeed has issues with wildcards when creating URL's.

Changed the tests a bit so they are using validateUrl instead of validateRedirectUrl as it injecting a lot of deafults which makes the tests less reliable.