### PR TITLE
fix: code emails final fixes

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,6 +1,6 @@
 export const en = {
   // common
-  welcometoYourAccount: "Welcome to your {{vendorName}} account!",
+  welcomeToYourAccount: "Welcome to your {{vendorName}} account!",
   contactUs: "Contact us",
   copyright: "Copyright © 2023 SESAMY. All rights reserved.",
   codeValid30Mins: "The code is valid for 30 minutes",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,6 @@
-export const en = {
+import type { locale } from "./type";
+
+export const en: locale = {
   // common
   welcomeToYourAccount: "Welcome to your {{vendorName}} account!",
   contactUs: "Contact us",

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -10,7 +10,7 @@ export const sv: locale = {
     "Om du har frågor eller behöver assistans kan du kontakta vårt supportteam",
   // code email
   codeEmailTitle:
-    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in", // this one is missing WHY
+    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
   codeEmailEnterCode:
     "Skriv in koden på {{vendorName}} för att slutföra inloggningen.",
   // link email

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -10,7 +10,7 @@ export const sv = {
   codeEmailTitle:
     "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
   codeEmailEnterCode:
-    "Skriv in koden på {{vendorName}} för att slutföra inloggningen",
+    "Skriv in koden på {{vendorName}} för att slutföra inloggningen.",
   // link email
   linkEmailClickToLogin: "Klicka på knappen för att logga in",
   linkEmailLogin: "Logga in",

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -1,4 +1,6 @@
-export const sv = {
+import type { locale } from "./type";
+
+export const sv: locale = {
   // common
   welcomeToYourAccount: "Välkommen till ditt {{vendorName}}-konto!",
   contactUs: "Kontakta oss",
@@ -8,7 +10,7 @@ export const sv = {
     "Om du har frågor eller behöver assistans kan du kontakta vårt supportteam",
   // code email
   codeEmailTitle:
-    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
+    "Välkommen till {{vendorName}}! {{code}} är koden för att logga in", // this one is missing WHY
   codeEmailEnterCode:
     "Skriv in koden på {{vendorName}} för att slutföra inloggningen.",
   // link email

--- a/src/locales/type.ts
+++ b/src/locales/type.ts
@@ -1,0 +1,13 @@
+export type locale = {
+  welcomeToYourAccount: string;
+  contactUs: string;
+  copyright: string;
+  codeValid30Mins: string;
+  supportInfo: string;
+  codeEmailTitle: string;
+  codeEmailEnterCode: string;
+  linkEmailClickToLogin: string;
+  linkEmailLogin: string;
+  linkEmailOrEnterCode: string;
+  passwordResetTitle: string;
+};


### PR DESCRIPTION
Fixes
* login2 email snapshots failing because of a fullstop I removed :smile:   (what a spot) :heavy_check_mark: 
* english emails lacking header: :heavy_check_mark: 


This PR is snapshot tested by https://github.com/sesamyab/login2/pull/474 _(this is the last I'll push to auth2 dev)_
