### PR TITLE
fix: correctly write profile data

### DIFF
--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -124,12 +124,12 @@ export async function socialAuthCallback({
   ctx.set("email", email);
   ctx.set("userId", user.id);
 
+  const idToken = parseJwt(token.id_token!);
+
+  const { iss, azp, aud, at_hash, iat, exp, ...profileData } = idToken;
+
   await env.data.users.update(client.tenant_id, ctx.get("userId"), {
-    // DG: we defintiely don't want to store this but I'm doing this temp just to investigate!
-    profileData: JSON.stringify({
-      id_token: token.id_token,
-      access_token: token.access_token,
-    }),
+    profileData: JSON.stringify(profileData),
   });
 
   await env.data.logs.create({

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -126,7 +126,7 @@ export async function socialAuthCallback({
 
   const idToken = parseJwt(token.id_token!);
 
-  const { iss, azp, aud, at_hash, iat, exp, ...profileData } = idToken;
+  const { iss, azp, aud, at_hash, iat, exp, sub, hd, ...profileData } = idToken;
 
   await env.data.users.update(client.tenant_id, ctx.get("userId"), {
     profileData: JSON.stringify(profileData),

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -83,7 +83,6 @@ export async function socialAuthCallback({
 }: socialAuthCallbackParams) {
   const { env } = ctx;
   const client = await getClient(env, state.authParams.client_id);
-
   const connection = client.connections.find(
     (p) => p.name === state.connection,
   );
@@ -113,15 +112,8 @@ export async function socialAuthCallback({
   );
 
   const token = await oauth2Client.exchangeCodeForTokenResponse(code);
-  const oauth2Profile = parseJwt(token.id_token!);
 
-  await env.data.users.update(client.tenant_id, ctx.get("userId"), {
-    // DG: we defintiely don't want to store this but I'm doing this temp just to investigate!
-    profileData: JSON.stringify({
-      id_token: token.id_token,
-      access_token: token.access_token,
-    }),
-  });
+  const oauth2Profile = parseJwt(token.id_token!);
 
   const email = oauth2Profile.email.toLocaleLowerCase();
   const user = await env.data.users.getByEmail(client.tenant_id, email);
@@ -131,6 +123,14 @@ export async function socialAuthCallback({
 
   ctx.set("email", email);
   ctx.set("userId", user.id);
+
+  await env.data.users.update(client.tenant_id, ctx.get("userId"), {
+    // DG: we defintiely don't want to store this but I'm doing this temp just to investigate!
+    profileData: JSON.stringify({
+      id_token: token.id_token,
+      access_token: token.access_token,
+    }),
+  });
 
   await env.data.logs.create({
     category: "login",


### PR DESCRIPTION
Fixed by pushing straight to dev

We probably don't want to keep persisting tokens so I'll keep investigating now

#### What I need
* `sub` or some unique ID: check these against Auth0
  * google :heavy_check_mark: 
  * apple
  * facebook
* `profileData` fields

Examples from Auth0

Looking at Auth0 mgmt API results

All seem to have
```
    email: "markus@ahlstrand.de",
    email_verified: true
```

And some have other fields, quite different ones! (I'm assuming unique to each provider)

Google id_token - minus the comment id_token fields `iss`, `azp`, `aud`, `at_hash`, `iat`, `exp`

I think we could remove these fields and then write the rest
```
{
  "iss": "https://accounts.google.com",
  "azp": "195867377305-j00komjaq7etk3ua9oab69klhlli4uk7.apps.googleusercontent.com",
  "aud": "195867377305-j00komjaq7etk3ua9oab69klhlli4uk7.apps.googleusercontent.com",
  "sub": "118350953091353068895",
  "hd": "sesamy.com",
  "email": "dan@sesamy.com",
  "email_verified": true,
  "at_hash": "B0KVPpE3dCYpr-q2HSiPdQ",
  "name": "Daniel Gent",
  "picture": "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
  "given_name": "Daniel",
  "family_name": "Gent",
  "locale": "en-GB",
  "iat": 1700767757,
  "exp": 1700771357
}
```
