### PR TITLE
fix: validate url function should return true/false

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ app.use(
   "/*",
   cors({
     origin: (origin) => {
+      if (!origin) return "";
       if (!validateUrl(ALLOWED_ORIGINS, origin)) {
         throw new Error("Invalid origin");
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,10 +42,10 @@ app.use(
   cors({
     origin: (origin) => {
       if (!origin) return "";
-      if (!validateUrl(ALLOWED_ORIGINS, origin)) {
-        throw new Error("Invalid origin");
+      if (validateUrl(ALLOWED_ORIGINS, origin)) {
+        return origin;
       }
-      return origin;
+      return "";
     },
     allowHeaders: [
       "Tenant-Id",

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,10 +41,10 @@ app.use(
   "/*",
   cors({
     origin: (origin) => {
-      if (validateUrl(ALLOWED_ORIGINS, origin)) {
-        return origin;
+      if (!validateUrl(ALLOWED_ORIGINS, origin)) {
+        throw new Error("Invalid origin");
       }
-      return "";
+      return origin;
     },
     allowHeaders: [
       "Tenant-Id",

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -18,6 +18,7 @@ import { applyTokenResponse } from "../helpers/apply-token-response";
 import { InvalidConnectionError } from "../errors";
 import { validateRedirectUrl } from "../utils/validate-redirect-url";
 import { Var } from "../types/Var";
+import { HTTPException } from "hono/http-exception";
 
 export interface SocialAuthState {
   authParams: AuthParams;
@@ -102,7 +103,9 @@ export async function socialAuthCallback({
       state.authParams.redirect_uri,
     )
   ) {
-    throw new Error("Invalid redirect URI");
+    throw new HTTPException(403, {
+      message: `Invalid redirect URI - ${state.authParams.redirect_uri}`,
+    });
   }
 
   const oauth2Client = env.oauth2ClientFactory.create(

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -96,10 +96,14 @@ export async function socialAuthCallback({
     throw new Error("Redirect URI not defined");
   }
 
-  validateRedirectUrl(
-    client.allowed_callback_urls,
-    state.authParams.redirect_uri,
-  );
+  if (
+    !validateRedirectUrl(
+      client.allowed_callback_urls,
+      state.authParams.redirect_uri,
+    )
+  ) {
+    throw new Error("Invalid redirect URI");
+  }
 
   const oauth2Client = env.oauth2ClientFactory.create(
     connection,

--- a/src/routes/tsoa/authorize.ts
+++ b/src/routes/tsoa/authorize.ts
@@ -117,10 +117,14 @@ export class AuthorizeController extends Controller {
     }
 
     if (authParams.redirect_uri) {
-      validateRedirectUrl(
-        client.allowed_callback_urls,
-        authParams.redirect_uri,
-      );
+      if (
+        !validateRedirectUrl(
+          client.allowed_callback_urls,
+          authParams.redirect_uri,
+        )
+      ) {
+        throw new Error("Invalid redirect URI");
+      }
     }
 
     // Silent authentication

--- a/src/routes/tsoa/authorize.ts
+++ b/src/routes/tsoa/authorize.ts
@@ -23,6 +23,7 @@ import {
   universalAuth,
 } from "../../authentication-flows";
 import { validateRedirectUrl } from "../../utils/validate-redirect-url";
+import { HTTPException } from "hono/http-exception";
 
 export interface AuthorizeParams {
   request: RequestWithContext;
@@ -123,7 +124,9 @@ export class AuthorizeController extends Controller {
           authParams.redirect_uri,
         )
       ) {
-        throw new Error("Invalid redirect URI");
+        throw new HTTPException(400, {
+          message: `Invalid redirect URI - ${authParams.redirect_uri}`,
+        });
       }
     }
 

--- a/src/routes/tsoa/logout.ts
+++ b/src/routes/tsoa/logout.ts
@@ -12,7 +12,7 @@ import { getClient } from "../../services/clients";
 import { serializeClearCookie } from "../../services/cookies";
 import { headers } from "../../constants";
 import { validateRedirectUrl } from "../../utils/validate-redirect-url";
-
+import { HTTPException } from "hono/http-exception";
 @Route("v2/logout")
 @Tags("logout")
 export class LogoutController extends Controller {
@@ -34,7 +34,9 @@ export class LogoutController extends Controller {
     }
 
     if (!validateRedirectUrl(client.allowed_logout_urls, redirectUri)) {
-      throw new Error("Invalid logout url");
+      throw new HTTPException(403, {
+        message: `Invalid logout URI - ${redirectUri}`,
+      });
     }
 
     this.setStatus(302);

--- a/src/routes/tsoa/logout.ts
+++ b/src/routes/tsoa/logout.ts
@@ -33,7 +33,9 @@ export class LogoutController extends Controller {
       throw new Error("No return to url found");
     }
 
-    validateRedirectUrl(client.allowed_logout_urls, redirectUri);
+    if (!validateRedirectUrl(client.allowed_logout_urls, redirectUri)) {
+      throw new Error("Invalid logout url");
+    }
 
     this.setStatus(302);
     serializeClearCookie().forEach((cookie) => {

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -171,7 +171,7 @@ export class PasswordlessController extends Controller {
         user_id: id,
       });
 
-      if (validateRedirectUrl(client.allowed_callback_urls, redirect_uri)) {
+      if (!validateRedirectUrl(client.allowed_callback_urls, redirect_uri)) {
         throw new Error("Invalid redirect URI");
       }
 

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -171,7 +171,9 @@ export class PasswordlessController extends Controller {
         user_id: id,
       });
 
-      validateRedirectUrl(client.allowed_callback_urls, redirect_uri);
+      if (validateRedirectUrl(client.allowed_callback_urls, redirect_uri)) {
+        throw new Error("Invalid redirect URI");
+      }
 
       const authParams: AuthParams = {
         client_id,

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -19,7 +19,7 @@ import { validateRedirectUrl } from "../../utils/validate-redirect-url";
 import { setSilentAuthCookies } from "../../helpers/silent-auth-cookie";
 import { headers } from "../../constants";
 import { getId } from "../../models";
-
+import { HTTPException } from "hono/http-exception";
 export interface PasswordlessOptions {
   client_id: string;
   client_secret?: string;
@@ -172,7 +172,9 @@ export class PasswordlessController extends Controller {
       });
 
       if (!validateRedirectUrl(client.allowed_callback_urls, redirect_uri)) {
-        throw new Error("Invalid redirect URI");
+        throw new HTTPException(400, {
+          message: `Invalid redirect URI - ${redirect_uri}`,
+        });
       }
 
       const authParams: AuthParams = {

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -148,8 +148,7 @@ export function validateRedirectUrl(
 
 export function validateUrl(allowedUrls: string[], redirectUri?: string) {
   if (!redirectUri) {
-    // I'm not sure about this one... I'm matching existing tests
-    return false;
+    return true;
   }
 
   const matches: boolean[] = allowedUrls.map((allowedUrl) => {
@@ -157,7 +156,6 @@ export function validateUrl(allowedUrls: string[], redirectUri?: string) {
   });
 
   if (matches.some((match) => match)) {
-    // to maintain current functionality I'm returning true, or throwing an error for false
     return true;
   }
 

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -148,7 +148,8 @@ export function validateRedirectUrl(
 
 export function validateUrl(allowedUrls: string[], redirectUri?: string) {
   if (!redirectUri) {
-    return;
+    // I'm not sure about this one... I'm matching existing tests
+    return false;
   }
 
   const matches: boolean[] = allowedUrls.map((allowedUrl) => {
@@ -160,7 +161,5 @@ export function validateUrl(allowedUrls: string[], redirectUri?: string) {
     return true;
   }
 
-  throw new HTTPException(400, {
-    message: `Invalid redirectUri: ${redirectUri}`,
-  });
+  return false;
 }

--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -151,13 +151,7 @@ export function validateUrl(allowedUrls: string[], redirectUri?: string) {
     return true;
   }
 
-  const matches: boolean[] = allowedUrls.map((allowedUrl) => {
-    return matchUrlWithAllowedUrl(allowedUrl, redirectUri);
-  });
-
-  if (matches.some((match) => match)) {
-    return true;
-  }
-
-  return false;
+  return allowedUrls.some((allowedUrl) =>
+    matchUrlWithAllowedUrl(allowedUrl, redirectUri),
+  );
 }

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -121,11 +121,10 @@ describe("validateRedirectUrl", () => {
     expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  // should this throw na exception?
-  it("should return false if no redirect uri is provided", () => {
+  it("should return true if no redirect uri is provided", () => {
     const allowedUrls = ["http://foo.com"];
     const redirectUri = undefined;
-    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
   it("should throw an exception if redirectUri is no a real URL", () => {

--- a/test/utils/validate-redirect-url.spec.ts
+++ b/test/utils/validate-redirect-url.spec.ts
@@ -1,151 +1,134 @@
-import {
-  validateRedirectUrl,
-  validateUrl,
-} from "../../src/utils/validate-redirect-url";
+import { validateRedirectUrl } from "../../src/utils/validate-redirect-url";
 
-describe("validateUrl", () => {
-  it("should allow valid redirectUri with wildcard", () => {
+describe("validateRedirectUrl", () => {
+  it("should match when valid redirectUri with wildcard", () => {
     const allowedUrls = ["https://*.example.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should allow valid redirectUri with a wildcard and a path", () => {
+  it("should match when valid redirectUri with a wildcard and a path", () => {
     const allowedUrls = ["https://*.example.com/path"];
     const redirectUri = "https://sub.example.com/path";
-    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should not allow wildcard to span multiple subdomains", () => {
+  it("should not match when wildcard spans multiple subdomains", () => {
     const allowedUrls = ["https://*.example.com/path"];
     const redirectUri = "https://sub.sub.example.com/path";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should not allow domain wildcards", () => {
+  // should this throw an exception to say not allowed?
+  it("should not match with domain wildcards", () => {
     const allowedUrls = ["https://*.com"];
     const redirectUri = "https://anything.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should not allow wildcard for full URL", () => {
+  // should this throw an exception to say not allowed?
+  it("should not match wildcard for full URL", () => {
     const allowedUrls = ["https://*"];
     const redirectUri = "https://*";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
   it("should not allow bad URLs with just wildcards", () => {
     const allowedUrls = ["*"];
     const redirectUri = "*";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
+    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
   });
 
-  it("should disallow redirectUri with wildcard subdomain specified but not existing", () => {
+  it("should not match redirectUri with wildcard subdomain specified on redirect uri that odes not have this", () => {
     const allowedUrls = ["https://*.example.com"];
     const redirectUri = "https://notexample.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow(
-      "Invalid redirectUri",
-    );
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
   it("should be case insensitive", () => {
     const allowedUrls = ["https://*.EXAMPLE.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
   it("should handle URLs without wildcards", () => {
     const allowedUrls = ["https://sub.example.com"];
     const redirectUri = "https://sub.example.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should handle bad URLs without wildcards", () => {
-    const allowedUrls = ["https://sub.example.com"];
-    const redirectUri = "https://bad.example.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
-  });
-
-  it("should handle exact matches of urls with ports", () => {
+  it("should match exact on ports", () => {
     const allowedUrls = ["http://localhost:3000"];
     const redirectUri = "http://localhost:3000";
-    expect(() => validateUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
   it("should fail when no exact match of urls with ports", () => {
     const allowedUrls = ["http://localhost:3000"];
     const redirectUri = "http://localhost:3001";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should throw error for URLs that don't exactly match", () => {
+  it("should no match when subdomain is different", () => {
     const allowedUrls = ["https://sub.example.com"];
     const redirectUri = "https://sub2.example.com";
-    expect(() => validateUrl(allowedUrls, redirectUri)).toThrow(
-      "Invalid redirectUri",
-    );
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should throw if the path isn't specified", () => {
+  it("should not match if contains path", () => {
     const allowedUrls = ["https://example.com"];
     const redirectUri = "https://example.com/path";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow(
-      "Invalid redirectUri",
-    );
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should throw if the path does not match", () => {
+  it("should not match if the path is different", () => {
     const allowedUrls = ["https://example.com/foo"];
     const redirectUri = "https://example.com/bar";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow(
-      "Invalid redirectUri",
-    );
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should not accept wildcards in the path", () => {
+  it("should not match on wildcards in the path", () => {
     const allowedUrls = ["https://example.com/*"];
     const redirectUri = "https://example.com/path";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow(
-      "Invalid redirectUri",
-    );
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should should handle trailing slashes on the allowed url", () => {
+  it("should match when trailing slashes in the allowed url", () => {
     const allowedUrls = ["http://example.com"];
     const redirectUri = "http://example.com/";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should should ignore query strings", () => {
+  it("should ignore query strings", () => {
     const allowedUrls = ["http://example.com"];
     const redirectUri = "http://example.com?foo=bar";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should should ignore hash fragments", () => {
+  it("should ignore hash fragments", () => {
     const allowedUrls = ["http://example.com"];
     const redirectUri = "http://example.com#hey=ho";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  it("should match one of the URLs in the list", () => {
+  it("should match one of the URLs in the allowed list", () => {
     const allowedUrls = [
       "http://foo.com",
       "http://example.com",
       "http://bar.com",
     ];
     const redirectUri = "http://example.com";
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
   });
 
-  // these tests increase the code coverage
-  it("should return nothing if no redirect uri is provided", () => {
+  // should this throw na exception?
+  it("should return false if no redirect uri is provided", () => {
     const allowedUrls = ["http://foo.com"];
     const redirectUri = undefined;
-    expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+    expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(false);
   });
 
-  it("should only allow real URLs", () => {
+  it("should throw an exception if redirectUri is no a real URL", () => {
     const allowedUrls = ["this is not a real url"];
     const redirectUri = "this is not a real url";
     expect(() => validateRedirectUrl(allowedUrls, redirectUri)).toThrow();
@@ -155,18 +138,18 @@ describe("validateUrl", () => {
     test("example.com", () => {
       const allowedUrls = [];
       const redirectUri = "http://example.com";
-      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+      expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
     });
     test("http://localhost:3000#auth_token=foo-bar", () => {
       const allowedUrls = [];
       const redirectUri = "http://localhost:3000/sv";
-      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+      expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
     });
     test("A Vercel preview domain in Swedish", () => {
       const allowedUrls = [];
       const redirectUri =
         "https://test-test.vercel.sesamy.dev/sv/callback?auth_token=foo-bar";
-      expect(() => validateRedirectUrl(allowedUrls, redirectUri)).not.toThrow();
+      expect(validateRedirectUrl(allowedUrls, redirectUri)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This would have saved us a lot of time :smile: 


#### TODO?
Do we need some integration tests showing 
* when the origin doesn't match on a few different routes
* when the logout URL doesn't match on the logout route
* when the redirect URL doesn't match? (in the places it's used)