### PR TITLE
feat: use node container instead of installing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,13 +8,9 @@ on: pull_request
 jobs:
   node-test:
     runs-on: ubuntu-latest
+    container: node:18.13
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          cache: "yarn"
-          node-version: "18.13"
       - uses: actions/cache@v3
         with:
           path: "**/node_modules"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,13 +1,12 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Unit tests
 
 on: pull_request
 
 jobs:
   node-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - X64
     container: node:18.13
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I noticed the post-setup Node step was starting to take longer

I had the same issue on login2 where it started to take 8 minutes!

What's the reason to install Node in every action when we can use an pre-existing image with this version of Node :thinking: 


I got a syntax error on the penultimate commit (strange as the yaml is copied from existing projects)
So I tried using one of our runners but it just hangs

*none of this is urgent* I'll have a look another day