### PR TITLE
fix: refactor connections to support vipps

### DIFF
--- a/src/adapters/in-memory/clients/getClient.ts
+++ b/src/adapters/in-memory/clients/getClient.ts
@@ -38,8 +38,10 @@ export function getClient(
     );
     if (!tenant) return null;
 
+    const tenantIds = [application.tenant_id, "DEFAULT_SETTINGS"];
+
     const connections = connectionsList
-      .filter((connection) => connection.tenant_id === application.tenant_id)
+      .filter((connection) => tenantIds.includes(connection.tenant_id))
       .map((connection) => removeNullProperties(connection));
 
     const domains = domainsList


### PR DESCRIPTION
We had some old fallbacks for KV-storage and didn't pull the connections from the default settings correctly so we filtered out the connections added to a specific tenant.