### PR TITLE
test: silent auth across different clients and tenants

### DIFF
--- a/integration-test/flows/silent-auth.spec.ts
+++ b/integration-test/flows/silent-auth.spec.ts
@@ -1,5 +1,6 @@
 import { setup } from "../helpers/setup";
 import { start } from "../start";
+import { parseJwt } from "../../src/utils/parse-jwt";
 
 describe("silent-auth", () => {
   let worker;
@@ -26,5 +27,143 @@ describe("silent-auth", () => {
 
   // this is tested in code-flow.spec.ts. which makes sense for integration tests
   // and to do this skipped test would require that entire test as setup
-  it.todo("should return a 200 for a valid silent auth request");
+  it.only("should return a 200 for a valid silent auth request", async () => {
+    const loginResponse = await worker.fetch("/co/authenticate", {
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+      // this user already created when seeding db
+      body: JSON.stringify({
+        client_id: "clientId",
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: "Username-Password-Authentication",
+        password: "Test!",
+        username: "foo@example.com",
+      }),
+    });
+
+    expect(loginResponse.status).toBe(200);
+
+    const { login_ticket } = await loginResponse.json();
+
+    const query = new URLSearchParams({
+      auth0client: "eyJuYW1lIjoiYXV0aDAuanMiLCJ2ZXJzaW9uIjoiOS4yMy4wIn0=",
+      client_id: "clientId",
+      login_ticket,
+      referrer: "https://login.example.com",
+      response_type: "token id_token",
+      redirect_uri: "http://login.example.com",
+      state: "state",
+    });
+
+    // Trade the ticket for token
+    const tokenResponse = await worker.fetch(`/authorize?${query.toString()}`, {
+      redirect: "manual",
+    });
+
+    expect(tokenResponse.status).toBe(302);
+    expect(await tokenResponse.text()).toBe("Redirecting");
+
+    const location = tokenResponse.headers.get("location");
+    const redirectUri = new URL(location);
+
+    expect(redirectUri.hostname).toBe("login.example.com");
+    expect(redirectUri.searchParams.get("state")).toBe("state");
+
+    const accessToken = redirectUri.searchParams.get("access_token");
+
+    const accessTokenPayload = parseJwt(accessToken!);
+    expect(accessTokenPayload.aud).toBe("default");
+    expect(accessTokenPayload.iss).toBe("https://example.com/");
+    expect(accessTokenPayload.scope).toBe("");
+
+    const idToken = redirectUri.searchParams.get("id_token");
+    const idTokenPayload = parseJwt(idToken!);
+    expect(idTokenPayload.email).toBe("foo@example.com");
+    expect(idTokenPayload.aud).toBe("clientId");
+
+    // now check silent auth works
+    const cookies = tokenResponse.headers
+      .get("set-cookie")
+      .split(";")
+      .map((c) => c.trim());
+    const authCookie = cookies.find((c) => c.startsWith("auth-token"));
+
+    const silentAuthSearchParams = new URLSearchParams();
+    silentAuthSearchParams.set("client_id", "clientId");
+    silentAuthSearchParams.set("response_type", "token id_token");
+    silentAuthSearchParams.set("scope", "openid profile email");
+    silentAuthSearchParams.set(
+      "redirect_uri",
+      "http://localhost:3000/callback",
+    );
+    silentAuthSearchParams.set("state", "state");
+    // silent auth pararms!
+    silentAuthSearchParams.set("prompt", "none");
+    silentAuthSearchParams.set("nonce", "unique-nonce");
+    silentAuthSearchParams.set("response_mode", "web_message");
+
+    const silentAuthResponse = await worker.fetch(
+      `/authorize?${silentAuthSearchParams.toString()}`,
+      {
+        headers: {
+          // here we set the auth cookie given to us from the previous successful auth request
+          cookie: authCookie,
+        },
+      },
+    );
+
+    const body = await silentAuthResponse.text();
+
+    expect(body).not.toContain("Login required");
+    expect(body).toContain("access_token");
+    // this is tested more extensively on other flows
+
+    // Silent auth same tenant different client ------------------
+    const silentAuthSearchParamsDifferentClient = new URLSearchParams();
+    silentAuthSearchParamsDifferentClient.set("client_id", "otherClientId");
+    silentAuthSearchParamsDifferentClient.set(
+      "response_type",
+      "token id_token",
+    );
+    silentAuthSearchParamsDifferentClient.set("scope", "openid profile email");
+    silentAuthSearchParamsDifferentClient.set(
+      "redirect_uri",
+      "http://localhost:3000/callback",
+    );
+    silentAuthSearchParamsDifferentClient.set("state", "state");
+    // silent auth pararms!
+    silentAuthSearchParamsDifferentClient.set("prompt", "none");
+    silentAuthSearchParamsDifferentClient.set("nonce", "unique-nonce");
+    silentAuthSearchParamsDifferentClient.set("response_mode", "web_message");
+
+    const silentAuthResponseDifferentClient = await worker.fetch(
+      `/authorize?${silentAuthSearchParamsDifferentClient.toString()}`,
+      {
+        headers: {
+          // here we set the auth cookie given to us from the previous successful auth request
+          cookie: authCookie,
+        },
+      },
+    );
+
+    const bodyDifferentClient = await silentAuthResponseDifferentClient.text();
+
+    expect(bodyDifferentClient).not.toContain("Login required");
+    expect(bodyDifferentClient).toContain("access_token");
+
+    // silent auth different tenant -------------------
+  });
 });
+
+// what's the quickest way to log in to one client, and then check silent auth with another client?
+// same and different tenants
+
+// SO NEED
+// a. another user in the same tenant, different client
+// b. another user in a different tenant, different client
+
+// THEN
+// what is the quickest way to log in here? Just check tests and pick fam... probably username/password
+// BUT run the risk... that only testing one flow? really should duplicate to each flow? meh... I don't know. leave comments

--- a/integration-test/flows/silent-auth.spec.ts
+++ b/integration-test/flows/silent-auth.spec.ts
@@ -25,7 +25,7 @@ describe("silent-auth", () => {
     expect(body).toContain("Login required");
   });
 
-  it("should return a 200 for a valid silent auth request", async () => {
+  it("should return a 200 for a valid silent auth request from the same client, same tenant, but not a different tenant", async () => {
     const loginResponse = await worker.fetch("/co/authenticate", {
       headers: {
         "content-type": "application/json",
@@ -81,7 +81,9 @@ describe("silent-auth", () => {
     expect(idTokenPayload.email).toBe("foo@example.com");
     expect(idTokenPayload.aud).toBe("clientId");
 
-    // now check silent auth works
+    // -------------------------------------------------------------
+    // now check silent auth works on the same client
+    // -------------------------------------------------------------
     const cookies = tokenResponse.headers
       .get("set-cookie")
       .split(";")
@@ -118,7 +120,9 @@ describe("silent-auth", () => {
     expect(body).toContain("access_token");
     // this is tested more extensively on other flows
 
-    // Silent auth same tenant different client ------------------
+    // -------------------------------------------------------------
+    // now check silent auth works on the same tenant
+    // -------------------------------------------------------------
     const silentAuthSearchParamsDifferentClient = new URLSearchParams();
     silentAuthSearchParamsDifferentClient.set("client_id", "otherClientId");
     silentAuthSearchParamsDifferentClient.set(
@@ -151,7 +155,9 @@ describe("silent-auth", () => {
     expect(bodyDifferentClient).not.toContain("Login required");
     expect(bodyDifferentClient).toContain("access_token");
 
-    // silent auth different tenant -------------------
+    // -------------------------------------------------------------
+    // now check silent auth does not on a different tenant
+    // -------------------------------------------------------------
     const silentAuthSearchParamsDifferentTenant = new URLSearchParams();
     silentAuthSearchParamsDifferentTenant.set(
       "client_id",

--- a/integration-test/helpers/setup.ts
+++ b/integration-test/helpers/setup.ts
@@ -1,4 +1,3 @@
-import exp from "constants";
 import { getAdminToken } from "./token";
 
 export async function setup(worker: any) {
@@ -21,6 +20,28 @@ export async function setup(worker: any) {
   if (createTenantResponse.status !== 201) {
     throw new Error(
       `Setup: Failed to create tenant: ${await createTenantResponse.text()}`,
+    );
+  }
+
+  // TODO - why not move all this into test-server.ts?
+  const createOtherTenantResponse = await worker.fetch("/api/v2/tenants", {
+    method: "POST",
+    body: JSON.stringify({
+      name: "otherTenant",
+      // change these!
+      audience: "test",
+      sender_name: "test",
+      sender_email: "test@example.com",
+    }),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+  });
+
+  if (createOtherTenantResponse.status !== 201) {
+    throw new Error(
+      `Setup: Failed to create other tenant: ${await createTenantResponse.text()}`,
     );
   }
 

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -17,8 +17,7 @@ data.clients.create({
   name: "Test Client",
   connections: [],
   domains: [],
-  // this isn't actually seeded to the tenants table right? not needed
-  // as this DO is actually a cache joining clients, tenants and connections
+  // this ID is not seeded to the tenants data adapter
   tenant_id: "tenantId",
   allowed_callback_urls: ["https://login.example.com/sv/callback"],
   allowed_logout_urls: [],

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -17,7 +17,45 @@ data.clients.create({
   name: "Test Client",
   connections: [],
   domains: [],
+  // this isn't actually seeded to the tenants table right? not needed
+  // as this DO is actually a cache joining clients, tenants and connections
   tenant_id: "tenantId",
+  allowed_callback_urls: ["https://login.example.com/sv/callback"],
+  allowed_logout_urls: [],
+  allowed_web_origins: [],
+  email_validation: "enforced",
+  client_secret: "XjI8-WPndjtNHDu4ybXrD",
+  tenant: {
+    audience: "https://example.com",
+    sender_email: "login@example.com",
+    sender_name: "SenderName",
+  },
+});
+
+data.clients.create({
+  id: "otherClientId",
+  name: "Test Client",
+  connections: [],
+  domains: [],
+  tenant_id: "tenantId",
+  allowed_callback_urls: ["https://login.example.com/sv/callback"],
+  allowed_logout_urls: [],
+  allowed_web_origins: [],
+  email_validation: "enforced",
+  client_secret: "XjI8-WPndjtNHDu4ybXrD",
+  tenant: {
+    audience: "https://example.com",
+    sender_email: "login@example.com",
+    sender_name: "SenderName",
+  },
+});
+
+data.clients.create({
+  id: "otherClientIdOnOtherTenant",
+  name: "Test Client",
+  connections: [],
+  domains: [],
+  tenant_id: "otherTenant",
   allowed_callback_urls: ["https://login.example.com/sv/callback"],
   allowed_logout_urls: [],
   allowed_web_origins: [],


### PR DESCRIPTION
We've had this regression a few times and it seems more sensible to do it extensively here on integration tests than login2 :sunglasses: 

It is sort of already done there but I can be sure of all the use cases here