### PR TITLE
fix: pass error in correctly to login render

### DIFF
--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -432,7 +432,7 @@ export class LoginController extends Controller {
 
       return handleLogin(env, this, user, session);
     } catch (err: any) {
-      return renderSignup(env, this, session, err.message);
+      return renderSignup(env, this, session, state, err.message);
     }
   }
 


### PR DESCRIPTION
I made similar fixes to other routes

I'm not sure the signup route works correctly... If I signup with an email+password, and then I sign up again for the same email + different password - there's some error but I can't see it

Then neither work :thinking: 