### PR TITLE
fix: user integration tests

### DIFF
--- a/__mocks__/nanoid.ts
+++ b/__mocks__/nanoid.ts
@@ -1,5 +1,7 @@
+let counter = 0;
+
 // Nanois is a mess with esm an modules..
 module.exports = {
-  nanoid: () => "testid",
-  customAlphabet: () => () => "testid",
+  nanoid: () => `testid-${counter++}`,
+  customAlphabet: () => () => `testid-${counter++}`,
 };

--- a/migrate/migrations/2022-12-11T09:17:35_init.ts
+++ b/migrate/migrations/2022-12-11T09:17:35_init.ts
@@ -38,8 +38,15 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("modified_at", "varchar(255)")
     .addPrimaryKeyConstraint("users_tenants", ["id", "tenant_id"])
     // Added in later migration
-    .addColumn("linked_to", "varchar(255)", (col) =>
-      col.references("users.id").onDelete("cascade"),
+    // .addColumn("linked_to", "varchar(255)", (col) =>
+    //   col.references("users.id").onDelete("cascade"),
+    // )
+    .addColumn("linked_to", "varchar(255)")
+    .addForeignKeyConstraint(
+      "linked_to_constraint",
+      ["linked_to", "tenant_id"],
+      "users",
+      ["id", "tenant_id"],
     )
     .addColumn("last_ip", "varchar(255)")
     .addColumn("login_count", "integer")

--- a/migrate/migrations/2023-10-26T08:14:09_log_table.ts
+++ b/migrate/migrations/2023-10-26T08:14:09_log_table.ts
@@ -13,11 +13,19 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("category", "varchar(255)", (col) => col.notNull())
     .addColumn("message", "varchar(255)", (col) => col.notNull())
     // Added in later migration
-    .addColumn("tenant_id", "varchar(255)", (col) =>
-      col.references("tenants.id").onDelete("cascade").notNull(),
-    )
-    .addColumn("user_id", "varchar(255)", (col) =>
-      col.references("users.id").onDelete("cascade").notNull(),
+    // .addColumn("tenant_id", "varchar(255)", (col) =>
+    //   col.references("tenants.id").onDelete("cascade").notNull(),
+    // )
+    // .addColumn("user_id", "varchar(255)", (col) =>
+    //   col.references("users.id").onDelete("cascade").notNull(),
+    // )
+    .addColumn("tenant_id", "varchar(255)")
+    .addColumn("user_id", "varchar(255)")
+    .addForeignKeyConstraint(
+      "user_id_constraint",
+      ["user_id", "tenant_id"],
+      "users",
+      ["id", "tenant_id"],
     )
     // End added columns
     .execute();

--- a/src/adapters/kysely/users/booleans.ts
+++ b/src/adapters/kysely/users/booleans.ts
@@ -1,7 +1,7 @@
 import { User } from "../../../types";
 
 /** Mysql doesn't have a boolean type so it uses a integer instead */
-export function fixBooleans(user: User) {
+export function parseBooleans(user: User) {
   if (user.email_verified !== undefined) {
     user.email_verified = !!user.email_verified;
   }

--- a/src/adapters/kysely/users/create.ts
+++ b/src/adapters/kysely/users/create.ts
@@ -15,7 +15,7 @@ export function create(db: Kysely<Database>) {
       if (typeof data[key] === "boolean") {
         data[key] = data[key] ? 1 : 0;
       }
-      data.linked_to = null;
+      // data.linked_to = null;
     });
 
     await db.insertInto("users").values(sqlUser).execute();

--- a/src/adapters/kysely/users/get.ts
+++ b/src/adapters/kysely/users/get.ts
@@ -1,6 +1,6 @@
 import { Database, SqlUser } from "../../../types";
 import { Kysely } from "kysely";
-import { fixBooleans } from "./booleans";
+import { parseBooleans } from "./booleans";
 
 export function get(db: Kysely<Database>) {
   return async (tenantId: string, id: string): Promise<SqlUser | null> => {
@@ -15,6 +15,6 @@ export function get(db: Kysely<Database>) {
       return null;
     }
 
-    return fixBooleans(user);
+    return parseBooleans(user);
   };
 }

--- a/src/adapters/kysely/users/list.ts
+++ b/src/adapters/kysely/users/list.ts
@@ -3,7 +3,7 @@ import { Database } from "../../../types";
 import { Kysely, SelectQueryBuilder } from "kysely";
 import { ListParams } from "../../interfaces/ListParams";
 import getCountAsInt from "../../../utils/getCountAsInt";
-import { fixBooleans } from "./booleans";
+import { parseBooleans } from "./booleans";
 
 const searchableColumns = ["email", "name"];
 
@@ -100,7 +100,7 @@ export function listUsers(db: Kysely<Database>) {
     const countInt = getCountAsInt(count);
 
     return {
-      users: users.map(fixBooleans),
+      users: users.map(parseBooleans),
       start: (params.page - 1) * params.per_page,
       limit: params.per_page,
       length: countInt,

--- a/src/adapters/kysely/users/update.ts
+++ b/src/adapters/kysely/users/update.ts
@@ -7,10 +7,17 @@ export function update(db: Kysely<Database>) {
     id: string,
     user: Partial<BaseUser>,
   ): Promise<boolean> => {
+    const booleans: any = {};
+
+    if (user.email_verified !== undefined) {
+      booleans.email_verified = user.email_verified ? 1 : 0;
+    }
+
     const results = await db
       .updateTable("users")
       .set({
         ...user,
+        ...booleans,
         updated_at: new Date().toISOString(),
       })
       .where("users.tenant_id", "=", tenant_id)

--- a/test/authentication-flows/ticket.spec.ts
+++ b/test/authentication-flows/ticket.spec.ts
@@ -68,7 +68,7 @@ describe("passwordlessAuth", () => {
     expect(controller.getStatus()).toEqual(302);
     expect(accessToken).toEqual({
       aud: "default",
-      sub: "email|testid",
+      sub: "email|testid-0",
       scope: "openid profile email",
       iss: "https://auth.example.com/",
       iat: Math.floor(date.getTime() / 1000),

--- a/test/helpers/silent-auth-cookie.spec.ts
+++ b/test/helpers/silent-auth-cookie.spec.ts
@@ -1,6 +1,5 @@
 import { contextFixture, controllerFixture } from "../fixtures";
 import { setSilentAuthCookies } from "../../src/helpers/silent-auth-cookie";
-import { AuthParams, Profile } from "../../src/types";
 import { headers } from "../../src/constants";
 import { testUser } from "../fixtures/user";
 
@@ -19,7 +18,7 @@ describe("silentAuthCookie", () => {
 
     const cookie = controller.getHeader(headers.setCookie) as string;
     expect(cookie).toBe(
-      "auth-token=testid; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=None",
+      "auth-token=testid-0; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=None",
     );
   });
 });

--- a/test/integration/helpers/createTestUsers.ts
+++ b/test/integration/helpers/createTestUsers.ts
@@ -1,0 +1,50 @@
+import { testClient } from "hono/testing";
+import { getAdminToken } from "../../../integration-test/helpers/token";
+import { UserResponse } from "../../../src/types/auth0";
+import { EnvType } from "./test-client";
+import { tsoaApp } from "../../../src/app";
+
+export default async function createTestUsers(env: EnvType) {
+  const token = await getAdminToken();
+  const client = testClient(tsoaApp, env);
+
+  const createUserResponse1 = await client.api.v2.users.$post(
+    {
+      json: {
+        email: "test1@example.com",
+        connection: "email",
+      },
+    },
+    {
+      headers: {
+        authorization: `Bearer ${token}`,
+        "tenant-id": "tenantId",
+        "content-type": "application/json",
+      },
+    },
+  );
+
+  expect(createUserResponse1.status).toBe(201);
+  const newUser1 = (await createUserResponse1.json()) as UserResponse;
+
+  const createUserResponse2 = await client.api.v2.users.$post(
+    {
+      json: {
+        email: "test2@example.com",
+        connection: "email",
+      },
+    },
+    {
+      headers: {
+        authorization: `Bearer ${token}`,
+        "tenant-id": "tenantId",
+        "content-type": "application/json",
+      },
+    },
+  );
+
+  expect(createUserResponse2.status).toBe(201);
+  const newUser2 = (await createUserResponse2.json()) as UserResponse;
+
+  return [newUser1, newUser2];
+}

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -6,8 +6,6 @@ import { getCertificate } from "../../../integration-test/helpers/token";
 import { Database } from "../../../src/types";
 
 export async function getEnv() {
-  console.log("start", Date.now());
-
   const dialect = new SqliteDialect({
     database: new SQLite(":memory:"),
   });
@@ -35,3 +33,5 @@ export async function getEnv() {
     db,
   };
 }
+
+export type EnvType = Awaited<ReturnType<typeof getEnv>>;

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -3,12 +3,11 @@ import { tsoaApp } from "../../../src/app";
 import { UserResponse } from "../../../src/types/auth0";
 import { getAdminToken } from "../../../integration-test/helpers/token";
 import { getEnv } from "../helpers/test-client";
+import createTestUsers from "../helpers/createTestUsers";
 
 describe("users", () => {
   it("should return an empty list of users for a tenant", async () => {
-    console.log("start");
     const env = await getEnv();
-    console.log("got env");
     const client = testClient(tsoaApp, env);
 
     const token = await getAdminToken();
@@ -31,9 +30,7 @@ describe("users", () => {
 
   // this is different to Auth0 where user_id OR email is required
   it("should return a 400 if try and create a new user for a tenant without an email", async () => {
-    console.log("start");
     const env = await getEnv();
-    console.log("got env");
     const client = testClient(tsoaApp, env);
 
     const token = await getAdminToken();
@@ -54,337 +51,376 @@ describe("users", () => {
     );
 
     expect(createUserResponse.status).toBe(400);
-    console.log("done");
   });
 
-  // it("should create a new user for a tenant", async () => {
-  //   const token = await getAdminToken();
+  it("should create a new user for a tenant", async () => {
+    const token = await getAdminToken();
 
-  //   const env = await getEnv();
-  //   const client = testClient(tsoaApp, env);
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
 
-  //   const createUserResponse = await client.api.v2.users.$post(
-  //     {
-  //       json: {
-  //         email: "test@example.com",
-  //         connection: "email",
-  //       },
-  //     },
-  //     {
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "tenantId",
-  //         "content-type": "application/json",
-  //       },
-  //     },
-  //   );
+    const createUserResponse = await client.api.v2.users.$post(
+      {
+        json: {
+          email: "test@example.com",
+          connection: "email",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      },
+    );
 
-  //   const tmp = await createUserResponse.text();
-  //   expect(createUserResponse.status).toBe(201);
+    expect(createUserResponse.status).toBe(201);
 
-  //   const newUser = (await createUserResponse.json()) as UserResponse;
-  //   expect(newUser.email).toBe("test@example.com");
-  //   expect(newUser.user_id).toContain("|");
+    const newUser = (await createUserResponse.json()) as UserResponse;
+    expect(newUser.email).toBe("test@example.com");
+    expect(newUser.user_id).toContain("|");
 
-  //   const [provider, id] = newUser.user_id.split("|");
+    const [provider, id] = newUser.user_id.split("|");
 
-  //   expect(provider).toBe("email");
-  //   expect(id.length).toBe(6);
+    expect(provider).toBe("email");
+    expect(id.startsWith("testid-")).toBe(true);
 
-  //   const usersResponse = await client.api.v2.users.$get(
-  //     {},
-  //     {
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "tenantId",
-  //       },
-  //     },
-  //   );
+    const usersResponse = await client.api.v2.users.$get(
+      {},
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+    );
 
-  //   expect(usersResponse.status).toBe(200);
+    expect(usersResponse.status).toBe(200);
 
-  //   const body = (await usersResponse.json()) as UserResponse[];
-  //   expect(body.length).toBe(1);
-  //   expect(body[0].user_id).toBe(newUser.user_id);
-  //   expect(body[0].identities).toEqual([
-  //     {
-  //       connection: "email",
-  //       // inside the identity the user_id isn't prefixed with the provider
-  //       user_id: id,
-  //       provider: "email",
-  //       isSocial: false,
-  //     },
-  //   ]);
-  // });
+    const body = (await usersResponse.json()) as UserResponse[];
+    expect(body.length).toBe(1);
+    expect(body[0].user_id).toBe(newUser.user_id);
+    expect(body[0].identities).toEqual([
+      {
+        connection: "email",
+        // inside the identity the user_id isn't prefixed with the provider
+        user_id: id,
+        provider: "email",
+        isSocial: false,
+      },
+    ]);
+  });
 
-  // it("should update a user", async () => {
-  //   const token = await getAdminToken();
+  it("should update a user", async () => {
+    const token = await getAdminToken();
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
 
-  //   const createUserResponse = await worker.fetch("/api/v2/users", {
-  //     method: "POST",
-  //     body: JSON.stringify({
-  //       email: "test@example.com",
-  //       connection: "email",
-  //     }),
-  //     headers: {
-  //       authorization: `Bearer ${token}`,
-  //       "tenant-id": "test",
-  //       "content-type": "application/json",
-  //     },
-  //   });
+    const createUserResponse = await client.api.v2.users.$post(
+      {
+        json: {
+          email: "test@example.com",
+          connection: "email",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      },
+    );
 
-  //   expect(createUserResponse.status).toBe(201);
+    expect(createUserResponse.status).toBe(201);
 
-  //   const newUser = (await createUserResponse.json()) as UserResponse;
-  //   const [provider, id] = newUser.user_id.split("|");
+    const newUser = (await createUserResponse.json()) as UserResponse;
+    const [provider, id] = newUser.user_id.split("|");
 
-  //   const updateUserResponse = await worker.fetch(
-  //     `/api/v2/users/${provider}|${id}`,
-  //     {
-  //       method: "PATCH",
-  //       body: JSON.stringify({
-  //         email_verified: true,
-  //       }),
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "content-type": "application/json",
-  //         "tenant-id": "test",
-  //       },
-  //     },
-  //   );
+    const params = {
+      json: {
+        email_verified: true,
+      },
+      param: {
+        user_id: `${provider}|${id}`,
+      },
+    };
 
-  //   if (updateUserResponse.status !== 200) {
-  //     console.log(await updateUserResponse.text());
-  //   }
+    const updateUserResponse = await client.api.v2.users[":user_id"].$patch(
+      params,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+          "tenant-id": "tenantId",
+        },
+      },
+    );
 
-  //   expect(updateUserResponse.status).toBe(200);
+    if (updateUserResponse.status !== 200) {
+      console.log(await updateUserResponse.text());
+    }
 
-  //   const usersResponse = await worker.fetch("/api/v2/users", {
-  //     headers: {
-  //       authorization: `Bearer ${token}`,
-  //       "tenant-id": "test",
-  //     },
-  //   });
+    expect(updateUserResponse.status).toBe(200);
 
-  //   const body = (await usersResponse.json()) as UserResponse[];
-  //   expect(body.length).toBe(1);
-  //   expect(body[0].email_verified).toBe(true);
-  // });
+    const usersResponse = await client.api.v2.users.$get(
+      {},
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+        },
+      },
+    );
 
-  // describe("search for user", () => {
-  //   it("should search for a user with wildcard search", async () => {
-  //     const token = await getAdminToken();
+    const body = (await usersResponse.json()) as UserResponse[];
+    expect(body.length).toBe(1);
+    expect(body[0].email_verified).toBe(true);
+  });
 
-  //     const createUserResponse = await worker.fetch("/api/v2/users", {
-  //       method: "POST",
-  //       body: JSON.stringify({
-  //         email: "test@example.com",
-  //         connection: "email",
-  //       }),
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "test",
-  //         "content-type": "application/json",
-  //       },
-  //     });
+  describe("search for user", () => {
+    it("should search for a user with wildcard search", async () => {
+      const token = await getAdminToken();
 
-  //     expect(createUserResponse.status).toBe(201);
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
 
-  //     const usersResponse = await worker.fetch(
-  //       "/api/v2/users?page=0&per_page=2&q=example",
-  //       {
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //         },
-  //       },
-  //     );
+      const createUserResponse = await client.api.v2.users.$post(
+        {
+          json: {
+            email: "test@example.com",
+            connection: "email",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+            "content-type": "application/json",
+          },
+        },
+      );
 
-  //     expect(usersResponse.status).toBe(200);
+      expect(createUserResponse.status).toBe(201);
 
-  //     const body = (await usersResponse.json()) as UserResponse[];
-  //     expect(body.length).toBe(1);
-  //   });
-  // });
+      const usersResponse = await client.api.v2.users.$get(
+        {
+          query: {
+            per_page: 2,
+            q: "example",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
-  // describe("link user", () => {
-  //   it("should link two users using link_to parameter", async () => {
-  //     const token = await getAdminToken();
+      expect(usersResponse.status).toBe(200);
 
-  //     const [newUser1, newUser2] = await createTestUsers(worker);
+      const body = (await usersResponse.json()) as UserResponse[];
+      expect(body.length).toBe(1);
+    });
+  });
 
-  //     const linkUserResponse = await worker.fetch(
-  //       `/api/v2/users/${newUser1.id}/identities`,
-  //       {
-  //         method: "POST",
-  //         body: JSON.stringify({
-  //           // so we want to pass up the provider-id, but only persist the id?
-  //           link_with: newUser2.id,
-  //         }),
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //           "content-type": "application/json",
-  //         },
-  //       },
-  //     );
+  describe("link user", () => {
+    it("should link two users using link_to parameter", async () => {
+      const token = await getAdminToken();
 
-  //     expect(linkUserResponse.status).toBe(201);
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+      const [newUser1, newUser2] = await createTestUsers(env);
 
-  //     // Fetch all users
-  //     const listUsersResponse = await worker.fetch("/api/v2/users", {
-  //       headers: {
-  //         authorization: `Bearer ${token}`,
-  //         "tenant-id": "test",
-  //       },
-  //     });
+      const params = {
+        param: {
+          user_id: newUser1.id,
+        },
+        json: {
+          link_with: newUser2.id,
+        },
+      };
+      const linkUserResponse = await client.api.v2.users[
+        ":user_id"
+      ].identities.$post(params, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      });
 
-  //     expect(listUsersResponse.status).toBe(200);
+      expect(linkUserResponse.status).toBe(201);
 
-  //     const usersList = (await listUsersResponse.json()) as UserResponse[];
-  //     expect(usersList.length).toBe(1);
-  //     expect(usersList[0].user_id).toBe(newUser2.user_id);
+      // Fetch all users
+      const listUsersResponse = await client.api.v2.users.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
-  //     // Fetch a single users
-  //     const userResponse = await worker.fetch(
-  //       // note we fetch with the user_id prefixed with provider as per the Auth0 standard
-  //       `/api/v2/users/${newUser2.user_id}`,
-  //       {
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //         },
-  //       },
-  //     );
+      expect(listUsersResponse.status).toBe(200);
 
-  //     expect(userResponse.status).toBe(200);
+      const usersList = (await listUsersResponse.json()) as UserResponse[];
+      expect(usersList.length).toBe(1);
+      expect(usersList[0].user_id).toBe(newUser2.user_id);
 
-  //     const [, newUser1Id] = newUser1.user_id.split("|");
-  //     const [, newUser2Id] = newUser2.user_id.split("|");
+      // Fetch a single users
+      const userResponse = await client.api.v2.users[":user_id"].$get(
+        // note we fetch with the user_id prefixed with provider as per the Auth0 standard
+        {
+          param: { user_id: newUser2.user_id },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
-  //     const body = (await userResponse.json()) as UserResponse;
-  //     expect(body.user_id).toBe(newUser2.user_id);
-  //     expect(body.identities).toEqual([
-  //       {
-  //         connection: "email",
-  //         user_id: newUser2Id,
-  //         provider: "email",
-  //         isSocial: false,
-  //       },
-  //       {
-  //         connection: "email",
-  //         user_id: newUser1Id,
-  //         provider: "email",
-  //         isSocial: false,
-  //         profileData: {
-  //           email: "test1@example.com",
-  //           email_verified: false,
-  //         },
-  //       },
-  //     ]);
+      expect(userResponse.status).toBe(200);
 
-  //     // and now unlink!
+      const [, newUser1Id] = newUser1.user_id.split("|");
+      const [, newUser2Id] = newUser2.user_id.split("|");
 
-  //     const unlinkUserResponse = await worker.fetch(
-  //       `/api/v2/users/${newUser1.id}/identities`,
-  //       {
-  //         method: "DELETE",
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //           "content-type": "application/json",
-  //         },
-  //       },
-  //     );
+      const body = (await userResponse.json()) as UserResponse;
+      expect(body.user_id).toBe(newUser2.user_id);
+      expect(body.identities).toEqual([
+        {
+          connection: "email",
+          user_id: newUser2Id,
+          provider: "email",
+          isSocial: false,
+        },
+        {
+          connection: "email",
+          user_id: newUser1Id,
+          provider: "email",
+          isSocial: false,
+          profileData: {
+            email: "test1@example.com",
+            email_verified: false,
+          },
+        },
+      ]);
 
-  //     expect(unlinkUserResponse.status).toBe(200);
+      // and now unlink!
+      const unlinkUserResponse = await client.api.v2.users[
+        ":user_id"
+      ].identities.$delete(
+        { param: { user_id: newUser1.id } },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+            "content-type": "application/json",
+          },
+        },
+      );
 
-  //     // now fetch user 1 again to check doesn't have user2 as identity
-  //     const userResponse1 = await worker.fetch(
-  //       `/api/v2/users/${newUser1.user_id}`,
-  //       {
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //         },
-  //       },
-  //     );
+      expect(unlinkUserResponse.status).toBe(200);
 
-  //     expect(userResponse1.status).toBe(200);
-  //     const user1 = (await userResponse1.json()) as UserResponse;
-  //     expect(user1.identities).toEqual([
-  //       {
-  //         connection: "email",
-  //         user_id: newUser1.user_id.split("|")[1],
-  //         provider: "email",
-  //         isSocial: false,
-  //       },
-  //     ]);
-  //     // this shows we have unlinked
-  //     expect(user1.identities.length).toBe(1);
-  //   });
+      // now fetch user 1 again to check doesn't have user2 as identity
+      const userResponse1 = await client.api.v2.users[":user_id"].$get(
+        { param: { user_id: newUser1.user_id } },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
-  //   it("should link two users using user_id and provider parameter", async () => {
-  //     const token = await getAdminToken();
+      expect(userResponse1.status).toBe(200);
+      const user1 = (await userResponse1.json()) as UserResponse;
+      expect(user1.identities).toEqual([
+        {
+          connection: "email",
+          user_id: newUser1.user_id.split("|")[1],
+          provider: "email",
+          isSocial: false,
+        },
+      ]);
+      // this shows we have unlinked
+      expect(user1.identities.length).toBe(1);
+    });
 
-  //     const [newUser1, newUser2] = await createTestUsers(worker);
+    it("should link two users using user_id and provider parameter", async () => {
+      const token = await getAdminToken();
 
-  //     const [provider] = newUser2.id.split("|");
-  //     const linkUserResponse = await worker.fetch(
-  //       `/api/v2/users/${newUser1.id}/identities`,
-  //       {
-  //         method: "POST",
-  //         body: JSON.stringify({
-  //           provider,
-  //           user_id: newUser2.id,
-  //         }),
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //           "content-type": "application/json",
-  //         },
-  //       },
-  //     );
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+      const [newUser1, newUser2] = await createTestUsers(env);
 
-  //     expect(linkUserResponse.status).toBe(201);
+      const [provider] = newUser2.id.split("|");
+      const params = {
+        param: { user_id: newUser1.id },
+        json: {
+          provider,
+          user_id: newUser2.id,
+        },
+      };
 
-  //     // Fetch a single users
-  //     const userResponse = await worker.fetch(
-  //       // note we fetch with the user_id prefixed with provider as per the Auth0 standard
-  //       `/api/v2/users/${newUser2.user_id}`,
-  //       {
-  //         headers: {
-  //           authorization: `Bearer ${token}`,
-  //           "tenant-id": "test",
-  //         },
-  //       },
-  //     );
+      const linkUserResponse = await client.api.v2.users[
+        ":user_id"
+      ].identities.$post(params, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      });
 
-  //     expect(userResponse.status).toBe(200);
+      expect(linkUserResponse.status).toBe(201);
 
-  //     const [, newUser1Id] = newUser1.user_id.split("|");
-  //     const [, newUser2Id] = newUser2.user_id.split("|");
+      // Fetch a single users
+      const userResponse = await client.api.v2.users[":user_id"].$get(
+        {
+          param: {
+            // note we fetch with the user_id prefixed with provider as per the Auth0 standard
+            user_id: newUser2.user_id,
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
 
-  //     const body = (await userResponse.json()) as UserResponse;
-  //     expect(body.user_id).toBe(newUser2.user_id);
-  //     expect(body.identities).toEqual([
-  //       {
-  //         connection: "email",
-  //         user_id: newUser2Id,
-  //         provider: "email",
-  //         isSocial: false,
-  //       },
-  //       {
-  //         connection: "email",
-  //         user_id: newUser1Id,
-  //         provider: "email",
-  //         isSocial: false,
-  //         profileData: {
-  //           email: "test1@example.com",
-  //           email_verified: false,
-  //         },
-  //       },
-  //     ]);
-  //   });
-  // });
+      expect(userResponse.status).toBe(200);
+
+      const [, newUser1Id] = newUser1.user_id.split("|");
+      const [, newUser2Id] = newUser2.user_id.split("|");
+
+      const body = (await userResponse.json()) as UserResponse;
+      expect(body.user_id).toBe(newUser2.user_id);
+      expect(body.identities).toEqual([
+        {
+          connection: "email",
+          user_id: newUser2Id,
+          provider: "email",
+          isSocial: false,
+        },
+        {
+          connection: "email",
+          user_id: newUser1Id,
+          provider: "email",
+          isSocial: false,
+          profileData: {
+            email: "test1@example.com",
+            email_verified: false,
+          },
+        },
+      ]);
+    });
+  });
 });

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -250,7 +250,7 @@ describe("authorize", () => {
       const redirectUrl = new URL(locationHeader);
       const state = redirectUrl.searchParams.get("state");
 
-      expect(state).toBe("testid");
+      expect(state?.startsWith("testid-")).toBe(true);
 
       expect(actual).toBe("Redirecting...");
       expect(controller.getStatus()).toBe(302);
@@ -456,7 +456,7 @@ describe("authorize", () => {
       expect(accessToken).toEqual({
         aud: "default",
         scope: "openid profile email",
-        sub: "email|testid",
+        sub: "email|testid-1",
         iss: "https://auth.example.com/",
         iat: Math.floor(date.getTime() / 1000),
         exp: Math.floor(date.getTime() / 1000) + 86400,
@@ -520,9 +520,9 @@ describe("authorize", () => {
 
       expect(idToken).toEqual({
         aud: "clientId",
-        sub: "email|testid",
+        sub: "email|testid-3",
         nonce: "nonce",
-        sid: "testid",
+        sid: "testid-4",
         iss: "https://auth.example.com/",
         iat: Math.floor(date.getTime() / 1000),
         exp: Math.floor(date.getTime() / 1000) + 86400,
@@ -576,14 +576,14 @@ describe("authorize", () => {
           response_type: AuthorizationResponseType.CODE,
           client_id: "clientId",
         },
-        sid: "testid",
+        sid: "testid-6",
         state: "state",
         user: {
           connection: "email",
           created_at: "2023-11-28T12:00:00.000Z",
           email: "test@example.com",
           email_verified: true,
-          id: "email|testid",
+          id: "email|testid-5",
           is_social: false,
           last_ip: "",
           last_login: "2023-11-28T12:00:00.000Z",
@@ -593,7 +593,7 @@ describe("authorize", () => {
           tenant_id: "tenantId",
           updated_at: "2023-11-28T12:00:00.000Z",
         },
-        userId: "email|testid",
+        userId: "email|testid-5",
       });
 
       expect(redirectUrl.searchParams.get("state")).toBe("state");
@@ -625,7 +625,7 @@ describe("authorize", () => {
 
       const locationHeader = controller.getHeader("location") as string;
       // The state is stored in a durable object
-      expect(locationHeader).toBe("/u/login?state=testid");
+      expect(locationHeader).toBe("/u/login?state=testid-7");
     });
   });
 });


### PR DESCRIPTION
This moves the user integrations tests over to using the hono test library and a in-memory sqlite. Hopefully we can remove the in-memory adapter when all tests are moved over to the hono client.
We need to update the foreign keys for the users and the logs to make it work with sqlite.