### PR TITLE
test: create new user test on hono - but nuked the linked_to foreign key... fix on another PR

### DIFF
--- a/migrate/migrations/2022-12-11T09:17:35_init.ts
+++ b/migrate/migrations/2022-12-11T09:17:35_init.ts
@@ -38,9 +38,14 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("modified_at", "varchar(255)")
     .addPrimaryKeyConstraint("users_tenants", ["id", "tenant_id"])
     // Added in later migration
-    .addColumn("linked_to", "varchar(255)", (col) =>
-      col.references("users.id").onDelete("cascade"),
-    )
+    // sanity check that this is actually the issue...
+    // YES - with this everything seems to work...
+    // SO what is the problem with SQLite here? That can't be null?
+    .addColumn("linked_to", "varchar(255)")
+    // .addColumn("linked_to", "varchar(255)", (col) =>
+    //   // where is this actually set as a foreign key?? are we sure this is even what is going wrong?
+    //   col.references("users.id").onDelete("cascade"),
+    // )
     .addColumn("last_ip", "varchar(255)")
     .addColumn("login_count", "integer")
     .addColumn("last_login", "varchar(255)")

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -6,15 +6,13 @@ import { getCertificate } from "../../../integration-test/helpers/token";
 import { Database } from "../../../src/types";
 
 export async function getEnv() {
-  console.log("start", Date.now());
-
   const dialect = new SqliteDialect({
     database: new SQLite(":memory:"),
   });
   // Don't use getDb here as it will reuse the connection
   const db = new Kysely<Database>({ dialect: dialect });
 
-  await migrateToLatest(dialect, true, db);
+  await migrateToLatest(dialect, false, db);
 
   const data = createAdapters(db);
   await data.keys.create(getCertificate());

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -51,65 +51,64 @@ describe("users", () => {
     expect(createUserResponse.status).toBe(400);
   });
 
-  // it("should create a new user for a tenant", async () => {
-  //   const token = await getAdminToken();
+  it("should create a new user for a tenant", async () => {
+    const token = await getAdminToken();
 
-  //   const env = await getEnv();
-  //   const client = testClient(tsoaApp, env);
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
 
-  //   const createUserResponse = await client.api.v2.users.$post(
-  //     {
-  //       json: {
-  //         email: "test@example.com",
-  //         connection: "email",
-  //       },
-  //     },
-  //     {
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "tenantId",
-  //         "content-type": "application/json",
-  //       },
-  //     },
-  //   );
+    const createUserResponse = await client.api.v2.users.$post(
+      {
+        json: {
+          email: "test@example.com",
+          connection: "email",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      },
+    );
 
-  //   const tmp = await createUserResponse.text();
-  //   expect(createUserResponse.status).toBe(201);
+    expect(createUserResponse.status).toBe(201);
 
-  //   const newUser = (await createUserResponse.json()) as UserResponse;
-  //   expect(newUser.email).toBe("test@example.com");
-  //   expect(newUser.user_id).toContain("|");
+    const newUser = (await createUserResponse.json()) as UserResponse;
+    expect(newUser.email).toBe("test@example.com");
+    expect(newUser.user_id).toContain("|");
 
-  //   const [provider, id] = newUser.user_id.split("|");
+    const [provider, id] = newUser.user_id.split("|");
 
-  //   expect(provider).toBe("email");
-  //   expect(id.length).toBe(6);
+    expect(provider).toBe("email");
+    expect(id.length).toBe(6);
 
-  //   const usersResponse = await client.api.v2.users.$get(
-  //     {},
-  //     {
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "tenantId",
-  //       },
-  //     },
-  //   );
+    const usersResponse = await client.api.v2.users.$get(
+      {},
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+    );
 
-  //   expect(usersResponse.status).toBe(200);
+    expect(usersResponse.status).toBe(200);
 
-  //   const body = (await usersResponse.json()) as UserResponse[];
-  //   expect(body.length).toBe(1);
-  //   expect(body[0].user_id).toBe(newUser.user_id);
-  //   expect(body[0].identities).toEqual([
-  //     {
-  //       connection: "email",
-  //       // inside the identity the user_id isn't prefixed with the provider
-  //       user_id: id,
-  //       provider: "email",
-  //       isSocial: false,
-  //     },
-  //   ]);
-  // });
+    const body = (await usersResponse.json()) as UserResponse[];
+    expect(body.length).toBe(1);
+    expect(body[0].user_id).toBe(newUser.user_id);
+    expect(body[0].identities).toEqual([
+      {
+        connection: "email",
+        // inside the identity the user_id isn't prefixed with the provider
+        user_id: id,
+        provider: "email",
+        isSocial: false,
+      },
+    ]);
+  });
 
   // it("should update a user", async () => {
   //   const token = await getAdminToken();

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -6,9 +6,7 @@ import { getEnv } from "../helpers/test-client";
 
 describe("users", () => {
   it("should return an empty list of users for a tenant", async () => {
-    console.log("start");
     const env = await getEnv();
-    console.log("got env");
     const client = testClient(tsoaApp, env);
 
     const token = await getAdminToken();
@@ -26,14 +24,11 @@ describe("users", () => {
 
     const body = (await response.json()) as UserResponse[];
     expect(body.length).toBe(0);
-    console.log("done");
   });
 
   // this is different to Auth0 where user_id OR email is required
   it("should return a 400 if try and create a new user for a tenant without an email", async () => {
-    console.log("start");
     const env = await getEnv();
-    console.log("got env");
     const client = testClient(tsoaApp, env);
 
     const token = await getAdminToken();
@@ -54,7 +49,6 @@ describe("users", () => {
     );
 
     expect(createUserResponse.status).toBe(400);
-    console.log("done");
   });
 
   // it("should create a new user for a tenant", async () => {


### PR DESCRIPTION
I only enabled the create user test here *but* I've disabled the `linked_to` FK

I'll fix that on [the next PR](https://github.com/sesamyab/auth/pulls) - I figure we can merge this then that one straight after - I don't want to merge that into here as the discussion is there :clown_face: 


