### PR TITLE
fix: strip out more fields from facebook id_token

### DIFF
--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -151,7 +151,19 @@ export async function socialAuthCallback({
 
   const idToken = parseJwt(token.id_token!);
 
-  const { iss, azp, aud, at_hash, iat, exp, sub, hd, ...profileData } = idToken;
+  const {
+    iss,
+    azp,
+    aud,
+    at_hash,
+    iat,
+    exp,
+    sub,
+    hd,
+    jti,
+    nonce,
+    ...profileData
+  } = idToken;
 
   await env.data.users.update(client.tenant_id, ctx.get("userId"), {
     profileData: JSON.stringify(profileData),


### PR DESCRIPTION
Cleans up what we write to `profileData` on FB