### PR TITLE
test: fixing second code flow test

### DIFF
--- a/migrate/migrations/2023-11-19T20:53:00_univeral-login-session.ts
+++ b/migrate/migrations/2023-11-19T20:53:00_univeral-login-session.ts
@@ -21,6 +21,8 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("created_at", "varchar(255)", (col) => col.notNull())
     .addColumn("updated_at", "varchar(255)", (col) => col.notNull())
     .addColumn("expires_at", "varchar(255)", (col) => col.notNull())
+    // 5th Jan 2024 this column was missing
+    .addColumn("nonce", "varchar(255)")
     .execute();
 }
 

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -10,32 +10,32 @@ import { getEnv } from "../helpers/test-client";
 import { Tenant } from "../../../src/types";
 import { EmailAdapter } from "../../../src/adapters/interfaces/Email";
 
-const emailInfo: {
-  email: string;
-  code: string;
-  magicLink?: string;
-}[] = [];
-
-const email: EmailAdapter = {
-  sendLink: (env, client, to, code, magicLink) => {
-    emailInfo.push({
-      email: to,
-      code,
-      magicLink,
-    });
-    return Promise.resolve();
-  },
-  sendCode: (env, client, to, code) => {
-    emailInfo.push({
-      email: to,
-      code,
-    });
-    return Promise.resolve();
-  },
-};
-
 describe("code-flow", () => {
   it("should run a passwordless flow with code", async () => {
+    const emailInfo: {
+      email: string;
+      code: string;
+      magicLink?: string;
+    }[] = [];
+
+    const email: EmailAdapter = {
+      sendLink: (env, client, to, code, magicLink) => {
+        emailInfo.push({
+          email: to,
+          code,
+          magicLink,
+        });
+        return Promise.resolve();
+      },
+      sendCode: (env, client, to, code) => {
+        emailInfo.push({
+          email: to,
+          code,
+        });
+        return Promise.resolve();
+      },
+    };
+
     const token = await getAdminToken();
     const env = (await getEnv()) as any;
     env.data.email = email;
@@ -303,6 +303,30 @@ describe("code-flow", () => {
     });
   });
   it("should return existing primary account when logging in with new code sign on with same email address", async () => {
+    const emailInfo: {
+      email: string;
+      code: string;
+      magicLink?: string;
+    }[] = [];
+
+    const email: EmailAdapter = {
+      sendLink: (env, client, to, code, magicLink) => {
+        emailInfo.push({
+          email: to,
+          code,
+          magicLink,
+        });
+        return Promise.resolve();
+      },
+      sendCode: (env, client, to, code) => {
+        emailInfo.push({
+          email: to,
+          code,
+        });
+        return Promise.resolve();
+      },
+    };
+
     const token = await getAdminToken();
     const env = (await getEnv()) as any;
     env.data.email = email;

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -302,8 +302,7 @@ describe("code-flow", () => {
       iss: "https://example.com/",
     });
   });
-  // wow - this test works in isolation... but NOT when ran after above test...
-  it.only("should return existing primary account when logging in with new code sign on with same email address", async () => {
+  it("should return existing primary account when logging in with new code sign on with same email address", async () => {
     const token = await getAdminToken();
     const env = (await getEnv()) as any;
     env.data.email = email;


### PR DESCRIPTION
This issue looks interesting...

If soloed, this test passes :heavy_check_mark: 

If ran with the previous test, it fails :x: 


The call to authorize to exchange the ticket doesn't give us the correct location header that we set in `applyTokenResponseAsQuery`

Instead we get `/u/login?state=testid-9`

