### PR TITLE
fix: pluck more keys from apple id_token

### DIFF
--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -162,6 +162,8 @@ export async function socialAuthCallback({
     hd,
     jti,
     nonce,
+    auth_time,
+    nonce_supported,
     ...profileData
   } = idToken;
 


### PR DESCRIPTION
See my latest comment on the linked ticket if you want

Now Apple SSO is working :+1: 

Try `select * from users where profileData is not null;` in planetscale-dev and you'll see these new SSO users being created :muscle: 