### PR TITLE
fix: when deleting a primary account, also delete linked accounts

### DIFF
--- a/migrate/migrations/2022-12-11T09:17:35_init.ts
+++ b/migrate/migrations/2022-12-11T09:17:35_init.ts
@@ -47,7 +47,8 @@ export async function up(db: Kysely<Database>): Promise<void> {
       ["linked_to", "tenant_id"],
       "users",
       ["id", "tenant_id"],
-      (cb) => cb.onDelete("cascade"),
+      // planetscale doesn't support FKs so we shouldn't rely on cascades!
+      // (cb) => cb.onDelete("cascade"),
     )
     .addColumn("last_ip", "varchar(255)")
     .addColumn("login_count", "integer")

--- a/src/adapters/kysely/users/remove.ts
+++ b/src/adapters/kysely/users/remove.ts
@@ -3,6 +3,14 @@ import { Database } from "../../../types";
 
 export function remove(db: Kysely<Database>) {
   return async (tenant_id: string, id: string): Promise<boolean> => {
+    // Planetscale has no cascading delete as it has no FK
+    // so we manually remove any users first that have linked_to set to this id!
+    await db
+      .deleteFrom("users")
+      .where("users.tenant_id", "=", tenant_id)
+      .where("users.linked_to", "=", id)
+      .execute();
+
     const results = await db
       .deleteFrom("users")
       .where("users.tenant_id", "=", tenant_id)

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -309,6 +309,9 @@ describe("users", () => {
     });
 
     expect(usersNowDeleted.length).toBe(1);
+
+    expect(usersNowDeleted[0].id).not.toBe(newUser1.id);
+    expect(usersNowDeleted[0].id).not.toBe(newUser2.id);
   });
 
   it("should lowercase email when creating a  user", async () => {


### PR DESCRIPTION
I think this is ready to go *BUT* currrently it's kind of already working as linked accounts don't appear when listing users... (they also shouldn't be searchable, which is something else we could fix)

I would like to actually confirm this by using Auth0 mgmt API