### PR TITLE
feat: getUsersByEmail endpoint is plural

### DIFF
--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -60,6 +60,33 @@ describe("users by email", () => {
     );
 
     expect(response.status).toBe(200);
+
+    const users = (await response.json()) as UserResponse[];
+
+    expect(users.length).toBe(1);
+
+    expect(users[0]).toMatchObject({
+      email: "foo@example.com",
+      email_verified: true,
+      name: "Foo Bar",
+      nickname: "Foo",
+      picture: "https://example.com/foo.png",
+      tenant_id: "tenantId",
+      login_count: 0,
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      user_id: "userId",
+    });
+
+    expect(users[0].identities).toMatchObject([
+      {
+        connection: "email",
+        provider: "email",
+        user_id: "userId",
+        isSocial: false,
+      },
+    ]);
   });
 
   /* 

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -81,7 +81,7 @@ describe("users by email", () => {
       user_id: "userId",
     });
 
-    expect(users[0].identities).toMatchObject([
+    expect(users[0].identities).toEqual([
       {
         connection: "email",
         provider: "email",
@@ -141,7 +141,7 @@ describe("users by email", () => {
       is_social: false,
       user_id: "userId",
     });
-    expect(users[0].identities).toMatchObject([
+    expect(users[0].identities).toEqual([
       {
         connection: "email",
         provider: "email",

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -283,22 +283,4 @@ describe("users by email", () => {
     // ALSO TO TEST
     // - unlink accounts
   });
-
-  /* 
-  TO TEST
-  * a primary account with multiple linked accounts - some on different email addresses
-  // HOW? kiss. Do same test really as previous but create x2 new users WITH DIFFERENT EMAIL ADDRESSES!
-  // store ids of each of these new users
-  // THEN
-  // call /link endpoint on both to link them - kind of a test of linking... hmmmm
-  // -------- would be better to have these in fixtures? meh. OVERTEST FOR NOW! worry later-------
-  // getUserByEmail - call again
-  // expect to get back ONE user
-  // with other user in identities
-   
-  
-  TO INVESTIGATE
-  * what happens when search for an email address on a linked account?
-  Test this out on Auth0 mgmt API!
-  */
 });

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -90,7 +90,7 @@ describe("users by email", () => {
     ]);
   });
 
-  it.skip("should return multiple users for a simple get by email - no linked accounts", async () => {
+  it("should return multiple users for a simple get by email - no linked accounts", async () => {
     const token = await getAdminToken();
 
     // duplicate existing email foo@example.com for provider: 'username - password'

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -137,7 +137,7 @@ describe("users by email", () => {
     const users = (await response.json()) as UserResponse[];
 
     // Nice! this POST endpoint just duplicates the user anyway  8-)
-    // expect(users.length).toBe(2);
+    expect(users.length).toBe(2);
 
     // Cannot test this until we have a way to duplicate users...
     // TODO - investigate POST to Auth0 mgmt API/users

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -117,9 +117,6 @@ describe("users by email", () => {
       (await createDuplicateUserResponse.json()) as UserResponse;
     expect(newDuplicateUser.email).toBe("foo@example.com");
 
-    // user id here should be different to existing user id for foo@example.com
-    console.log(newDuplicateUser.user_id);
-
     expect(createDuplicateUserResponse.status).toBe(201);
 
     const response = await worker.fetch(
@@ -136,11 +133,38 @@ describe("users by email", () => {
 
     const users = (await response.json()) as UserResponse[];
 
-    // Nice! this POST endpoint just duplicates the user anyway  8-)
     expect(users.length).toBe(2);
 
-    // Cannot test this until we have a way to duplicate users...
-    // TODO - investigate POST to Auth0 mgmt API/users
+    expect(users[0]).toMatchObject({
+      email: "foo@example.com",
+      email_verified: true,
+      name: "Foo Bar",
+      nickname: "Foo",
+      picture: "https://example.com/foo.png",
+      tenant_id: "tenantId",
+      login_count: 0,
+      provider: "email",
+      connection: "email",
+      is_social: false,
+      user_id: "userId",
+    });
+    expect(users[0].identities).toMatchObject([
+      {
+        connection: "email",
+        provider: "email",
+        user_id: "userId",
+        isSocial: false,
+      },
+    ]);
+    expect(users[1]).toMatchObject({
+      email: "foo@example.com",
+      tenant_id: "tenantId",
+      name: "foo@example.com",
+      provider: "email",
+      connection: "email",
+      email_verified: false,
+      is_social: false,
+    });
   });
 
   /* 

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -45,4 +45,16 @@ describe("users by email", () => {
 
     expect(response.status).toBe(404);
   });
+
+  /* 
+  TO TEST
+  * simple get by email - no linked accounts
+  * multiple simple primary not linked accounts
+  * a primary account with multiple linked accounts - some on different email addresses
+   
+  
+  TO INVESTIGATE
+  * what happens when search for an email address on a linked account?
+  Test this out on Auth0 mgmt API!
+  */
 });

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -2,6 +2,7 @@ import { UserResponse } from "../../src/types/auth0";
 import { getAdminToken } from "../helpers/token";
 import { start } from "../start";
 import type { UnstableDevWorker } from "wrangler";
+import { setup } from "../helpers/setup";
 
 describe("users by email", () => {
   let worker: UnstableDevWorker;
@@ -89,9 +90,61 @@ describe("users by email", () => {
     ]);
   });
 
+  it.skip("should return multiple users for a simple get by email - no linked accounts", async () => {
+    const token = await getAdminToken();
+
+    // duplicate existing email foo@example.com for provider: 'username - password'
+    // This assumes the POST endpoint doesn't do automatic account linking...
+    // would be better if we could initialise the database with multiple accounts...
+    // and different on different test runs... TBD another time
+    const createDuplicateUserResponse = await worker.fetch("/api/v2/users", {
+      method: "POST",
+      body: JSON.stringify({
+        email: "foo@example.com",
+        connection: "Username-Password-Authentication",
+        // seems odd that this isn't allowed... I think this endpoint needs looking at
+        // maybe it's good we have to use the mgmt API for our test fixtures
+        // provider: "auth2",
+      }),
+      headers: {
+        authorization: `Bearer ${token}`,
+        "tenant-id": "tenantId",
+        "content-type": "application/json",
+      },
+    });
+
+    const newDuplicateUser =
+      (await createDuplicateUserResponse.json()) as UserResponse;
+    expect(newDuplicateUser.email).toBe("foo@example.com");
+
+    // user id here should be different to existing user id for foo@example.com
+    console.log(newDuplicateUser.user_id);
+
+    expect(createDuplicateUserResponse.status).toBe(201);
+
+    const response = await worker.fetch(
+      `/api/v2/users-by-email?email=${encodeURIComponent("foo@example.com")}`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const users = (await response.json()) as UserResponse[];
+
+    // Nice! this POST endpoint just duplicates the user anyway  8-)
+    // expect(users.length).toBe(2);
+
+    // Cannot test this until we have a way to duplicate users...
+    // TODO - investigate POST to Auth0 mgmt API/users
+  });
+
   /* 
   TO TEST
-  * multiple simple primary not linked accounts
   * a primary account with multiple linked accounts - some on different email addresses
    
   

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -1,0 +1,48 @@
+import { UserResponse } from "../../src/types/auth0";
+import { getAdminToken } from "../helpers/token";
+import { start } from "../start";
+import type { UnstableDevWorker } from "wrangler";
+
+describe("users by email", () => {
+  let worker: UnstableDevWorker;
+  let token;
+
+  beforeEach(async () => {
+    worker = await start();
+
+    token = await getAdminToken();
+    await worker.fetch("/api/v2/tenants", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "test",
+        audience: "test",
+        sender_name: "test",
+        sender_email: "test@example.com",
+      }),
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+    });
+  });
+
+  afterEach(() => {
+    worker.stop();
+  });
+
+  it("should return 404 for non existent email address?", async () => {
+    const token = await getAdminToken();
+
+    const response = await worker.fetch(
+      "/api/v2/users-by-email/?email=i-do-not-exist@all.com",
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "test",
+        },
+      },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -34,11 +34,11 @@ describe("users by email", () => {
     const token = await getAdminToken();
 
     const response = await worker.fetch(
-      "/api/v2/users-by-email/?email=i-do-not-exist@all.com",
+      "/api/v2/users-by-email?email=i-do-not-exist@all.com",
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "test",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -46,9 +46,24 @@ describe("users by email", () => {
     expect(response.status).toBe(404);
   });
 
+  it("should return a single user for a simple get by email - no linked accounts", async () => {
+    const token = await getAdminToken();
+
+    const response = await worker.fetch(
+      `/api/v2/users-by-email?email=${encodeURIComponent("foo@example.com")}`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   /* 
   TO TEST
-  * simple get by email - no linked accounts
   * multiple simple primary not linked accounts
   * a primary account with multiple linked accounts - some on different email addresses
    

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -99,6 +99,8 @@ data.clients.create({
 });
 
 data.users.create("tenantId", {
+  // my test correctly informs this is not a valid user_id!
+  // TODO - fix this in another PR? or do we want backwards compatibility?
   id: "userId",
   email: "foo@example.com",
   email_verified: true,

--- a/src/adapters/in-memory/users/getByEmail.ts
+++ b/src/adapters/in-memory/users/getByEmail.ts
@@ -1,9 +1,11 @@
 import { SqlUser } from "../../../types";
 
 export function getByEmail(users: SqlUser[]) {
-  return async (tenant_id: string, email: string): Promise<SqlUser | null> => {
-    const sqlUser = users.find((user) => user.email === email) || null;
+  return async (tenant_id: string, email: string): Promise<SqlUser[]> => {
+    const sqlUsers = users.filter(
+      (user) => user.tenant_id === tenant_id && user.email === email,
+    );
 
-    return sqlUser;
+    return sqlUsers;
   };
 }

--- a/src/adapters/interfaces/Users.ts
+++ b/src/adapters/interfaces/Users.ts
@@ -8,7 +8,7 @@ export interface ListUsersResponse extends Totals {
 
 export interface UserDataAdapter {
   get(tenant_id: string, id: string): Promise<User | null>;
-  getByEmail(tenant_id: string, email: string): Promise<User | null>;
+  getByEmail(tenant_id: string, email: string): Promise<User[]>;
   create(tenantId: string, user: User): Promise<User>;
   remove(tenantId: string, id: string): Promise<boolean>;
   list(tenantId: string, params: ListParams): Promise<ListUsersResponse>;

--- a/src/adapters/kysely/users/getByEmail.ts
+++ b/src/adapters/kysely/users/getByEmail.ts
@@ -2,18 +2,14 @@ import { Database, SqlUser } from "../../../types";
 import { Kysely } from "kysely";
 
 export function getByEmail(db: Kysely<Database>) {
-  return async (tenantId: string, email: string): Promise<SqlUser | null> => {
-    const user = await db
+  return async (tenantId: string, email: string): Promise<SqlUser[]> => {
+    const users = await db
       .selectFrom("users")
       .where("users.tenant_id", "=", tenantId)
       .where("users.email", "=", email)
       .selectAll()
-      .executeTakeFirst();
+      .execute();
 
-    if (!user) {
-      return null;
-    }
-
-    return user;
+    return users;
   };
 }

--- a/src/authentication-flows/passwordless.ts
+++ b/src/authentication-flows/passwordless.ts
@@ -20,7 +20,8 @@ export async function validateCode(env: Env, params: LoginParams) {
     throw new HTTPException(403, { message: "Code not found or expired" });
   }
 
-  let user = await env.data.users.getByEmail(client.tenant_id, params.email);
+  // fix this to get the primary user! filter to !linked_to - could then throw if more than one? hmmmm
+  let [user] = await env.data.users.getByEmail(client.tenant_id, params.email);
   if (!user) {
     user = await env.data.users.create(client.tenant_id, {
       id: `email|${userIdGenerate()}`,

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -151,7 +151,8 @@ export async function socialAuthCallback({
   }
 
   if (!user) {
-    const sameEmailUser = await env.data.users.getByEmail(
+    // This should be fixed to get the primary user!
+    const [sameEmailUser] = await env.data.users.getByEmail(
       client.tenant_id,
       // TODO - this needs to ONLY fetch primary users e.g. where linked_to is null
       email,

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -19,7 +19,8 @@ export async function ticketAuth(
     throw new HTTPException(403, { message: "Ticket not found" });
   }
 
-  let user = await env.data.users.getByEmail(tenant_id, ticket.email);
+  // TODO - filter for primary user
+  let [user] = await env.data.users.getByEmail(tenant_id, ticket.email);
 
   if (!user) {
     user = await env.data.users.create(tenant_id, {

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -20,19 +20,11 @@ export interface LinkBodyParams {
   link_with: string;
 }
 
-// Who knows what this should be called?
-// let's get this working and then extract out common code
 async function enrichUser(
   env: Env,
   tenantId: string,
   primaryUser: User,
 ): Promise<UserResponse> {
-  // lots of this code is copied from the GET route. I'll TDD this first
-  // and code whatever
-
-  // I had assumed that we would already have all the linked users
-  // by searching by email BUT Markus is correct   8-)
-  // anything can be linked to anything
   const linkedusers = await env.data.users.list(tenantId, {
     page: 0,
     per_page: 10,
@@ -74,11 +66,9 @@ export class UsersByEmailController extends Controller {
       throw new HTTPException(404, { message: "User not found" });
     }
 
-    // We could do defensive coding here and alert if we have multiple primary users...
     const primarySqlUsers = users.filter((user) => !user.linked_to);
 
     if (primarySqlUsers.length === 0) {
-      // don't return secondary accounts
       this.setStatus(404);
       return [];
     }

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -12,11 +12,49 @@ import { RequestWithContext } from "../../types/RequestWithContext";
 import { HTTPException } from "hono/http-exception";
 import { UserResponse } from "../../types/auth0/UserResponse";
 import userIdParse from "../../utils/userIdParse";
+import { Env, User } from "../../types";
 
 export interface LinkBodyParams {
   provider?: string;
   connection_id?: string;
   link_with: string;
+}
+
+// Who knows what this should be called?
+// let's get this working and then extract out common code
+async function enrichUser(
+  env: Env,
+  tenantId: string,
+  primaryUser: User,
+): Promise<UserResponse> {
+  // lots of this code is copied from the GET route. I'll TDD this first
+  // and code whatever
+
+  // I had assumed that we would already have all the linked users
+  // by searching by email BUT Markus is correct   8-)
+  // anything can be linked to anything
+  const linkedusers = await env.data.users.list(tenantId, {
+    page: 0,
+    per_page: 10,
+    include_totals: false,
+    q: `linked_to:${primaryUser.id}`,
+  });
+
+  const identities = [primaryUser, ...linkedusers.users].map((u) => ({
+    connection: u.connection,
+    provider: u.provider,
+    user_id: userIdParse(u.id),
+    isSocial: u.is_social,
+    // TODO - have profileData PR that needs continuing...
+  }));
+
+  const { id, ...userWithoutId } = primaryUser;
+
+  return {
+    ...userWithoutId,
+    identities,
+    user_id: primaryUser.id,
+  };
 }
 
 @Route("api/v2/users-by-email")
@@ -45,44 +83,23 @@ export class UsersByEmailController extends Controller {
       throw new HTTPException(500, { message: "No primary user" });
     }
 
-    // lots of this code is copied from the GET route. I'll TDD this first
-    // and code whatever
-
-    // I had assumed that we would already have all the linked users
-    // by searching by email BUT Markus is correct   8-)
-    // anything can be linked to anything
-    const linkedusers = await env.data.users.list(tenant_id, {
-      page: 0,
-      per_page: 10,
-      include_totals: false,
-      q: `linked_to:${primarySqlUser.id}`,
-    });
-
-    const identities = [primarySqlUser, ...linkedusers.users].map((u) => ({
-      connection: u.connection,
-      provider: u.provider,
-      user_id: userIdParse(u.id),
-      isSocial: u.is_social,
-      // TODO - have profileData PR that needs continuing...
-    }));
-
     // Step 1 - return this user in array
     // Step 2 - return all users with this email address
     // Step 3- filter out linked users e.g. linked_to field is populated
     // Step 4 - return nested identities
     // don't overthink this last step. copy-paste but have tests so can TDD
 
-    const { id, ...userWithoutId } = primarySqlUser;
+    const userResponse: UserResponse = await enrichUser(
+      env,
+      tenant_id,
+      primarySqlUser,
+    );
 
     // This is assuming we'll only have one user returned
     // but if we return multiple users, we'll need to do this mapping for each
     // BUT in our use case this is most likely a bug!
-    return [
-      {
-        ...userWithoutId,
-        identities,
-        user_id: primarySqlUser.id,
-      },
-    ];
+    // --------
+    // TODO - need to map through all users with linked_to as NULL
+    return [userResponse];
   }
 }

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -27,7 +27,8 @@ export class UsersByEmailController extends Controller {
     @Request() request: RequestWithContext,
     @Query("email") email: string,
     @Header("tenant-id") tenant_id: string,
-  ): Promise<User> {
+  ): Promise<User[]> {
+    // This should be ResponseUser!  8-)
     const { env } = request.ctx;
 
     const user = await env.data.users.getByEmail(tenant_id, email);
@@ -35,6 +36,11 @@ export class UsersByEmailController extends Controller {
       throw new HTTPException(404, { message: "User not found" });
     }
 
-    return user;
+    // Step 1 - return this user in array
+    // Step 2 - return all users with this email address
+    // Step 3- filter out linked users e.g. linked_to field is populated
+    // Step 4 - return nested identities
+    // don't overthink this last step. copy-paste but have tests so can TDD
+    return [user];
   }
 }

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -41,6 +41,6 @@ export class UsersByEmailController extends Controller {
     // Step 3- filter out linked users e.g. linked_to field is populated
     // Step 4 - return nested identities
     // don't overthink this last step. copy-paste but have tests so can TDD
-    return [user];
+    return user;
   }
 }

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -9,8 +9,9 @@ import {
   Security,
 } from "@tsoa/runtime";
 import { RequestWithContext } from "../../types/RequestWithContext";
-import { User } from "../../types";
 import { HTTPException } from "hono/http-exception";
+import { UserResponse } from "../../types/auth0/UserResponse";
+import userIdParse from "../../utils/userIdParse";
 
 export interface LinkBodyParams {
   provider?: string;
@@ -27,20 +28,61 @@ export class UsersByEmailController extends Controller {
     @Request() request: RequestWithContext,
     @Query("email") email: string,
     @Header("tenant-id") tenant_id: string,
-  ): Promise<User[]> {
+  ): Promise<UserResponse[]> {
     // This should be ResponseUser!  8-)
     const { env } = request.ctx;
 
-    const user = await env.data.users.getByEmail(tenant_id, email);
-    if (!user) {
+    const users = await env.data.users.getByEmail(tenant_id, email);
+    if (users.length === 0) {
       throw new HTTPException(404, { message: "User not found" });
     }
+
+    // We could do defensive coding here and alert if we have multiple primary users...
+    const primarySqlUser = users.find((user) => !user.linked_to);
+
+    if (!primarySqlUser) {
+      // seems a 500 as we've messed something up here!
+      throw new HTTPException(500, { message: "No primary user" });
+    }
+
+    // lots of this code is copied from the GET route. I'll TDD this first
+    // and code whatever
+
+    // I had assumed that we would already have all the linked users
+    // by searching by email BUT Markus is correct   8-)
+    // anything can be linked to anything
+    const linkedusers = await env.data.users.list(tenant_id, {
+      page: 0,
+      per_page: 10,
+      include_totals: false,
+      q: `linked_to:${primarySqlUser.id}`,
+    });
+
+    const identities = [primarySqlUser, ...linkedusers.users].map((u) => ({
+      connection: u.connection,
+      provider: u.provider,
+      user_id: userIdParse(u.id),
+      isSocial: u.is_social,
+      // TODO - have profileData PR that needs continuing...
+    }));
 
     // Step 1 - return this user in array
     // Step 2 - return all users with this email address
     // Step 3- filter out linked users e.g. linked_to field is populated
     // Step 4 - return nested identities
     // don't overthink this last step. copy-paste but have tests so can TDD
-    return user;
+
+    const { id, ...userWithoutId } = primarySqlUser;
+
+    // This is assuming we'll only have one user returned
+    // but if we return multiple users, we'll need to do this mapping for each
+    // BUT in our use case this is most likely a bug!
+    return [
+      {
+        ...userWithoutId,
+        identities,
+        user_id: primarySqlUser.id,
+      },
+    ];
   }
 }

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -52,7 +52,7 @@ export class UsersMgmtController extends Controller {
   ): Promise<UserResponse[] | GetUserResponseWithTotals> {
     const { env } = request.ctx;
 
-    // Filter out linked userss
+    // Filter out linked users
     const query: string[] = ["-_exists_:linked_to"];
     if (q) {
       query.push(q);

--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -91,7 +91,8 @@ export class AuthenticateController extends Controller {
 
       ticket.authParams = otp.authParams;
     } else {
-      const user = await env.data.users.getByEmail(client.tenant_id, email);
+      // TODO - filter this don't just take first
+      const [user] = await env.data.users.getByEmail(client.tenant_id, email);
 
       if (!user) {
         throw new HTTPException(403);

--- a/src/routes/tsoa/dbconnection.ts
+++ b/src/routes/tsoa/dbconnection.ts
@@ -56,7 +56,8 @@ export class DbConnectionController extends Controller {
     }
 
     // Ensure the user exists
-    let user = await ctx.env.data.users.getByEmail(
+    // TODO - filter this don't just take first
+    let [user] = await ctx.env.data.users.getByEmail(
       client.tenant_id,
       body.email,
     );

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -324,7 +324,8 @@ export class LoginController extends Controller {
         return renderEnterCode(env, this, session, "Code not found or expired");
       }
 
-      let user = await env.data.users.getByEmail(client.tenant_id, email);
+      // TODO - filter by primary user
+      let [user] = await env.data.users.getByEmail(client.tenant_id, email);
       if (!user) {
         throw new HTTPException(500, { message: "No user found" });
       }
@@ -376,7 +377,8 @@ export class LoginController extends Controller {
     }
 
     try {
-      let user = await env.data.users.getByEmail(
+      // TODO - filter by primary user
+      let [user] = await env.data.users.getByEmail(
         client.tenant_id,
         loginParams.username,
       );
@@ -476,7 +478,8 @@ export class LoginController extends Controller {
       await env.data.universalLoginSessions.update(session.id, session);
     }
 
-    const user = await env.data.users.getByEmail(
+    // TODO - filter by primary user
+    const [user] = await env.data.users.getByEmail(
       client.tenant_id,
       params.username,
     );
@@ -561,7 +564,8 @@ export class LoginController extends Controller {
       throw new HTTPException(400, { message: "Client not found" });
     }
 
-    const user = await env.data.users.getByEmail(
+    // TODO - filter by primary user
+    const [user] = await env.data.users.getByEmail(
       client.tenant_id,
       session.authParams.username,
     );
@@ -621,8 +625,8 @@ export class LoginController extends Controller {
       throw new HTTPException(400, { message: "Client not found" });
     }
 
-    // TODO - this needs to return multiple results or search by provider...
-    const user = await env.data.users.getByEmail(
+    // TODO - wait, each of these is different! need to search by  email AND provider, and then return the primary user...
+    const [user] = await env.data.users.getByEmail(
       client.tenant_id,
       loginParams.username,
     );


### PR DESCRIPTION
This fixes our `getUsersByEmail` endpoint to match Auth0

*but more importantly* this PR is my first step towards signing on properly with different providers - we need a way to search by email _and_ provider

So I figure I'll KISS by returning _all_ users for a given email in the adapter