### PR TITLE
fix: sub in access token should be user_id

### DIFF
--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -75,16 +75,16 @@ describe("users by email", () => {
       picture: "https://example.com/foo.png",
       tenant_id: "tenantId",
       login_count: 0,
-      provider: "email",
-      connection: "email",
+      connection: "Username-Password-Authentication",
+      provider: "auth2",
       is_social: false,
       user_id: "userId",
     });
 
     expect(users[0].identities).toEqual([
       {
-        connection: "email",
-        provider: "email",
+        connection: "Username-Password-Authentication",
+        provider: "auth2",
         user_id: "userId",
         isSocial: false,
       },
@@ -136,15 +136,15 @@ describe("users by email", () => {
       picture: "https://example.com/foo.png",
       tenant_id: "tenantId",
       login_count: 0,
-      provider: "email",
-      connection: "email",
+      connection: "Username-Password-Authentication",
+      provider: "auth2",
       is_social: false,
       user_id: "userId",
     });
     expect(users[0].identities).toEqual([
       {
-        connection: "email",
-        provider: "email",
+        connection: "Username-Password-Authentication",
+        provider: "auth2",
         user_id: "userId",
         isSocial: false,
       },
@@ -223,8 +223,8 @@ describe("users by email", () => {
     expect(linkResponseData).toHaveLength(2);
 
     expect(linkResponseData[0]).toEqual({
-      connection: "email",
-      provider: "email",
+      connection: "Username-Password-Authentication",
+      provider: "auth2",
       user_id: fooEmailId,
       isSocial: false,
     });
@@ -254,8 +254,8 @@ describe("users by email", () => {
 
     expect(fooEmailAfterLinkUsers[0].identities).toEqual([
       {
-        connection: "email",
-        provider: "email",
+        connection: "Username-Password-Authentication",
+        provider: "auth2",
         user_id: fooEmailId,
         isSocial: false,
       },

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -109,9 +109,8 @@ data.users.create("tenantId", {
   picture: "https://example.com/foo.png",
   tenant_id: "tenantId",
   login_count: 0,
-  // this isn't correct right?
-  provider: "email",
-  connection: "email",
+  provider: "auth2",
+  connection: "Username-Password-Authentication",
   is_social: false,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.96.1",
+  "version": "1.96.2",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.96.4",
+  "version": "1.97.0",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.97.2",
+  "version": "1.97.3",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.97.0",
+  "version": "1.97.1",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.97.1",
+  "version": "1.97.2",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.96.2",
+  "version": "1.96.3",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth2",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "description": "",
   "main": "build/src/server.js",
   "scripts": {

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -50,9 +50,7 @@ export async function ticketAuth(
 
   const tokenResponse = await generateAuthResponse({
     env,
-    // userId: user.id,
-    // should this be called sub?
-    userId: `${tenant_id}|${nanoid()}`,
+    userId: `${tenant_id}|${user.id}`,
     state: authParams.state,
     authParams: {
       ...authParams,

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -50,7 +50,7 @@ export async function ticketAuth(
 
   const tokenResponse = await generateAuthResponse({
     env,
-    userId: `${tenant_id}|${user.id}`,
+    userId: user.id,
     state: authParams.state,
     authParams: {
       ...authParams,

--- a/test/authentication-flows/ticket.spec.ts
+++ b/test/authentication-flows/ticket.spec.ts
@@ -67,7 +67,7 @@ describe("passwordlessAuth", () => {
     expect(controller.getStatus()).toEqual(302);
     expect(accessToken).toEqual({
       aud: "default",
-      sub: "tenant_id|email|testid",
+      sub: "email|testid",
       scope: "openid profile email",
       iss: "https://auth.example.com/",
       iat: Math.floor(date.getTime() / 1000),

--- a/test/authentication-flows/ticket.spec.ts
+++ b/test/authentication-flows/ticket.spec.ts
@@ -67,7 +67,7 @@ describe("passwordlessAuth", () => {
     expect(controller.getStatus()).toEqual(302);
     expect(accessToken).toEqual({
       aud: "default",
-      sub: "tenant_id|testid",
+      sub: "tenant_id|email|testid",
       scope: "openid profile email",
       iss: "https://auth.example.com/",
       iat: Math.floor(date.getTime() / 1000),

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -457,7 +457,7 @@ describe("authorize", () => {
       expect(accessToken).toEqual({
         aud: "default",
         scope: "openid profile email",
-        sub: "tenantId|testid",
+        sub: "tenantId|email|testid",
         iss: "https://auth.example.com/",
         iat: Math.floor(date.getTime() / 1000),
         exp: Math.floor(date.getTime() / 1000) + 86400,
@@ -521,7 +521,7 @@ describe("authorize", () => {
 
       expect(idToken).toEqual({
         aud: "clientId",
-        sub: "tenantId|testid",
+        sub: "tenantId|email|testid",
         nonce: "nonce",
         sid: "testid",
         iss: "https://auth.example.com/",
@@ -594,7 +594,7 @@ describe("authorize", () => {
           tenant_id: "tenantId",
           updated_at: "2023-11-28T12:00:00.000Z",
         },
-        userId: "tenantId|testid",
+        userId: "tenantId|email|testid",
       });
 
       expect(redirectUrl.searchParams.get("state")).toBe("state");

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -457,7 +457,7 @@ describe("authorize", () => {
       expect(accessToken).toEqual({
         aud: "default",
         scope: "openid profile email",
-        sub: "tenantId|email|testid",
+        sub: "email|testid",
         iss: "https://auth.example.com/",
         iat: Math.floor(date.getTime() / 1000),
         exp: Math.floor(date.getTime() / 1000) + 86400,
@@ -521,7 +521,7 @@ describe("authorize", () => {
 
       expect(idToken).toEqual({
         aud: "clientId",
-        sub: "tenantId|email|testid",
+        sub: "email|testid",
         nonce: "nonce",
         sid: "testid",
         iss: "https://auth.example.com/",
@@ -594,7 +594,7 @@ describe("authorize", () => {
           tenant_id: "tenantId",
           updated_at: "2023-11-28T12:00:00.000Z",
         },
-        userId: "tenantId|email|testid",
+        userId: "email|testid",
       });
 
       expect(redirectUrl.searchParams.get("state")).toBe("state");


### PR DESCRIPTION
This looks like a bug to me! :smile: 

We were always returning a `nanoId()` for the `sub` 