### PR TITLE
fix: add subdomain support in dev

### DIFF
--- a/integration-test/ping.spec.ts
+++ b/integration-test/ping.spec.ts
@@ -6,6 +6,6 @@ describe("ping", () => {
     const response = await testClient(app, { env: {} }).index.$get();
 
     const body: any = await response.json();
-    expect(body.name).toBe("auth2");
+    expect(body.name).toBe("localhost");
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,8 +61,10 @@ const app = new Hono<{ Bindings: Env }>()
   )
   .use(loggerMiddleware)
   .get("/", async (ctx: Context<{ Bindings: Env; Variables: Var }>) => {
+    const url = new URL(ctx.req.url);
+    const tenantId = url.hostname.split(".")[0];
     return ctx.json({
-      name: packageJson.name,
+      name: tenantId,
       version: packageJson.version,
     });
   });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,7 +14,10 @@ kv_namespaces = [
 
 services = [{ binding = "TOKEN_SERVICE", service = "token-service-dev" }]
 
-route = { pattern = "auth2.sesamy.dev/*", zone_id = "b56a76d859fe2ed6a8d77270cd2e8ba8" }
+routes = [
+    { pattern = "auth2.sesamy.dev/*", zone_id = "b56a76d859fe2ed6a8d77270cd2e8ba8" },
+    { pattern = "*.auth2.sesamy.dev/*", zone_id = "b56a76d859fe2ed6a8d77270cd2e8ba8" },
+]
 
 [vars]
 IMAGE_PROXY_URL = "https://imgproxy.prod.sesamy.cloud"


### PR DESCRIPTION
This is still early.. we should add a middleware that picks the tenantId from the sub or the header.