### PR TITLE
fix: pull domains from in-memory adapter when building Client

### DIFF
--- a/src/adapters/in-memory/clients/getClient.ts
+++ b/src/adapters/in-memory/clients/getClient.ts
@@ -1,5 +1,5 @@
 import { PartialClient } from "../../../types";
-import { Application, Tenant, SqlConnection } from "../../../types";
+import { Application, Tenant, SqlConnection, SqlDomain } from "../../../types";
 
 function removeNullProperties<T = any>(obj: Record<string, any>) {
   const clone = { ...obj };
@@ -24,6 +24,7 @@ export function getClient(
   applications: Application[],
   tenants: Tenant[],
   connectionsList: SqlConnection[],
+  domainsList: SqlDomain[],
 ) {
   return async (id: string) => {
     const application = applications.find(
@@ -41,12 +42,16 @@ export function getClient(
       .filter((connection) => connection.tenant_id === application.tenant_id)
       .map((connection) => removeNullProperties(connection));
 
+    // TODO - need to pull domain here!
+    const domains = domainsList
+      .filter((domain) => domain.tenant_id === application.tenant_id)
+      .map((domain) => removeNullProperties(domain));
+
     const client: PartialClient = {
       id: application.id,
       name: application.name,
       connections,
-      // TODO - not using domains yet
-      domains: [],
+      domains,
       tenant_id: application.tenant_id,
       allowed_callback_urls: splitUrls(application.allowed_callback_urls),
       allowed_logout_urls: splitUrls(application.allowed_logout_urls),

--- a/src/adapters/in-memory/clients/getClient.ts
+++ b/src/adapters/in-memory/clients/getClient.ts
@@ -42,7 +42,6 @@ export function getClient(
       .filter((connection) => connection.tenant_id === application.tenant_id)
       .map((connection) => removeNullProperties(connection));
 
-    // TODO - need to pull domain here!
     const domains = domainsList
       .filter((domain) => domain.tenant_id === application.tenant_id)
       .map((domain) => removeNullProperties(domain));

--- a/src/adapters/in-memory/clients/index.ts
+++ b/src/adapters/in-memory/clients/index.ts
@@ -1,14 +1,14 @@
 import { ClientsAdapter } from "../../interfaces/Clients";
-import { Application, Tenant, SqlConnection } from "../../../types";
+import { Application, Tenant, SqlConnection, SqlDomain } from "../../../types";
 import { getClient } from "./getClient";
-import { createClient } from "./createClient";
 
 export function createClientsAdapter(
   applications: Application[],
   tenants: Tenant[],
   connections: SqlConnection[],
+  domains: SqlDomain[],
 ): ClientsAdapter {
   return {
-    get: getClient(applications, tenants, connections),
+    get: getClient(applications, tenants, connections, domains),
   };
 }

--- a/src/adapters/in-memory/domains/create.ts
+++ b/src/adapters/in-memory/domains/create.ts
@@ -1,0 +1,17 @@
+import { CreateDomainParams } from "../../interfaces/Domains";
+import { SqlDomain } from "../../../types";
+
+export function create(domains: SqlDomain[]) {
+  return async (tenant_id: string, params: CreateDomainParams) => {
+    const domain: SqlDomain = {
+      ...params,
+      tenant_id,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    domains.push(domain);
+
+    return domain;
+  };
+}

--- a/src/adapters/in-memory/domains/index.ts
+++ b/src/adapters/in-memory/domains/index.ts
@@ -1,0 +1,9 @@
+import { DomainsAdapter } from "../../interfaces/Domains";
+import { SqlDomain } from "../../../types";
+import { create } from "./create";
+
+export function createDomainsAdapter(domains: SqlDomain[]): DomainsAdapter {
+  return {
+    create: create(domains),
+  };
+}

--- a/src/adapters/in-memory/index.ts
+++ b/src/adapters/in-memory/index.ts
@@ -14,7 +14,8 @@ import { createLogsAdapter } from "./logs";
 import { createApplicationsAdapter } from "./applications";
 import { createUniversalLoginSessionsAdapter } from "./universal-auth-sessions";
 import { createConnectionsAdapter } from "./connections";
-import { Application, SqlConnection, Tenant } from "../../types";
+import { Application, SqlConnection, Tenant, SqlDomain } from "../../types";
+import { createDomainsAdapter } from "./domains";
 
 export default function createAdapters(): DataAdapters {
   const connections: SqlConnection[] = [];
@@ -39,6 +40,13 @@ export default function createAdapters(): DataAdapters {
     connections: createConnectionsAdapter(connections),
     templates: {
       get: async (...inputs) => `<div>${JSON.stringify(inputs, null, 2)}</div>`,
+    },
+    domains: {
+      get: async (...inputs) => ({
+        domain: "example.com",
+        dkim_private_key: "dkimKey",
+        email_service: "mailchannels",
+      }),
     },
   };
 }

--- a/src/adapters/in-memory/index.ts
+++ b/src/adapters/in-memory/index.ts
@@ -21,12 +21,13 @@ export default function createAdapters(): DataAdapters {
   const connections: SqlConnection[] = [];
   const tenants: Tenant[] = [];
   const applications: Application[] = [];
+  const domains: SqlDomain[] = [];
 
   return {
     applications: createApplicationsAdapter(applications),
     certificates: createCertificateAdapter(),
     codes: createCodesAdapter(),
-    clients: createClientsAdapter(applications, tenants, connections),
+    clients: createClientsAdapter(applications, tenants, connections, domains),
     email: emailAdapter(),
     members: createMembersAdapter(),
     OTP: createOTPAdapter(),
@@ -38,15 +39,9 @@ export default function createAdapters(): DataAdapters {
     tickets: createTicketsAdapter(),
     logs: createLogsAdapter(),
     connections: createConnectionsAdapter(connections),
+    domains: createDomainsAdapter(domains),
     templates: {
       get: async (...inputs) => `<div>${JSON.stringify(inputs, null, 2)}</div>`,
-    },
-    domains: {
-      get: async (...inputs) => ({
-        domain: "example.com",
-        dkim_private_key: "dkimKey",
-        email_service: "mailchannels",
-      }),
     },
   };
 }

--- a/src/adapters/interfaces/Domains.ts
+++ b/src/adapters/interfaces/Domains.ts
@@ -1,11 +1,7 @@
 import { SqlDomain } from "../../types";
 
-// DomainsAdapter
-
 export type CreateDomainParams = SqlDomain;
 
 export interface DomainsAdapter {
   create(tenant_id: string, params: CreateDomainParams): Promise<SqlDomain>;
-  // TODO
-  // what other methods are needed to load this into default settings?
 }

--- a/src/adapters/interfaces/Domains.ts
+++ b/src/adapters/interfaces/Domains.ts
@@ -1,0 +1,11 @@
+import { SqlDomain } from "../../types";
+
+// DomainsAdapter
+
+export type CreateDomainParams = SqlDomain;
+
+export interface DomainsAdapter {
+  create(tenant_id: string, params: CreateDomainParams): Promise<SqlDomain>;
+  // TODO
+  // what other methods are needed to load this into default settings?
+}

--- a/src/adapters/interfaces/index.ts
+++ b/src/adapters/interfaces/index.ts
@@ -14,6 +14,7 @@ import { ApplicationsAdapter } from "./Applications";
 import { UniversalLoginSessionsAdapter } from "./UniversalLoginSession";
 import { TemplatesAdapter } from "./Templates";
 import { ConnectionsAdapter } from "./Connections";
+import { DomainsAdapter } from "./Domains";
 
 export interface DataAdapters {
   applications: ApplicationsAdapter;
@@ -32,4 +33,5 @@ export interface DataAdapters {
   logs: LogsDataAdapter;
   templates: TemplatesAdapter;
   connections: ConnectionsAdapter;
+  domains: DomainsAdapter;
 }

--- a/test/fixtures/client.ts
+++ b/test/fixtures/client.ts
@@ -4,6 +4,7 @@ import {
   Application,
   Tenant,
   SqlConnection,
+  SqlDomain,
 } from "../../src/types";
 
 export const application: Application = {
@@ -57,5 +58,17 @@ export const connections: SqlConnection[] = [
     created_at: "created_at",
     updated_at: "updated_at",
     tenant_id: "tenantId",
+  },
+];
+
+export const domains: SqlDomain[] = [
+  {
+    id: "domainId",
+    domain: "example2.com",
+    api_key: "apiKey",
+    email_service: "mailgun",
+    tenant_id: "tenantId",
+    created_at: "created_at",
+    updated_at: "updated_at",
   },
 ];

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -45,7 +45,7 @@ export interface ContextFixtureParams {
   applications?: Application[];
   tenants?: Tenant[];
   connections?: SqlConnection[];
-  domains: SqlDomain[];
+  domains?: SqlDomain[];
 }
 
 export function contextFixture(

--- a/test/fixtures/context.ts
+++ b/test/fixtures/context.ts
@@ -8,6 +8,7 @@ import {
   Tenant,
   User,
   SqlConnection,
+  SqlDomain,
 } from "../../src/types";
 import { oAuth2ClientFactory } from "./oauth2Client";
 import { mockedR2Bucket } from "./mocked-r2-bucket";
@@ -24,6 +25,7 @@ import {
   application,
   tenant,
   connections as connectionsFixture,
+  domains as domainsFixture,
 } from "./client";
 
 export interface ContextFixtureParams {
@@ -43,6 +45,7 @@ export interface ContextFixtureParams {
   applications?: Application[];
   tenants?: Tenant[];
   connections?: SqlConnection[];
+  domains: SqlDomain[];
 }
 
 export function contextFixture(
@@ -60,6 +63,7 @@ export function contextFixture(
     connections,
     applications,
     tenants,
+    domains,
   } = params || {};
 
   const data = createAdapters();
@@ -101,6 +105,7 @@ export function contextFixture(
     data.applications.create(tenant.id, application);
     data.connections.create(tenant.id, connectionsFixture[0]);
     data.connections.create(tenant.id, connectionsFixture[1]);
+    data.domains.create(tenant.id, domainsFixture[0]);
   } else {
     if (applications) {
       applications.forEach((application) => {
@@ -117,6 +122,11 @@ export function contextFixture(
     if (connections) {
       connections.forEach((connection) => {
         data.connections.create(connection.tenant_id, connection);
+      });
+    }
+    if (domains) {
+      domains.forEach((domain) => {
+        data.domains.create(domain.tenant_id, domain);
       });
     }
   }

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -138,8 +138,7 @@ describe("getClient", () => {
     ]);
   });
 
-  // implement domains! need data adapters and default fixtures
-  it.only("should add a domain from the envDefaultSettings to the client domains", async () => {
+  it("should add a domain from the envDefaultSettings to the client domains", async () => {
     const ctx = contextFixture({
       applications: [APPLICATION_FIXTURE],
       tenants: [TENANT_FIXTURE],

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -51,6 +51,7 @@ const CONNECTION_FIXTURE: SqlConnection = {
 };
 
 const DOMAIN_FIXTURE: SqlDomain = {
+  id: "domainId",
   domain: "example2.com",
   api_key: "apiKey",
   email_service: "mailgun",
@@ -74,6 +75,7 @@ describe("getClient", () => {
           updated_at: "updated_at",
         },
       ],
+      domains: [DOMAIN_FIXTURE],
     });
 
     const envDefaultSettings: DefaultSettings = {

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -8,6 +8,7 @@ import {
   Application,
   Tenant,
   SqlConnection,
+  SqlDomain,
 } from "../../src/types";
 
 const TENANT_FIXTURE: Tenant = {
@@ -47,6 +48,15 @@ const CONNECTION_FIXTURE: SqlConnection = {
   created_at: "created_at",
   updated_at: "updated_at",
   tenant_id: "tenantId",
+};
+
+const DOMAIN_FIXTURE: SqlDomain = {
+  domain: "example2.com",
+  api_key: "apiKey",
+  email_service: "mailgun",
+  tenant_id: "tenantId",
+  created_at: "created_at",
+  updated_at: "updated_at",
 };
 
 describe("getClient", () => {
@@ -99,6 +109,7 @@ describe("getClient", () => {
       applications: [APPLICATION_FIXTURE],
       tenants: [TENANT_FIXTURE],
       connections: [CONNECTION_FIXTURE],
+      domains: [DOMAIN_FIXTURE],
     });
 
     const defaultSettings: DefaultSettings = {
@@ -126,34 +137,12 @@ describe("getClient", () => {
   });
 
   // implement domains! need data adapters and default fixtures
-  it.skip("should add a domain from the envDefaultSettings to the client domains", async () => {
-    const partialClient: PartialClient = {
-      id: "testClient",
-      name: "clientName",
-      client_secret: "clientSecret",
-      tenant_id: "tenantId",
-      allowed_callback_urls: ["http://localhost:3000", "https://example.com"],
-      allowed_logout_urls: ["http://localhost:3000", "https://example.com"],
-      allowed_web_origins: ["http://localhost:3000", "https://example.com"],
-      email_validation: "enabled",
-      tenant: {
-        sender_email: "senderEmail",
-        sender_name: "senderName",
-        audience: "audience",
-        support_url: "supportUrl",
-      },
-      connections: [],
-      domains: [
-        {
-          domain: "example2.com",
-          api_key: "apiKey",
-          email_service: "mailgun",
-        },
-      ],
-    };
-
+  it.only("should add a domain from the envDefaultSettings to the client domains", async () => {
     const ctx = contextFixture({
-      // clients: [partialClient]
+      applications: [APPLICATION_FIXTURE],
+      tenants: [TENANT_FIXTURE],
+      connections: [CONNECTION_FIXTURE],
+      domains: [DOMAIN_FIXTURE],
     });
 
     const defaultSettings: DefaultSettings = {
@@ -186,24 +175,6 @@ describe("getClient", () => {
   });
 
   it("should store the support url from the tenant in the client", async () => {
-    const testClient: PartialClient = {
-      id: "testClient",
-      name: "clientName",
-      client_secret: "clientSecret",
-      tenant_id: "tenantId",
-      allowed_callback_urls: ["http://localhost:3000", "https://example.com"],
-      allowed_logout_urls: ["http://localhost:3000", "https://example.com"],
-      allowed_web_origins: ["http://localhost:3000", "https://example.com"],
-      email_validation: "enabled",
-      tenant: {
-        sender_email: "senderEmail",
-        sender_name: "senderName",
-        support_url: "https://example.com/support",
-      },
-      connections: [],
-      domains: [],
-    };
-
     const ctx = contextFixture({
       applications: [APPLICATION_FIXTURE],
       tenants: [
@@ -213,6 +184,7 @@ describe("getClient", () => {
         },
       ],
       connections: [CONNECTION_FIXTURE],
+      domains: [DOMAIN_FIXTURE],
     });
 
     const envDefaultSettings: DefaultSettings = {

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -131,6 +131,11 @@ describe("getClient", () => {
 
     expect(client!.domains).toEqual([
       {
+        api_key: "apiKey",
+        domain: "example2.com",
+        email_service: "mailgun",
+      },
+      {
         domain: "example.com",
         dkim_private_key: "dkimKey",
         email_service: "mailchannels",

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -54,7 +54,16 @@ describe("getClient", () => {
     const ctx = contextFixture({
       applications: [APPLICATION_FIXTURE],
       tenants: [TENANT_FIXTURE],
-      connections: [CONNECTION_FIXTURE],
+      connections: [
+        {
+          // only has minimal specified
+          id: "connectionId",
+          name: "facebook",
+          tenant_id: "tenantId",
+          created_at: "created_at",
+          updated_at: "updated_at",
+        },
+      ],
     });
 
     const envDefaultSettings: DefaultSettings = {


### PR DESCRIPTION
I didn't implement `domains` when I changed the `getClient` in-memory data adapter to assemble `client` from the respective entities


I also had a skipped test checking this so I've brought this back