### PR TITLE
test: mock nanoid in just one place

### DIFF
--- a/__mocks__/nanoid.ts
+++ b/__mocks__/nanoid.ts
@@ -1,4 +1,5 @@
 // Nanois is a mess with esm an modules..
 module.exports = {
   nanoid: () => "testid",
+  customAlphabet: () => () => "testid",
 };

--- a/test/authentication-flows/ticket.spec.ts
+++ b/test/authentication-flows/ticket.spec.ts
@@ -8,14 +8,6 @@ import {
 } from "../../src/types";
 import { parseJwt } from "../../src/utils/parse-jwt";
 
-// nanoid blows up in Jest when try to import customAlphabet...
-jest.mock("nanoid", () => {
-  return {
-    customAlphabet: () => () => "testid",
-    nanoid: () => "testid",
-  };
-});
-
 describe("passwordlessAuth", () => {
   const date = new Date();
 

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -13,14 +13,6 @@ import { Session } from "../../../src/types/Session";
 import { Ticket } from "../../../src/types/Ticket";
 import { testUser } from "../../fixtures/user";
 
-// nanoid blows up in Jest when try to import customAlphabet...
-jest.mock("nanoid", () => {
-  return {
-    customAlphabet: () => () => "testid",
-    nanoid: () => "testid",
-  };
-});
-
 describe("authorize", () => {
   const date = new Date();
 

--- a/test/utils/userIdGenerate.spec.ts
+++ b/test/utils/userIdGenerate.spec.ts
@@ -1,6 +1,7 @@
 import userIdGenerate from "../../src/utils/userIdGenerate";
 
-// nanoid cannot be imported... maybe just on tests
+// this test makes no sense as the util function is just calling nanoid
+// and we have to mock nanoid due to esm issues
 describe.skip("userIdGenerate", () => {
   it("should return a 24 character long string", () => {
     const result = userIdGenerate();


### PR DESCRIPTION
I was doing this inline the test suites _but_ I should have added this to the existing nanoid `__mock__`