### PR TITLE
test: skip datadog if in test environment

### DIFF
--- a/src/services/datadog.ts
+++ b/src/services/datadog.ts
@@ -17,6 +17,11 @@ async function log(
   response: Response,
   message?: string,
 ) {
+  // we know we're in a test environment if we have this
+  if (ctx.env.ISSUER.includes("example.com")) {
+    return;
+  }
+
   const ddApiKey = ctx.env.DD_API_KEY;
 
   if (!ddApiKey?.length) {

--- a/src/services/datadog.ts
+++ b/src/services/datadog.ts
@@ -17,8 +17,11 @@ async function log(
   response: Response,
   message?: string,
 ) {
-  // we know we're in a test environment if we have this
-  if (ctx.env.ISSUER.includes("example.com")) {
+  const { req } = ctx;
+  const hostname = req.header("host") || "";
+
+  // on integration tests I see the host as the loopback address witha  different port everytime
+  if (hostname.includes("127.0.0.1")) {
     return;
   }
 
@@ -31,9 +34,6 @@ async function log(
 
   // Get our key from secrets
   const dd_logsEndpoint = "https://http-intake.logs.datadoghq.eu/api/v2/logs";
-
-  const { req } = ctx;
-  const hostname = req.header("host") || "";
   const headers = instanceToJson(ctx.req.raw.headers);
 
   if (headers.cookie) {


### PR DESCRIPTION
Currently on our integration tests we get spammed by our console log informing us there's no datadog key :smile: 

This fixes that!