### PR TITLE
fix: more descriptive error message if user not found

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -45,7 +45,7 @@ export async function ticketAuth(
   if (!user) {
     if (realm === "Username-Password-Authentication") {
       throw new Error(
-        "ticket flow should not arrive here with non existent user",
+        "ticket flow should not arrive here with non existent user - probably the provider is not set on the user",
       );
     }
 


### PR DESCRIPTION
In this case, the user record must not have a provider

I don't have access to planetscale production but *we really need to make sure all our prod users have providers set* (they'll be code if not set I think)