### PR TITLE
fix: correct name domain columns

### DIFF
--- a/src/models/DefaultSettings.ts
+++ b/src/models/DefaultSettings.ts
@@ -31,7 +31,7 @@ const DefaultSettingsSchema = z.object({
         email_service: z
           .union([z.literal("mailchannels"), z.literal("mailgun")])
           .optional(),
-        api_key: z.string().optional(),
+        email_api_key: z.string().optional(),
       }),
     )
     .optional(),

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -15,11 +15,11 @@ export default async function sendEmail(
 
   switch (domain?.email_service) {
     case "mailgun":
-      if (!domain.api_key) {
+      if (!domain.email_api_key) {
         throw new Error("Api key required");
       }
 
-      return sendWithMailgun(emailOptions, domain.api_key);
+      return sendWithMailgun(emailOptions, domain.email_api_key);
     case "mailchannels":
     default:
       return sendWithMailchannels(emailOptions, domain?.dkim_private_key);

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -8,7 +8,7 @@ export const ClientDomainSchema = z.object({
   domain: z.string(),
   dkim_private_key: z.string().optional(),
   dkim_public_key: z.string().optional(),
-  api_key: z.string().optional(),
+  email_api_key: z.string().optional(),
   email_service: z
     .union([z.literal("mailgun"), z.literal("mailchannels")])
     .optional(),

--- a/src/types/sql/Domain.ts
+++ b/src/types/sql/Domain.ts
@@ -6,6 +6,6 @@ export interface SqlDomain {
   domain: string;
   dkim_private_key?: string;
   dkim_public_key?: string;
-  api_key?: string;
+  email_api_key?: string;
   email_service?: "mailgun" | "mailchannels";
 }

--- a/test/fixtures/client.ts
+++ b/test/fixtures/client.ts
@@ -65,7 +65,7 @@ export const DOMAINS_FIXTURE: SqlDomain[] = [
   {
     id: "domainId",
     domain: "example2.com",
-    api_key: "apiKey",
+    email_api_key: "apiKey",
     email_service: "mailgun",
     tenant_id: "tenantId",
     created_at: "created_at",

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -126,7 +126,7 @@ describe("getClient", () => {
 
     expect(client!.domains).toEqual([
       {
-        api_key: "apiKey",
+        email_api_key: "apiKey",
         domain: "example2.com",
         email_service: "mailgun",
       },
@@ -162,7 +162,7 @@ describe("getClient", () => {
     expect(client!.domains).toEqual([
       {
         domain: "example2.com",
-        api_key: "apiKey",
+        email_api_key: "apiKey",
         email_service: "mailgun",
       },
       {

--- a/test/services/getClient.spec.ts
+++ b/test/services/getClient.spec.ts
@@ -53,7 +53,7 @@ const CONNECTION_FIXTURE: SqlConnection = {
 const DOMAIN_FIXTURE: SqlDomain = {
   id: "domainId",
   domain: "example2.com",
-  api_key: "apiKey",
+  email_api_key: "apiKey",
   email_service: "mailgun",
   tenant_id: "tenantId",
   created_at: "created_at",


### PR DESCRIPTION
Ooops we had the wrong column name in the SQL typescript type


Maybe we could have renamed the database field... but migrating the db always feels less clean