### PR TITLE
fix: password flow finished off here

### DIFF
--- a/src/adapters/planetscale/index.ts
+++ b/src/adapters/planetscale/index.ts
@@ -6,6 +6,7 @@ import { Env } from "../../types";
 import { createSessionsAdapter } from "./sessions";
 import { createTicketsAdapter } from "./tickets";
 import { createOTPAdapter } from "./otps";
+import { createPasswordAdapter } from "./passwords";
 
 export default function createAdapters(env: Env) {
   return {
@@ -16,5 +17,6 @@ export default function createAdapters(env: Env) {
     tickets: createTicketsAdapter(env),
     OTP: createOTPAdapter(env),
     logs: createLogsAdapter(env),
+    passwords: createPasswordAdapter(env),
   };
 }

--- a/src/migrate/migrations/2023-11-16T14:27:00_passwords-table-password.ts
+++ b/src/migrate/migrations/2023-11-16T14:27:00_passwords-table-password.ts
@@ -1,0 +1,18 @@
+import { Kysely } from "kysely";
+import { Database } from "../../types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("passwords")
+    .addColumn(
+      "password",
+      "varchar(255)",
+      // do we want not null?
+      (col) => col.notNull(),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("passwords").dropColumn("password").execute();
+}

--- a/src/migrate/migrations/index.ts
+++ b/src/migrate/migrations/index.ts
@@ -6,6 +6,7 @@ import * as m5_userProfile from "./2023-10-27T16:00:11_picture-length";
 import * as m6_sessions from "./2023-11-02T23:18:12_sessions";
 import * as m7_passwords from "./2023-11-07T23:18:12_passwords";
 import * as m8_logsTableNewFields from "./2023-11-08T17:12:09_logs-table-new-fields";
+import * as m9_passwordTableNewField from "./2023-11-16T14:27:00_passwords-table-password";
 
 // These need to be in alphabetic order
 export default {
@@ -17,4 +18,5 @@ export default {
   m6_sessions,
   m7_passwords,
   m8_logsTableNewFields,
+  m9_passwordTableNewField,
 };


### PR DESCRIPTION
~I'm going to add migrations in this PR but I'll run them on a different planetscale branch~


~If we're going to run them on dev then I figure I should move the migration script into a branch going straight to `main` so we don't end up with migration conflict hell~ :smile: 

~*then* on this branch I can manually add my test passwords~

I just ran the migrations on planetscale dev so (as commented) if they're not ok, let me know!

----------------------

This is it working! 

On auth2 I suffix the passwords with `-auth2` to make sure we don't get false positives, that's why the first login *correctly* fails :+1: 

[Screencast from 2023-11-16 19-28-39.webm](https://github.com/sesamyab/auth/assets/8496063/346729df-818f-40a7-b2eb-6d8a688e035f)
