### PR TITLE
fix: use client_id from request not from session state

### DIFF
--- a/src/authentication-flows/silent.ts
+++ b/src/authentication-flows/silent.ts
@@ -19,6 +19,7 @@ export interface SilentAuthParams {
   redirect_uri: string;
   state: string;
   response_type: AuthorizationResponseType;
+  client_id: string;
   nonce?: string;
   code_challenge_method?: CodeChallengeMethod;
   code_challenge?: string;
@@ -35,6 +36,7 @@ export async function silentAuth({
   state,
   nonce,
   response_type,
+  client_id,
   code_challenge_method,
   code_challenge,
   audience,
@@ -64,7 +66,7 @@ export async function silentAuth({
           nonce,
           userId: session.user_id,
           authParams: {
-            client_id: session.client_id,
+            client_id,
             audience,
             code_challenge_method,
             code_challenge,

--- a/src/routes/tsoa/authorize.ts
+++ b/src/routes/tsoa/authorize.ts
@@ -143,6 +143,7 @@ export class AuthorizeController extends Controller {
         redirect_uri,
         state,
         response_type,
+        client_id,
         nonce,
         code_challenge_method,
         code_challenge,


### PR DESCRIPTION
This will fix a *lot* of the errors we're getting on datadog

The `aud` in the `id_token` has to match the `client_id` else auth0.js gives an error

This also matches what happens with auth0.  Happy to demo this demo app further

Logging in is done per auth0 tenant. Logging in on one logs in on others. Logging out on one logs out on them all

[Screencast from 2023-11-27 12-17-47.webm](https://github.com/sesamyab/auth/assets/8496063/0a8540b2-aa6e-4f9d-8022-078b5b1a43b8)

We could investigate further what happens when different scopes are requested, but I think this is good for now :+1: 
