### PR TITLE
bugfix: identities done wrong in two places

### DIFF
--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -458,8 +458,7 @@ describe("social sign on", () => {
         aud: "clientId",
         name: "john.doe@example.com",
         email: "john.doe@example.com",
-        // is this actually correct? I wonder...
-        email_verified: true,
+        email_verified: false,
         nonce: "nonce",
         iss: "https://example.com/",
       });

--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -40,7 +40,8 @@ const EXPECTED_NEW_USER = {
   ],
   login_count: 0,
   is_social: true,
-  profileData: '{"name":"John Doe","picture":"https://example.com/john.jpg"}',
+  profileData:
+    '{"name":"John Doe Social","picture":"https://social-provider.example.com/john.jpg"}',
   user_id: "demo-social-provider|1234567890",
 };
 
@@ -391,8 +392,8 @@ describe("social sign on", () => {
           user_id: "1234567890",
           isSocial: true,
           profileData: {
-            name: "John Doe",
-            picture: "https://example.com/john.jpg",
+            name: "John Doe Social",
+            picture: "https://social-provider.example.com/john.jpg",
             email: "john.doe@example.com",
             email_verified: true,
             // TODO - test more SSO id_tokens with more nested keys
@@ -546,8 +547,8 @@ describe("social sign on", () => {
           user_id: "1234567890",
           isSocial: true,
           profileData: {
-            name: "John Doe",
-            picture: "https://example.com/john.jpg",
+            name: "John Doe Social",
+            picture: "https://social-provider.example.com/john.jpg",
             email: "john.doe@example.com",
             email_verified: true,
           },
@@ -559,9 +560,8 @@ describe("social sign on", () => {
           user_id: "test-new-sub",
           isSocial: true,
           profileData: {
-            // Should make this info different to stop false positives
-            name: "John Doe",
-            picture: "https://example.com/john.jpg",
+            name: "John Doe Other Social",
+            picture: "https://other-social-provider.example.com/alt-john.jpg",
             email: "john.doe@example.com",
             email_verified: true,
           },

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -35,7 +35,7 @@ class MockOAuth2Client implements IOAuth2Client {
   async exchangeCodeForTokenResponse(code: string) {
     if (this.params.client_id === "otherSocialClientId") {
       const otherClientIdToken = await createTokenExample({
-        iss: "https://opther-auth.example.com",
+        iss: "https://other-auth.example.com",
         sub: "test-new-sub",
         aud: "client123",
         exp: 1616470948,
@@ -54,25 +54,28 @@ class MockOAuth2Client implements IOAuth2Client {
         refresh_token: "refreshToken",
       };
     }
-    const clientIdToken = await createTokenExample({
-      iss: "https://auth.example.com",
-      sub: "1234567890",
-      aud: "client123",
-      exp: 1616470948,
-      iat: 1616467348,
-      name: "John Doe",
-      email: "john.doe@example.com",
-      picture: "https://example.com/john.jpg",
-      nonce: "abc123",
-      email_verified: true,
-    });
-    return {
-      access_token: "accessToken",
-      id_token: clientIdToken,
-      token_type: "tokenType",
-      expires_in: 1000,
-      refresh_token: "refreshToken",
-    };
+    if (this.params.client_id === "socialClientId") {
+      const clientIdToken = await createTokenExample({
+        iss: "https://auth.example.com",
+        sub: "1234567890",
+        aud: "client123",
+        exp: 1616470948,
+        iat: 1616467348,
+        name: "John Doe",
+        email: "john.doe@example.com",
+        picture: "https://example.com/john.jpg",
+        nonce: "abc123",
+        email_verified: true,
+      });
+      return {
+        access_token: "accessToken",
+        id_token: clientIdToken,
+        token_type: "tokenType",
+        expires_in: 1000,
+        refresh_token: "refreshToken",
+      };
+    }
+    throw new Error("Unknown client_id");
   }
   getUserProfile(accessToken: string): Promise<any> {
     throw new Error("getUserProfile method not implemented.");

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -40,9 +40,9 @@ class MockOAuth2Client implements IOAuth2Client {
         aud: "client123",
         exp: 1616470948,
         iat: 1616467348,
-        name: "John Doe",
+        name: "John Doe Other Social",
         email: "john.doe@example.com",
-        picture: "https://example.com/john.jpg",
+        picture: "https://other-social-provider.example.com/alt-john.jpg",
         nonce: "abc123",
         email_verified: true,
       });
@@ -61,9 +61,9 @@ class MockOAuth2Client implements IOAuth2Client {
         aud: "client123",
         exp: 1616470948,
         iat: 1616467348,
-        name: "John Doe",
+        name: "John Doe Social",
         email: "john.doe@example.com",
-        picture: "https://example.com/john.jpg",
+        picture: "https://social-provider.example.com/john.jpg",
         nonce: "abc123",
         email_verified: true,
       });

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -188,13 +188,6 @@ export async function socialAuthCallback({
   ctx.set("email", email);
   ctx.set("userId", user.id);
 
-  // this checks everytime we get the id_token that the email is verified, and updates the user in the db
-  // pssibly excessive and we could just set email_verified:true when creating the new social user (above)
-  // TODO - fix this and actually do some implementation (and testing!) on the email verified field, and how we use it
-  // if (email_verified) {
-  //   newUserFields.email_verified = strictEmailVerified;
-  // }
-
   await env.data.logs.create({
     category: "login",
     message: `Login with ${connection.name}`,

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -114,8 +114,6 @@ export async function socialAuthCallback({
 
   const idToken = parseJwt(token.id_token!);
 
-  console.log("idToken", idToken);
-
   const {
     iss,
     azp,

--- a/src/authentication-flows/social.ts
+++ b/src/authentication-flows/social.ts
@@ -114,6 +114,8 @@ export async function socialAuthCallback({
 
   const idToken = parseJwt(token.id_token!);
 
+  console.log("idToken", idToken);
+
   const {
     iss,
     azp,
@@ -134,11 +136,6 @@ export async function socialAuthCallback({
 
   const email = emailRaw.toLocaleLowerCase();
   const strictEmailVerified = !!email_verified;
-
-  const newUserFields: Partial<BaseUser> = {
-    profileData: JSON.stringify(profileData),
-    email,
-  };
 
   const ssoId = `${state.connection}|${sub}`;
   let user = await env.data.users.get(client.tenant_id, ssoId);
@@ -173,6 +170,7 @@ export async function socialAuthCallback({
       last_login: new Date().toISOString(),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      profileData: JSON.stringify(profileData),
     });
 
     // this means we have a primary account
@@ -193,16 +191,11 @@ export async function socialAuthCallback({
   ctx.set("userId", user.id);
 
   // this checks everytime we get the id_token that the email is verified, and updates the user in the db
-  // possibly excessive and we could just set email_verified:true when creating the new social user (above)
-  if (email_verified) {
-    newUserFields.email_verified = strictEmailVerified;
-  }
-
-  await env.data.users.update(
-    client.tenant_id,
-    ctx.get("userId"),
-    newUserFields,
-  );
+  // pssibly excessive and we could just set email_verified:true when creating the new social user (above)
+  // TODO - fix this and actually do some implementation (and testing!) on the email verified field, and how we use it
+  // if (email_verified) {
+  //   newUserFields.email_verified = strictEmailVerified;
+  // }
 
   await env.data.logs.create({
     category: "login",

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -139,28 +139,30 @@ export class UsersMgmtController extends Controller {
       isSocial: user.is_social,
     };
 
-    const linkedProfileIdentities: Identity[] = linkedusers.users.map((u) => {
-      let profileData: { [key: string]: any } = {};
+    const linkedProfileIdentities: Identity[] = linkedusers.users.map(
+      (linkedUser) => {
+        let profileData: { [key: string]: any } = {};
 
-      try {
-        profileData = JSON.parse(user.profileData || "{}");
-      } catch (e) {
-        console.error("Error parsing profileData", e);
-      }
+        try {
+          profileData = JSON.parse(linkedUser.profileData || "{}");
+        } catch (e) {
+          console.error("Error parsing profileData", e);
+        }
 
-      return {
-        connection: u.connection,
-        provider: u.provider,
-        user_id: userIdParse(u.id),
-        isSocial: u.is_social,
-        profileData: {
-          // both these two appear on every profile type
-          email: u.email,
-          email_verified: u.email_verified,
-          ...profileData,
-        },
-      };
-    });
+        return {
+          connection: linkedUser.connection,
+          provider: linkedUser.provider,
+          user_id: userIdParse(linkedUser.id),
+          isSocial: linkedUser.is_social,
+          profileData: {
+            // both these two appear on every profile type
+            email: linkedUser.email,
+            email_verified: linkedUser.email_verified,
+            ...profileData,
+          },
+        };
+      },
+    );
 
     const { id, ...userWithoutId } = user;
 


### PR DESCRIPTION
Lol. This confused me. I found it while trying to reuse a util function to populate the identities

During the social signup I was writing the `profileData` to the primary user :facepalm: 

Then on the `GET/[id]` I was spreading in the profile data from the primary user to every linked account :joy: 

So the tests were passing
