### PR TITLE
feat: check types yarn command and run on ci/cd

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,3 +30,4 @@ jobs:
       - run: yarn build
       - run: yarn test
       - run: yarn integration
+      - run: yarn type-check

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mime": "^3.0.0",
     "trpc-durable-objects": "^1.3.4",
     "tsoa": "^5.1.1",
-    "tsoa-hono": "^1.0.9",
+    "tsoa-hono": "^1.0.10",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/jest": "^29.5.5",
     "@types/node": "^20.8.3",
     "@types/service-worker-mock": "^2.0.2",
+    "cloudworker-router": "^4.1.5",
     "dotenv": "^16.3.1",
     "eslint": "^8.51.0",
     "husky": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "integration": "jest --config jest-integration.config.js --verbose",
     "test-with-coverage": "jest --config jest.config.js --coverage",
     "semantic-release": "semantic-release",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "type-check": "tsc"
   },
   "author": "",
   "license": "MIT",

--- a/src/adapters/in-memory/logs/list.ts
+++ b/src/adapters/in-memory/logs/list.ts
@@ -5,7 +5,6 @@ import { Log } from "../../../types";
 export function listLogs(logs: Log[]) {
   return async (
     tenantId,
-    userId,
     { page, per_page, include_totals, q }: ListParams,
   ): Promise<ListLogsResponse> => {
     return {

--- a/src/adapters/in-memory/user/listUsers.ts
+++ b/src/adapters/in-memory/user/listUsers.ts
@@ -9,6 +9,10 @@ export function listUsers(users: UserResponse[]) {
   ): Promise<ListUsersResponse> => {
     return {
       users,
+      // no pagination for now
+      start: 0,
+      limit: 0,
+      length: users.length,
     };
   };
 }

--- a/src/adapters/planetscale/users/listUsers.ts
+++ b/src/adapters/planetscale/users/listUsers.ts
@@ -69,12 +69,6 @@ export function listUsers(db: Kysely<Database>) {
       return userResponse;
     });
 
-    if (!params.include_totals) {
-      return {
-        users,
-      };
-    }
-
     const [{ count }] = await query
       .select((eb) => eb.fn.countAll().as("count"))
       .execute();

--- a/src/migrate/index.ts
+++ b/src/migrate/index.ts
@@ -1,4 +1,5 @@
 import { Migrator } from "kysely";
+// is this dependency still correct?
 import { Context } from "cloudworker-router";
 import { Env } from "../types/Env";
 import migrations from "./migrations";

--- a/src/routes/tsoa/applications.ts
+++ b/src/routes/tsoa/applications.ts
@@ -15,7 +15,7 @@ import {
   Put,
 } from "@tsoa/runtime";
 import { nanoid } from "nanoid";
-
+import { RequestWithContext } from "../../types/RequestWithContext";
 import { getDb } from "../../services/db";
 import { Application } from "../../types/sql";
 import { updateClientInKV } from "../../hooks/update-client";

--- a/src/routes/tsoa/dbconnection.ts
+++ b/src/routes/tsoa/dbconnection.ts
@@ -128,7 +128,13 @@ export class DbConnectionController extends Controller {
       ctx.env.USER,
       getId(clientId, body.email),
     );
-    const profile = await user.validateEmailValidationCode.query(body.code);
+    const client = await getClient(ctx.env, clientId);
+
+    const profile = await user.validateEmailValidationCode.mutate({
+      code: body.code,
+      email: body.email,
+      tenantId: client.tenant_id,
+    });
 
     const { tenant_id, id } = profile;
     await ctx.env.data.logs.create({

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -36,7 +36,7 @@ import { headers } from "../../constants";
 import { generateAuthResponse } from "../../helpers/generate-auth-response";
 import { applyTokenResponse } from "../../helpers/apply-token-response";
 import {
-  sendCode,
+  sendLink,
   sendEmailValidation,
   sendResetPassword,
 } from "../../controllers/email";
@@ -197,7 +197,7 @@ export class LoginController extends Controller {
     magicLink.searchParams.set("email", loginState.authParams.username);
     magicLink.searchParams.set("verification_code", code);
 
-    await sendCode(env, client, params.username, code, magicLink.href);
+    await sendLink(env, client, params.username, code, magicLink.href);
 
     this.setHeader(
       headers.location,

--- a/src/routes/tsoa/userinfo.ts
+++ b/src/routes/tsoa/userinfo.ts
@@ -18,8 +18,10 @@ export class UserinfoController extends Controller {
     const db = getDb(env);
     const dbUser = await db
       .selectFrom("users")
-      // what should be happening here? state is not a key on ctx...
-      .where("users.id", "=", ctx.state.user.sub)
+      // previously this was this
+      // .where("users.id", "=", ctx.state.user.sub)
+      // this fixes typescript, but we need to test this!
+      .where("users.id", "=", ctx.var.userId)
       .selectAll()
       .executeTakeFirst();
 

--- a/src/routes/tsoa/userinfo.ts
+++ b/src/routes/tsoa/userinfo.ts
@@ -18,6 +18,7 @@ export class UserinfoController extends Controller {
     const db = getDb(env);
     const dbUser = await db
       .selectFrom("users")
+      // what should be happening here? state is not a key on ctx...
       .where("users.id", "=", ctx.state.user.sub)
       .selectAll()
       .executeTakeFirst();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2020", "DOM"],
+    "lib": [
+      "es2020",
+      "DOM"
+    ],
     "module": "ESNext",
     "target": "es2020",
     "strict": true,
@@ -24,7 +27,9 @@
       "@types/service-worker-mock"
     ],
     "paths": {
-      "*": ["node_modules/*"]
+      "*": [
+        "node_modules/*"
+      ]
     }
   },
   "include": [
@@ -32,5 +37,10 @@
     "test/**/*",
     "integration-test/test-server.ts",
     "scripts/**/*"
+  ],
+  "exclude": [
+    "build/**/*",
+    "build/routes.ts",
+    "build/*",
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "es2020",
-      "DOM"
-    ],
+    "lib": ["es2020", "DOM"],
     "module": "ESNext",
     "target": "es2020",
     "strict": true,
@@ -27,9 +24,7 @@
       "@types/service-worker-mock"
     ],
     "paths": {
-      "*": [
-        "node_modules/*"
-      ]
+      "*": ["node_modules/*"]
     }
   },
   "include": [
@@ -38,9 +33,5 @@
     "integration-test/test-server.ts",
     "scripts/**/*"
   ],
-  "exclude": [
-    "build/**/*",
-    "build/routes.ts",
-    "build/*",
-  ]
+  "exclude": ["build/**/*", "build/routes.ts", "build/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,5 @@
     "test/**/*",
     "integration-test/test-server.ts",
     "scripts/**/*"
-  ],
-  "exclude": ["build/**/*", "build/routes.ts", "build/*"]
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9565,10 +9565,10 @@ tslib@^2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tsoa-hono@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/tsoa-hono/-/tsoa-hono-1.0.9.tgz#9d3c697c89bb4d693ce616bc1e346143d4d93c93"
-  integrity sha512-Z4YwQBitwM//XxiF+2I/IWC4WfrLR1gwSmRlzjk4OC/Bp6gtgV3ATbdnHZ1KBGF0c9AC1W6C1QJPua9hzLHcJw==
+tsoa-hono@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/tsoa-hono/-/tsoa-hono-1.0.10.tgz#1ba130181dbc1c16f97350d6a2d448d10a703868"
+  integrity sha512-xGEVqgDX8XzjFtuoF7I6xUbAL4MX9nqOSvxg9v+ALeDHsE1Dk3fMRuRoZXVZ1n++85y8pWtTEtVkhvr2TF9HZw==
 
 tsoa@^5.1.1:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,13 @@ cloudflare-workers-toolkit@^0.1.0:
     form-data "^2.3.3"
     node-fetch "^2.3.0"
 
+cloudworker-router@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/cloudworker-router/-/cloudworker-router-4.1.5.tgz#c7fa8a6c40af392842d49b7ec143a13615ca8c88"
+  integrity sha512-rCG06NWL3m3KK+uRUTErtRh9Fvcb8VCmugzNCJZiBO4z5weHNixw7QQ81ABhp40b2ikvBVEK2JNrMyAEr2bwjg==
+  dependencies:
+    path-to-regexp "^6.2.1"
+
 cmd-shim@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-6.0.2.tgz#435fd9e5c95340e61715e19f90209ed6fcd9e0a4"
@@ -7963,7 +7970,7 @@ path-scurry@^1.10.1:
     lru-cache "^9.1.1 || ^10.0.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^6.2.0:
+path-to-regexp@^6.2.0, path-to-regexp@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
   integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==


### PR DESCRIPTION
Previously when I tried to run `tsc` it was flagging all kinds of files inside `node_modules`

This seems to be better now _although_ it's still looking inside the `build` folder :thinking: 

It also flags quite a few errors which seem legit!


#### Still to do
* `/userinfo` endpoint - looks like has legit type issue. I could look into how this is queried... I'm guessing that the runtime is fine but the types aren't correct
* `/build/routes.ts` - as this is imported in `app.ts`, typescript is checking it.Why is this wrong though?
*because this guy's library is wrong!* :smile:   No fear though Markus I've made a PR -> https://github.com/markusahlstrand/tsoa-hono/pull/1  :heavy_check_mark:  *these fixes are working now*