### PR TITLE
fix: pin node types to 18.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/bcryptjs": "^2.4.4",
     "@types/cookie": "^0.6.0",
     "@types/jest": "^29.5.5",
-    "@types/node": "^20.8.3",
+    "@types/node": "18.13.0",
     "@types/service-worker-mock": "^2.0.2",
     "cloudworker-router": "^4.1.5",
     "dotenv": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,12 +1491,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^20.8.3":
+"@types/node@*":
   version "20.8.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.9.tgz#646390b4fab269abce59c308fc286dcd818a2b08"
   integrity sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@18.13.0":
+  version "18.13.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
+  integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
 
 "@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.1":
   version "2.4.3"


### PR DESCRIPTION
No issue with the upgrade actually