### PR TITLE
fix: ensure connection and provider are set correctly on new signups

### DIFF
--- a/src/routes/tsoa/dbconnection.ts
+++ b/src/routes/tsoa/dbconnection.ts
@@ -68,8 +68,8 @@ export class DbConnectionController extends Controller {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         email_verified: false,
-        provider: "email",
-        connection: "email",
+        provider: "auth2",
+        connection: "Username-Password-Authentication",
         is_social: false,
         login_count: 0,
       });


### PR DESCRIPTION
We're missing *a lot* of `provider` and `connection` fields in our dev db

probably this is from migrations as our code is mostly correct