### PR TITLE
fix: switch to hono testing

### DIFF
--- a/integration-test/ping.spec.ts
+++ b/integration-test/ping.spec.ts
@@ -1,25 +1,9 @@
-import { start } from "./start";
-import type { UnstableDevWorker } from "wrangler";
+import { testClient } from "hono/testing";
+import app from "../src/app";
 
 describe("ping", () => {
-  let worker: UnstableDevWorker;
-
-  beforeEach(async () => {
-    worker = await start();
-  });
-
-  afterEach(() => {
-    worker.stop();
-  });
-
   it("check that the root responds with a json document", async () => {
-    const response = await worker.fetch("/");
-
-    if (!response.ok) {
-      throw new Error(`Test failed with ${await response.text()}`);
-    }
-
-    expect(response.status).toBe(200);
+    const response = await testClient(app, { env: {} }).index.$get();
 
     const body: any = await response.json();
     expect(body.name).toBe("auth2");


### PR DESCRIPTION
Think I figured out the issue with hono testing. When we use the fluent api to create the router you get a typed version of the router. But.. like we did it before we created an empty router first and then added the routes. This way the router kept it's original type and the testing library didn't work.

Started by moving a single test and updated the main router. I'm not 100% sure this will work well with the tsoa routes? Maybe we just create a new instance of the router and it works?

If we get this working nicely we should be able to run the integration tests straight with bun which would be super fast, but we also could run the bun sqlite in-memory. That way we can finally drop the in-memory adapter.