### PR TITLE
test: properly type client arg for silent auth helper function

### DIFF
--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -6,7 +6,6 @@ import { testClient } from "hono/testing";
 import { tsoaApp } from "../../../src/app";
 import { getAdminToken } from "../../../integration-test/helpers/token";
 import { getEnv } from "../helpers/test-client";
-import { EmailAdapter } from "../../../src/adapters/interfaces/Email";
 
 describe("code-flow", () => {
   it("should run a passwordless flow with code", async () => {
@@ -137,7 +136,7 @@ describe("code-flow", () => {
       idToken: silentAuthIdTokenPayload,
     } = await doSilentAuthRequestAndReturnTokens(
       setCookiesHeader,
-      client.authorize,
+      client,
       AUTH_PARAMS.nonce,
       "clientId",
     );
@@ -229,7 +228,7 @@ describe("code-flow", () => {
     const { idToken: silentAuthIdTokenPayload2 } =
       await doSilentAuthRequestAndReturnTokens(
         setCookiesHeader2,
-        client.authorize,
+        client,
         AUTH_PARAMS.nonce,
         "clientId",
       );
@@ -378,7 +377,7 @@ describe("code-flow", () => {
     const { idToken: silentAuthIdTokenPayload } =
       await doSilentAuthRequestAndReturnTokens(
         setCookiesHeader,
-        client.authorize,
+        client,
         nonce,
         "clientId",
       );
@@ -491,7 +490,7 @@ describe("code-flow", () => {
     const { idToken: silentAuthIdTokenPayload2 } =
       await doSilentAuthRequestAndReturnTokens(
         setCookiesHeader2,
-        client.authorize,
+        client,
         nonce,
         "clientId",
       );

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -113,7 +113,7 @@ describe("code-flow", () => {
         idToken: silentAuthIdTokenPayload,
       } = await doSilentAuthRequestAndReturnTokens(
         authCookieHeader,
-        client.authorize,
+        client,
         AUTH_PARAMS.nonce,
         "clientId",
       );
@@ -246,7 +246,7 @@ describe("code-flow", () => {
       const { idToken: silentAuthIdTokenPayload } =
         await doSilentAuthRequestAndReturnTokens(
           authCookieHeader,
-          client.authorize,
+          client,
           AUTH_PARAMS.nonce,
           "clientId",
         );

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -111,7 +111,7 @@ describe("password-flow", () => {
         idToken: silentAuthIdTokenPayload,
       } = await doSilentAuthRequestAndReturnTokens(
         authCookieHeader,
-        client.authorize,
+        client,
         "unique-nonce",
         "clientId",
       );
@@ -259,7 +259,7 @@ describe("password-flow", () => {
         idToken: silentAuthIdTokenPayload,
       } = await doSilentAuthRequestAndReturnTokens(
         authCookieHeader,
-        client.authorize,
+        client,
         "unique-nonce",
         "clientId",
       );

--- a/test/integration/helpers/silent-auth.ts
+++ b/test/integration/helpers/silent-auth.ts
@@ -1,10 +1,15 @@
 import { parseJwt } from "../../../src/utils/parse-jwt";
+import { testClient } from "hono/testing";
+import { tsoaApp } from "../../../src/app";
+import { getEnv } from "./test-client";
+
+const env = getEnv();
+const client = testClient(tsoaApp, env);
+type clientAppType = typeof client;
 
 export async function doSilentAuthRequestAndReturnTokens(
   setCookiesHeader: string,
-  // don't think hono exports these types...
-  // worth manually recreating it I think
-  authorize: any,
+  client: clientAppType,
   nonce: string,
   clientId: string,
 ) {
@@ -23,7 +28,7 @@ export async function doSilentAuthRequestAndReturnTokens(
     response_mode: "web_message",
   };
 
-  const silentAuthResponse = await authorize.$get(
+  const silentAuthResponse = await client.authorize.$get(
     {
       query,
     },

--- a/test/integration/helpers/silent-auth.ts
+++ b/test/integration/helpers/silent-auth.ts
@@ -1,10 +1,8 @@
 import { parseJwt } from "../../../src/utils/parse-jwt";
 import { testClient } from "hono/testing";
 import { tsoaApp } from "../../../src/app";
-import { getEnv } from "./test-client";
 
-const env = getEnv();
-const client = testClient(tsoaApp, env);
+const client = testClient(tsoaApp, {});
 type clientAppType = typeof client;
 
 export async function doSilentAuthRequestAndReturnTokens(


### PR DESCRIPTION
using `typeof client` for the testing helper function - as discussed here https://github.com/sesamyab/auth/pull/383/files#r1442384913