### PR TITLE
feat: first thoughts on returning current profile inside identities

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -61,21 +61,39 @@ export class UsersMgmtController extends Controller {
     });
 
     const users: UserResponse[] = result.users.map((user) => {
-      const identities = [];
-
       return {
         ...user,
-        user_id: user.id,
+        // this matches the auth0 spec for the top level user_id - BUT we need to remove the provider prefix in the database
+        user_id: `${user.provider}|${user.id}`,
         logins_count: 0,
         last_ip: "",
         last_login: "",
-        identities,
         // some fields copied from previous adapter/planetscale/list mapping
         // TODO: store this field in sql
         email_verified: true,
         username: user.email,
         phone_number: "",
         phone_verified: false,
+        identities: [
+          {
+            connection: user.connection,
+            provider: user.provider,
+            //
+            user_id: user.id,
+            isSocial: false,
+            profileData: {
+              email: user.email,
+              email_verified: true,
+              name: user.name,
+              username: user.email,
+              given_name: "",
+              phone_number: "",
+              phone_verified: false,
+              family_name: "",
+            },
+          },
+          // TODO - get other identies from db
+        ],
       };
     });
 
@@ -113,8 +131,27 @@ export class UsersMgmtController extends Controller {
       // TODO: Default value. Patch all users to have this value
       logins_count: 0,
       ...userWithoutId,
-      identities: [],
       user_id: user.id,
+      identities: [
+        {
+          // duplicated from GET above
+          connection: user.connection,
+          provider: user.provider,
+          //
+          user_id: user.id,
+          isSocial: false,
+          profileData: {
+            email: user.email,
+            email_verified: true,
+            name: user.name,
+            username: user.email,
+            given_name: "",
+            phone_number: "",
+            phone_verified: false,
+            family_name: "",
+          },
+        },
+      ],
     };
   }
 

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -210,11 +210,29 @@ export class UsersMgmtController extends Controller {
     this.setStatus(201);
     const userResponse: UserResponse = {
       ...data,
-      user_id: data.id,
+      user_id: `${data.provider}|${data.id}`,
       logins_count: 0,
       last_ip: "",
       last_login: "",
-      identities: [],
+      identities: [
+        {
+          connection: data.connection,
+          provider: data.provider,
+          //
+          user_id: data.id,
+          isSocial: false,
+          profileData: {
+            email: data.email,
+            email_verified: true,
+            name: data.name,
+            username: data.email,
+            given_name: "",
+            phone_number: "",
+            phone_verified: false,
+            family_name: "",
+          },
+        },
+      ],
     };
 
     return userResponse;


### PR DESCRIPTION
@markusahlstrand you might already have started this so just delete if so, but I'd thought I'd at least make a start by nesting the current main identity inside identities 

*also* the `user_id` at the top level is a concatenation of `provider` and `user_id` (like on Auth0)

So on planetscale we would need to remove everything before the pipe `|` in the `id` column

and other things of coures. prefill provider 