### PR TITLE
test: annotate what I see as type failure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,8 +26,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_READ_TOKEN }}
 
       - run: yarn lint
+      - run: yarn type-check
       - run: yarn format:ci-cd
       - run: yarn build
       - run: yarn test
       - run: yarn integration
-      - run: yarn type-check

--- a/test/integration/keys.spec.ts
+++ b/test/integration/keys.spec.ts
@@ -33,12 +33,17 @@ describe("keys", () => {
       ISSUER: "https://example.com/",
       READ_PERMISSION: "auth:read",
       WRITE_PERMISSION: "auth:write",
-    }).api.v2.keys.signing.$get(
-      {},
-      {
-        headers: { authorization: `Bearer ${token}`, "tenant-id": "tenantId" },
-      },
-    );
+    })
+      // keys here is failing on types for me
+      .api.v2.keys.signing.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
     const body = await response.text();
     expect(response.status).toBe(200);


### PR DESCRIPTION
![image](https://github.com/sesamyab/auth/assets/8496063/a4f27b4b-03ec-4021-8dcc-42e8c0822018)

Running `tsc` also gives me this. Are we not getting this on our CI/CD?