### PR TITLE
test: swedish name with non-ASCII characters

### DIFF
--- a/integration-test/flows/code-flow.spec.ts
+++ b/integration-test/flows/code-flow.spec.ts
@@ -277,8 +277,8 @@ describe("code-flow", () => {
       email: "foo@example.com",
       email_verified: true,
       iss: "https://example.com/",
-      name: "Foo Bar",
-      nickname: "Foo",
+      name: "Åkesson Þorsteinsson",
+      nickname: "Åkesson Þorsteinsson",
       nonce: "ehiIoMV7yJCNbSEpRq513IQgSX7XvvBM",
       picture: "https://example.com/foo.png",
     });

--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -176,7 +176,7 @@ describe("social sign on", () => {
         expect(silentAuthIdTokenPayload).toMatchObject({
           sub: "demo-social-provider|123456789012345678901",
           aud: "clientId",
-          name: "john.doe@example.com",
+          name: "orjan.lindstrom@example.com",
         });
 
         // ---------------------------------------------
@@ -283,7 +283,7 @@ describe("social sign on", () => {
         expect(silentAuthIdTokenPayload).toMatchObject({
           sub: "demo-social-provider|123456789012345678901",
           aud: "clientId",
-          name: "john.doe@example.com",
+          name: "orjan.lindstrom@example.com",
         });
 
         // ---------------------------------------------

--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -334,7 +334,7 @@ describe("social sign on", () => {
           connection: "email",
           // password: "Test!",
           // will this have email_verfied though? as this is a code account that has never been used...
-          // this does nothing. doesn't complain eitherw
+          // this does nothing. doesn't complain either
           email_verified: true,
         }),
       });

--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -33,10 +33,10 @@ const EXPECTED_PROFILE_DATA = {
 
 const EXPECTED_NEW_USER = {
   tenant_id: "tenantId",
-  name: "orjan.lindstrom@example.com",
+  name: "örjan.lindström@example.com",
   provider: "demo-social-provider",
   connection: "demo-social-provider",
-  email: "orjan.lindstrom@example.com",
+  email: "örjan.lindström@example.com",
   email_verified: true,
   last_ip: "",
   identities: [
@@ -149,8 +149,8 @@ describe("social sign on", () => {
         expect(idTokenPayload.sub).toBe(
           "demo-social-provider|123456789012345678901",
         );
-        expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
-        expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
+        expect(idTokenPayload.name).toBe("örjan.lindström@example.com");
+        expect(idTokenPayload.email).toBe("örjan.lindström@example.com");
         expect(idTokenPayload.email_verified).toBe(true);
         // the same that we passed in
         expect(idTokenPayload.nonce).toBe("MnjcTg0ay3xqf3JVqIL05ib.n~~eZcL_");
@@ -176,7 +176,7 @@ describe("social sign on", () => {
         expect(silentAuthIdTokenPayload).toMatchObject({
           sub: "demo-social-provider|123456789012345678901",
           aud: "clientId",
-          name: "orjan.lindstrom@example.com",
+          name: "örjan.lindström@example.com",
         });
 
         // ---------------------------------------------
@@ -258,8 +258,8 @@ describe("social sign on", () => {
         expect(idTokenPayload.sub).toBe(
           "demo-social-provider|123456789012345678901",
         );
-        expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
-        expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
+        expect(idTokenPayload.name).toBe("örjan.lindström@example.com");
+        expect(idTokenPayload.email).toBe("örjan.lindström@example.com");
         expect(idTokenPayload.email_verified).toBe(true);
         // the same that we passed in
         expect(idTokenPayload.nonce).toBe("MnjcTg0ay3xqf3JVqIL05ib.n~~eZcL_");
@@ -283,7 +283,7 @@ describe("social sign on", () => {
         expect(silentAuthIdTokenPayload).toMatchObject({
           sub: "demo-social-provider|123456789012345678901",
           aud: "clientId",
-          name: "orjan.lindstrom@example.com",
+          name: "örjan.lindström@example.com",
         });
 
         // ---------------------------------------------
@@ -330,11 +330,11 @@ describe("social sign on", () => {
           "content-type": "application/json",
         },
         body: JSON.stringify({
-          email: "orjan.lindstrom@example.com",
+          email: "örjan.lindström@example.com",
           connection: "email",
           // password: "Test!",
           // will this have email_verfied though? as this is a code account that has never been used...
-          // this does nothing. doesn't complain either
+          // this does nothing. doesn't complain eitherw
           email_verified: true,
         }),
       });
@@ -342,7 +342,7 @@ describe("social sign on", () => {
       const createEmailUser =
         (await createEmailUserResponse.json()) as UserResponse;
 
-      expect(createEmailUser.email).toBe("orjan.lindstrom@example.com");
+      expect(createEmailUser.email).toBe("örjan.lindström@example.com");
       expect(createEmailUser.identities).toEqual([
         {
           connection: "email",
@@ -393,8 +393,8 @@ describe("social sign on", () => {
       // This is the big change here
       expect(idTokenPayload.sub).not.toBe("demo-social-provider|1234567890");
       expect(idTokenPayload.sub).toBe(createEmailUser.user_id);
-      expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
-      expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
+      expect(idTokenPayload.name).toBe("örjan.lindström@example.com");
+      expect(idTokenPayload.email).toBe("örjan.lindström@example.com");
       // TODO - we are pretending that the email is always verified
       // expect(idTokenPayload.email_verified).toBe(true);
 
@@ -413,7 +413,7 @@ describe("social sign on", () => {
       );
 
       const newSocialUser = (await newSocialUserRes.json()) as UserResponse;
-      expect(newSocialUser.email).toBe("orjan.lindstrom@example.com");
+      expect(newSocialUser.email).toBe("örjan.lindström@example.com");
 
       // ---------------------------------------------
       // check that the primary user has new identities
@@ -449,7 +449,7 @@ describe("social sign on", () => {
             family_name: "Lindström",
             picture:
               "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
-            email: "orjan.lindstrom@example.com",
+            email: "örjan.lindström@example.com",
             email_verified: true,
             locale: "es-ES",
           },
@@ -477,8 +477,8 @@ describe("social sign on", () => {
         // testing this means it must be working
         sub: createEmailUser.user_id,
         aud: "clientId",
-        name: "orjan.lindstrom@example.com",
-        email: "orjan.lindstrom@example.com",
+        name: "örjan.lindström@example.com",
+        email: "örjan.lindström@example.com",
         email_verified: false,
         nonce: "nonce",
         iss: "https://example.com/",
@@ -572,7 +572,7 @@ describe("social sign on", () => {
             family_name: "Lindström",
             picture:
               "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
-            email: "orjan.lindstrom@example.com",
+            email: "örjan.lindström@example.com",
             email_verified: true,
             locale: "es-ES",
           },
@@ -588,7 +588,7 @@ describe("social sign on", () => {
             family_name: "Lindström",
             picture:
               "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1010",
-            email: "orjan.lindstrom@example.com",
+            email: "örjan.lindström@example.com",
             email_verified: true,
           },
         },

--- a/integration-test/flows/social.spec.ts
+++ b/integration-test/flows/social.spec.ts
@@ -22,12 +22,21 @@ const SOCIAL_STATE_PARAM = btoa(
   }),
 ).replace("==", "");
 
+const EXPECTED_PROFILE_DATA = {
+  locale: "es-ES",
+  name: "Örjan Lindström",
+  given_name: "Örjan",
+  family_name: "Lindström",
+  picture:
+    "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
+};
+
 const EXPECTED_NEW_USER = {
   tenant_id: "tenantId",
-  name: "john.doe@example.com",
+  name: "orjan.lindstrom@example.com",
   provider: "demo-social-provider",
   connection: "demo-social-provider",
-  email: "john.doe@example.com",
+  email: "orjan.lindstrom@example.com",
   email_verified: true,
   last_ip: "",
   identities: [
@@ -40,8 +49,7 @@ const EXPECTED_NEW_USER = {
   ],
   login_count: 0,
   is_social: true,
-  profileData:
-    '{"locale":"es-ES","name":"John Doe","given_name":"John","family_name":"Doe","picture":"https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c"}',
+  profileData: JSON.stringify(EXPECTED_PROFILE_DATA),
   user_id: "demo-social-provider|123456789012345678901",
 };
 
@@ -141,8 +149,8 @@ describe("social sign on", () => {
         expect(idTokenPayload.sub).toBe(
           "demo-social-provider|123456789012345678901",
         );
-        expect(idTokenPayload.name).toBe("john.doe@example.com");
-        expect(idTokenPayload.email).toBe("john.doe@example.com");
+        expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
+        expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
         expect(idTokenPayload.email_verified).toBe(true);
         // the same that we passed in
         expect(idTokenPayload.nonce).toBe("MnjcTg0ay3xqf3JVqIL05ib.n~~eZcL_");
@@ -250,8 +258,8 @@ describe("social sign on", () => {
         expect(idTokenPayload.sub).toBe(
           "demo-social-provider|123456789012345678901",
         );
-        expect(idTokenPayload.name).toBe("john.doe@example.com");
-        expect(idTokenPayload.email).toBe("john.doe@example.com");
+        expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
+        expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
         expect(idTokenPayload.email_verified).toBe(true);
         // the same that we passed in
         expect(idTokenPayload.nonce).toBe("MnjcTg0ay3xqf3JVqIL05ib.n~~eZcL_");
@@ -322,7 +330,7 @@ describe("social sign on", () => {
           "content-type": "application/json",
         },
         body: JSON.stringify({
-          email: "john.doe@example.com",
+          email: "orjan.lindstrom@example.com",
           connection: "email",
           // password: "Test!",
           // will this have email_verfied though? as this is a code account that has never been used...
@@ -334,7 +342,7 @@ describe("social sign on", () => {
       const createEmailUser =
         (await createEmailUserResponse.json()) as UserResponse;
 
-      expect(createEmailUser.email).toBe("john.doe@example.com");
+      expect(createEmailUser.email).toBe("orjan.lindstrom@example.com");
       expect(createEmailUser.identities).toEqual([
         {
           connection: "email",
@@ -385,8 +393,8 @@ describe("social sign on", () => {
       // This is the big change here
       expect(idTokenPayload.sub).not.toBe("demo-social-provider|1234567890");
       expect(idTokenPayload.sub).toBe(createEmailUser.user_id);
-      expect(idTokenPayload.name).toBe("john.doe@example.com");
-      expect(idTokenPayload.email).toBe("john.doe@example.com");
+      expect(idTokenPayload.name).toBe("orjan.lindstrom@example.com");
+      expect(idTokenPayload.email).toBe("orjan.lindstrom@example.com");
       // TODO - we are pretending that the email is always verified
       // expect(idTokenPayload.email_verified).toBe(true);
 
@@ -405,7 +413,7 @@ describe("social sign on", () => {
       );
 
       const newSocialUser = (await newSocialUserRes.json()) as UserResponse;
-      expect(newSocialUser.email).toBe("john.doe@example.com");
+      expect(newSocialUser.email).toBe("orjan.lindstrom@example.com");
 
       // ---------------------------------------------
       // check that the primary user has new identities
@@ -436,12 +444,12 @@ describe("social sign on", () => {
           user_id: "123456789012345678901",
           isSocial: true,
           profileData: {
-            name: "John Doe",
-            given_name: "John",
-            family_name: "Doe",
+            name: "Örjan Lindström",
+            given_name: "Örjan",
+            family_name: "Lindström",
             picture:
               "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
-            email: "john.doe@example.com",
+            email: "orjan.lindstrom@example.com",
             email_verified: true,
             locale: "es-ES",
           },
@@ -469,8 +477,8 @@ describe("social sign on", () => {
         // testing this means it must be working
         sub: createEmailUser.user_id,
         aud: "clientId",
-        name: "john.doe@example.com",
-        email: "john.doe@example.com",
+        name: "orjan.lindstrom@example.com",
+        email: "orjan.lindstrom@example.com",
         email_verified: false,
         nonce: "nonce",
         iss: "https://example.com/",
@@ -559,12 +567,12 @@ describe("social sign on", () => {
           user_id: "123456789012345678901",
           isSocial: true,
           profileData: {
-            name: "John Doe",
-            given_name: "John",
-            family_name: "Doe",
+            name: "Örjan Lindström",
+            given_name: "Örjan",
+            family_name: "Lindström",
             picture:
               "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
-            email: "john.doe@example.com",
+            email: "orjan.lindstrom@example.com",
             email_verified: true,
             locale: "es-ES",
           },
@@ -575,12 +583,12 @@ describe("social sign on", () => {
           user_id: "10451045104510451",
           isSocial: true,
           profileData: {
-            given_name: "John",
-            family_name: "Doe",
-            name: "John Doe",
+            name: "Örjan Lindström",
+            given_name: "Örjan",
+            family_name: "Lindström",
             picture:
               "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1010",
-            email: "john.doe@example.com",
+            email: "orjan.lindstrom@example.com",
             email_verified: true,
           },
         },

--- a/integration-test/management-api/users-by-email.spec.ts
+++ b/integration-test/management-api/users-by-email.spec.ts
@@ -69,8 +69,8 @@ describe("users by email", () => {
     expect(users[0]).toMatchObject({
       email: "foo@example.com",
       email_verified: true,
-      name: "Foo Bar",
-      nickname: "Foo",
+      name: "Åkesson Þorsteinsson",
+      nickname: "Åkesson Þorsteinsson",
       picture: "https://example.com/foo.png",
       tenant_id: "tenantId",
       login_count: 0,
@@ -130,8 +130,8 @@ describe("users by email", () => {
     expect(users[0]).toMatchObject({
       email: "foo@example.com",
       email_verified: true,
-      name: "Foo Bar",
-      nickname: "Foo",
+      name: "Åkesson Þorsteinsson",
+      nickname: "Åkesson Þorsteinsson",
       picture: "https://example.com/foo.png",
       tenant_id: "tenantId",
       login_count: 0,

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -46,8 +46,7 @@ class MockOAuth2Client implements IOAuth2Client {
         given_name: "Örjan",
         family_name: "Lindström",
         at_hash: "atHash",
-        // can we put non-ascii characters here? I don't think so
-        email: "john.doe@example.com",
+        email: "orjan.lindstrom@example.com",
         picture:
           "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1010",
         nonce: "abc123",
@@ -77,7 +76,7 @@ class MockOAuth2Client implements IOAuth2Client {
         name: "Örjan Lindström",
         given_name: "Örjan",
         family_name: "Lindström",
-        email: "john.doe@example.com",
+        email: "orjan.lindstrom@example.com",
         picture:
           "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
         nonce: "abc123",

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -41,7 +41,6 @@ class MockOAuth2Client implements IOAuth2Client {
         aud: "250848680337272",
         exp: 1616470948,
         iat: 1616467348,
-        // set another swedish name here
         name: "Örjan Lindström",
         given_name: "Örjan",
         family_name: "Lindström",

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -41,10 +41,12 @@ class MockOAuth2Client implements IOAuth2Client {
         aud: "250848680337272",
         exp: 1616470948,
         iat: 1616467348,
-        name: "John Doe",
-        given_name: "John",
-        family_name: "Doe",
+        // set another swedish name here
+        name: "Örjan Lindström",
+        given_name: "Örjan",
+        family_name: "Lindström",
         at_hash: "atHash",
+        // can we put non-ascii characters here? I don't think so
         email: "john.doe@example.com",
         picture:
           "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1010",
@@ -72,9 +74,9 @@ class MockOAuth2Client implements IOAuth2Client {
         locale: "es-ES",
         exp: 1616470948,
         iat: 1616467348,
-        name: "John Doe",
-        given_name: "John",
-        family_name: "Doe",
+        name: "Örjan Lindström",
+        given_name: "Örjan",
+        family_name: "Lindström",
         email: "john.doe@example.com",
         picture:
           "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",

--- a/integration-test/mockOauth2Client.ts
+++ b/integration-test/mockOauth2Client.ts
@@ -45,7 +45,7 @@ class MockOAuth2Client implements IOAuth2Client {
         given_name: "Örjan",
         family_name: "Lindström",
         at_hash: "atHash",
-        email: "orjan.lindstrom@example.com",
+        email: "örjan.lindström@example.com",
         picture:
           "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1010",
         nonce: "abc123",
@@ -75,7 +75,7 @@ class MockOAuth2Client implements IOAuth2Client {
         name: "Örjan Lindström",
         given_name: "Örjan",
         family_name: "Lindström",
-        email: "orjan.lindstrom@example.com",
+        email: "örjan.lindström@example.com",
         picture:
           "https://lh3.googleusercontent.com/a/ACg8ocKL2otiYIMIrdJso1GU8GtpcY9laZFqo7pfeHAPkU5J=s96-c",
         nonce: "abc123",

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -153,8 +153,9 @@ data.users.create("tenantId", {
   id: "userId",
   email: "foo@example.com",
   email_verified: true,
-  name: "Foo Bar",
-  nickname: "Foo",
+  name: "Åkesson Þorsteinsson",
+  // no nicknames for the norse!
+  nickname: "Åkesson Þorsteinsson",
   picture: "https://example.com/foo.png",
   tenant_id: "tenantId",
   login_count: 0,

--- a/integration-test/test-server.ts
+++ b/integration-test/test-server.ts
@@ -154,7 +154,7 @@ data.users.create("tenantId", {
   email: "foo@example.com",
   email_verified: true,
   name: "Åkesson Þorsteinsson",
-  // no nicknames for the norse!
+  // use a norse nickname here? more realistic
   nickname: "Åkesson Þorsteinsson",
   picture: "https://example.com/foo.png",
   tenant_id: "tenantId",


### PR DESCRIPTION
This was a legit bug we had on production for ages

By default, no tests should be in English or with English names, a bit like the survivors of a raid :sunglasses: 

![image](https://github.com/sesamyab/auth/assets/8496063/9a9bdc9f-9b46-442b-aa1b-fbcd8c48c82f)
