### PR TITLE
fix: do not just take first `users.getByEmail` result as the account we want

### DIFF
--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -375,7 +375,6 @@ export class LoginController extends Controller {
       let [user] = await getUsersByEmail(
         env.data.users,
         client.tenant_id,
-        // what is user name here? I'm not sure if this route actually works...
         loginParams.username,
       );
 
@@ -467,23 +466,21 @@ export class LoginController extends Controller {
       await env.data.universalLoginSessions.update(session.id, session);
     }
 
-    // TODO - filter by primary user
-    const users = await getUsersByEmail(
-      env.data.users,
-      client.tenant_id,
-      params.username,
-    );
+    const user = await getUserByEmailAndProvider({
+      userAdapter: env.data.users,
+      tenant_id: client.tenant_id,
+      email: params.username,
+      provider: "Username-Password-Authentication",
+    });
 
-    const auth2User = users.find((user) => user.provider === "auth2");
-
-    if (auth2User) {
+    if (user) {
       const code = generateOTP();
 
       await env.data.codes.create(client.tenant_id, {
         id: nanoid(),
         code,
         type: "password_reset",
-        user_id: auth2User.id,
+        user_id: user.id,
         created_at: new Date().toISOString(),
         expires_at: new Date(Date.now() + CODE_EXPIRATION_TIME).toISOString(),
       });
@@ -547,26 +544,22 @@ export class LoginController extends Controller {
     if (!client) {
       throw new HTTPException(400, { message: "Client not found" });
     }
+    // Note! we don't use the primary user here. Something to be careful of
+    // this means the primary user could have a totally different email address
+    const user = await getUserByEmailAndProvider({
+      userAdapter: env.data.users,
+      tenant_id: client.tenant_id,
+      email: session.authParams.username,
+      provider: "auth2",
+    });
 
-    const users = await env.data.users.getByEmail(
-      client.tenant_id,
-      session.authParams.username,
-    );
-
-    const auth2User = users.find((user) => user.provider === "auth2");
-
-    if (!auth2User) {
+    if (!user) {
       throw new HTTPException(400, { message: "User not found" });
     }
 
     try {
-<<<<<<< HEAD
       const codes = await env.data.codes.list(client.tenant_id, user.id);
       const foundCode = codes.find((storedCode) => storedCode.code === code);
-=======
-      const codes = await env.data.codes.list(client.tenant_id, auth2User.id);
-      const foundCode = codes.find((otp) => otp.code === code);
->>>>>>> 95445a37 (fix: select correct auth2 user providers on login flow routes)
 
       if (!foundCode) {
         return renderEnterCode(env, this, session, "Code not found or expired");

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -602,12 +602,12 @@ export class LoginController extends Controller {
       throw new HTTPException(400, { message: "Client not found" });
     }
 
-    const users = await env.data.users.getByEmail(
-      client.tenant_id,
-      loginParams.username,
-    );
-
-    const auth2User = users.find((user) => user.provider === "auth2");
+    const auth2User = await getUserByEmailAndProvider({
+      userAdapter: env.data.users,
+      tenant_id: client.tenant_id,
+      email: loginParams.username,
+      provider: "auth2",
+    });
 
     if (!auth2User) {
       throw new HTTPException(400, { message: "User not found" });

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -544,6 +544,7 @@ export class LoginController extends Controller {
     if (!client) {
       throw new HTTPException(400, { message: "Client not found" });
     }
+
     // Note! we don't use the primary user here. Something to be careful of
     // this means the primary user could have a totally different email address
     const user = await getUserByEmailAndProvider({
@@ -602,20 +603,20 @@ export class LoginController extends Controller {
       throw new HTTPException(400, { message: "Client not found" });
     }
 
-    const auth2User = await getUserByEmailAndProvider({
+    const user = await getUserByEmailAndProvider({
       userAdapter: env.data.users,
       tenant_id: client.tenant_id,
       email: loginParams.username,
       provider: "auth2",
     });
 
-    if (!auth2User) {
+    if (!user) {
       throw new HTTPException(400, { message: "User not found" });
     }
 
     try {
       const { valid } = await env.data.passwords.validate(client.tenant_id, {
-        user_id: auth2User.id,
+        user_id: user.id,
         password: loginParams.password,
       });
 
@@ -623,7 +624,7 @@ export class LoginController extends Controller {
         return renderLogin(env, this, session, state, "Invalid password");
       }
 
-      return handleLogin(env, this, auth2User, session);
+      return handleLogin(env, this, user, session);
     } catch (err: any) {
       return renderLogin(env, this, session, err.message);
     }


### PR DESCRIPTION
##### March 12th
A glorious day! Final change done :partying_face: 


##### March 8th
We've started actually doing the username-password implementation!


#### Feb 23rd
Passwordless has been fixed on another much smaller PR :ok: 


#### Feb 22nd - the saga continues!
We fixed passwordless linking on another much smaller PR so I'll rebase this one now and see what else is left



In lots of cases this was correct as the first user added is the first user returned so, by definition, it is the primary account

*but* it was not always correct


#### Jan 26th
We had an issue today on our CI/CD because one of the password logings was failing
We we're trying to find the user by an email lookup, but the using a newer code login user and then trying to find a password...
Which acts the same as though the password is invalid :sweat: 


#### TODO
I feel like we should
1. discuss each flow on this PR
2. probably break up each one into a new PR - we want to be sure we understand this and not create issues
3. add way more test fixtures... so we're always trying sign ups with new emails, existing emails, logging in with primary & secondary users
4. confirm how deep the linking should go!  Are we getting recursive? `while (!!user.linked_to)` :upside_down_face: 