### PR TITLE
test: helper functions to create fixtures

### DIFF
--- a/integration-test/management-api/users.spec.ts
+++ b/integration-test/management-api/users.spec.ts
@@ -2,6 +2,7 @@ import { UserResponse } from "../../src/types/auth0";
 import { getAdminToken } from "../helpers/token";
 import { start } from "../start";
 import type { UnstableDevWorker } from "wrangler";
+import createTestUsers from "../setups/createTestUsers";
 
 describe("users", () => {
   let worker: UnstableDevWorker;
@@ -210,37 +211,7 @@ describe("users", () => {
     it("should link two users using link_to parameter", async () => {
       const token = await getAdminToken();
 
-      const createUserResponse1 = await worker.fetch("/api/v2/users", {
-        method: "POST",
-        body: JSON.stringify({
-          email: "test1@example.com",
-          connection: "email",
-        }),
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "test",
-          "content-type": "application/json",
-        },
-      });
-
-      expect(createUserResponse1.status).toBe(201);
-      const newUser1 = (await createUserResponse1.json()) as UserResponse;
-
-      const createUserResponse2 = await worker.fetch("/api/v2/users", {
-        method: "POST",
-        body: JSON.stringify({
-          email: "test2@example.com",
-          connection: "email",
-        }),
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "test",
-          "content-type": "application/json",
-        },
-      });
-
-      expect(createUserResponse2.status).toBe(201);
-      const newUser2 = (await createUserResponse2.json()) as UserResponse;
+      const [newUser1, newUser2] = await createTestUsers(worker);
 
       const linkUserResponse = await worker.fetch(
         `/api/v2/users/${newUser1.id}/identities`,
@@ -356,37 +327,7 @@ describe("users", () => {
     it("should link two users using user_id and provider parameter", async () => {
       const token = await getAdminToken();
 
-      const createUserResponse1 = await worker.fetch("/api/v2/users", {
-        method: "POST",
-        body: JSON.stringify({
-          email: "test1@example.com",
-          connection: "email",
-        }),
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "test",
-          "content-type": "application/json",
-        },
-      });
-
-      expect(createUserResponse1.status).toBe(201);
-      const newUser1 = (await createUserResponse1.json()) as UserResponse;
-
-      const createUserResponse2 = await worker.fetch("/api/v2/users", {
-        method: "POST",
-        body: JSON.stringify({
-          email: "test2@example.com",
-          connection: "email",
-        }),
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "test",
-          "content-type": "application/json",
-        },
-      });
-
-      expect(createUserResponse2.status).toBe(201);
-      const newUser2 = (await createUserResponse2.json()) as UserResponse;
+      const [newUser1, newUser2] = await createTestUsers(worker);
 
       const [provider] = newUser2.id.split("|");
       const linkUserResponse = await worker.fetch(

--- a/integration-test/management-api/users.spec.ts
+++ b/integration-test/management-api/users.spec.ts
@@ -352,98 +352,98 @@ describe("users", () => {
       // this shows we have unlinked
       expect(user1.identities.length).toBe(1);
     });
-  });
 
-  it("should link two users using user_id and provider parameter", async () => {
-    const token = await getAdminToken();
+    it("should link two users using user_id and provider parameter", async () => {
+      const token = await getAdminToken();
 
-    const createUserResponse1 = await worker.fetch("/api/v2/users", {
-      method: "POST",
-      body: JSON.stringify({
-        email: "test1@example.com",
-        connection: "email",
-      }),
-      headers: {
-        authorization: `Bearer ${token}`,
-        "tenant-id": "test",
-        "content-type": "application/json",
-      },
-    });
-
-    expect(createUserResponse1.status).toBe(201);
-    const newUser1 = (await createUserResponse1.json()) as UserResponse;
-
-    const createUserResponse2 = await worker.fetch("/api/v2/users", {
-      method: "POST",
-      body: JSON.stringify({
-        email: "test2@example.com",
-        connection: "email",
-      }),
-      headers: {
-        authorization: `Bearer ${token}`,
-        "tenant-id": "test",
-        "content-type": "application/json",
-      },
-    });
-
-    expect(createUserResponse2.status).toBe(201);
-    const newUser2 = (await createUserResponse2.json()) as UserResponse;
-
-    const [provider] = newUser2.id.split("|");
-    const linkUserResponse = await worker.fetch(
-      `/api/v2/users/${newUser1.id}/identities`,
-      {
+      const createUserResponse1 = await worker.fetch("/api/v2/users", {
         method: "POST",
         body: JSON.stringify({
-          provider,
-          user_id: newUser2.id,
+          email: "test1@example.com",
+          connection: "email",
         }),
         headers: {
           authorization: `Bearer ${token}`,
           "tenant-id": "test",
           "content-type": "application/json",
         },
-      },
-    );
+      });
 
-    expect(linkUserResponse.status).toBe(201);
+      expect(createUserResponse1.status).toBe(201);
+      const newUser1 = (await createUserResponse1.json()) as UserResponse;
 
-    // Fetch a single users
-    const userResponse = await worker.fetch(
-      // note we fetch with the user_id prefixed with provider as per the Auth0 standard
-      `/api/v2/users/${newUser2.user_id}`,
-      {
+      const createUserResponse2 = await worker.fetch("/api/v2/users", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "test2@example.com",
+          connection: "email",
+        }),
         headers: {
           authorization: `Bearer ${token}`,
           "tenant-id": "test",
+          "content-type": "application/json",
         },
-      },
-    );
+      });
 
-    expect(userResponse.status).toBe(200);
+      expect(createUserResponse2.status).toBe(201);
+      const newUser2 = (await createUserResponse2.json()) as UserResponse;
 
-    const [, newUser1Id] = newUser1.user_id.split("|");
-    const [, newUser2Id] = newUser2.user_id.split("|");
-
-    const body = (await userResponse.json()) as UserResponse;
-    expect(body.user_id).toBe(newUser2.user_id);
-    expect(body.identities).toEqual([
-      {
-        connection: "email",
-        user_id: newUser2Id,
-        provider: "email",
-        isSocial: false,
-      },
-      {
-        connection: "email",
-        user_id: newUser1Id,
-        provider: "email",
-        isSocial: false,
-        profileData: {
-          email: "test1@example.com",
-          email_verified: false,
+      const [provider] = newUser2.id.split("|");
+      const linkUserResponse = await worker.fetch(
+        `/api/v2/users/${newUser1.id}/identities`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            provider,
+            user_id: newUser2.id,
+          }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "test",
+            "content-type": "application/json",
+          },
         },
-      },
-    ]);
+      );
+
+      expect(linkUserResponse.status).toBe(201);
+
+      // Fetch a single users
+      const userResponse = await worker.fetch(
+        // note we fetch with the user_id prefixed with provider as per the Auth0 standard
+        `/api/v2/users/${newUser2.user_id}`,
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "test",
+          },
+        },
+      );
+
+      expect(userResponse.status).toBe(200);
+
+      const [, newUser1Id] = newUser1.user_id.split("|");
+      const [, newUser2Id] = newUser2.user_id.split("|");
+
+      const body = (await userResponse.json()) as UserResponse;
+      expect(body.user_id).toBe(newUser2.user_id);
+      expect(body.identities).toEqual([
+        {
+          connection: "email",
+          user_id: newUser2Id,
+          provider: "email",
+          isSocial: false,
+        },
+        {
+          connection: "email",
+          user_id: newUser1Id,
+          provider: "email",
+          isSocial: false,
+          profileData: {
+            email: "test1@example.com",
+            email_verified: false,
+          },
+        },
+      ]);
+    });
   });
 });

--- a/integration-test/setups/createTestUsers.ts
+++ b/integration-test/setups/createTestUsers.ts
@@ -1,0 +1,41 @@
+import { UserResponse } from "../../src/types/auth0";
+import type { UnstableDevWorker } from "wrangler";
+import { getAdminToken } from "../helpers/token";
+
+export default async function createTestUsers(worker: UnstableDevWorker) {
+  const token = await getAdminToken();
+
+  const createUserResponse1 = await worker.fetch("/api/v2/users", {
+    method: "POST",
+    body: JSON.stringify({
+      email: "test1@example.com",
+      connection: "email",
+    }),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "tenant-id": "test",
+      "content-type": "application/json",
+    },
+  });
+
+  expect(createUserResponse1.status).toBe(201);
+  const newUser1 = (await createUserResponse1.json()) as UserResponse;
+
+  const createUserResponse2 = await worker.fetch("/api/v2/users", {
+    method: "POST",
+    body: JSON.stringify({
+      email: "test2@example.com",
+      connection: "email",
+    }),
+    headers: {
+      authorization: `Bearer ${token}`,
+      "tenant-id": "test",
+      "content-type": "application/json",
+    },
+  });
+
+  expect(createUserResponse2.status).toBe(201);
+  const newUser2 = (await createUserResponse2.json()) as UserResponse;
+
+  return [newUser1, newUser2];
+}


### PR DESCRIPTION
I removed that `setup()` helper that we weren't actually using (we weren't using any of the fixtures)

But I like the idea though. So I extracted out a common setup helper on the link tests