### PR TITLE
fix: handling nulls coming from database

### DIFF
--- a/src/services/token-factory.ts
+++ b/src/services/token-factory.ts
@@ -120,18 +120,38 @@ export class TokenFactory {
       // The audience for an id token is the client id
       aud: clientId,
       sub: userId,
-      given_name,
-      family_name,
-      nickname,
-      name,
-      email,
-      email_verified,
-      nonce,
       iss,
-      picture,
-      locale,
       sid,
     };
+
+    if (given_name) {
+      payload.given_name = given_name;
+    }
+    if (family_name) {
+      payload.family_name = family_name;
+    }
+    if (nickname) {
+      payload.nickname = nickname;
+    }
+    if (name) {
+      payload.name = name;
+    }
+    if (email !== undefined) {
+      payload.email = email;
+    }
+    if (nonce !== undefined) {
+      payload.nonce = nonce;
+    }
+    if (picture !== undefined) {
+      payload.picture = picture;
+    }
+    if (locale !== undefined) {
+      payload.locale = locale;
+    }
+    // boolean - typescript says can be undefined but can really be null
+    if (email_verified !== undefined || email_verified !== null) {
+      payload.email_verified = email_verified;
+    }
 
     return this.getJwt(payload);
   }

--- a/src/services/token-factory.ts
+++ b/src/services/token-factory.ts
@@ -136,16 +136,16 @@ export class TokenFactory {
     if (name) {
       payload.name = name;
     }
-    if (email !== undefined) {
+    if (email) {
       payload.email = email;
     }
-    if (nonce !== undefined) {
+    if (nonce) {
       payload.nonce = nonce;
     }
-    if (picture !== undefined) {
+    if (picture) {
       payload.picture = picture;
     }
-    if (locale !== undefined) {
+    if (locale) {
       payload.locale = locale;
     }
     // boolean - typescript says can be undefined but can really be null

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -145,12 +145,6 @@ describe("code-flow", () => {
       iat,
       sid,
       sub,
-      // what have I done here to have these fields? some patched id_token endpoint right?
-      family_name,
-      given_name,
-      nickname,
-      locale,
-      picture,
       ...restOfIdTokenPayload
     } = silentAuthIdTokenPayload;
 
@@ -386,10 +380,6 @@ describe("code-flow", () => {
       iat,
       sid,
       sub,
-      //
-      family_name,
-      given_name,
-      locale,
       ...restOfIdTokenPayload
     } = silentAuthIdTokenPayload;
 

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -121,12 +121,6 @@ describe("code-flow", () => {
         iat,
         sid,
         sub,
-        //
-        family_name,
-        given_name,
-        nickname,
-        picture,
-        locale,
         ...restOfIdTokenPayload
       } = silentAuthIdTokenPayload;
 
@@ -248,15 +242,8 @@ describe("code-flow", () => {
           "clientId",
         );
 
-      const {
-        exp,
-        iat,
-        sid,
-        family_name,
-        given_name,
-        locale,
-        ...restOfIdTokenPayload
-      } = silentAuthIdTokenPayload;
+      const { exp, iat, sid, ...restOfIdTokenPayload } =
+        silentAuthIdTokenPayload;
 
       expect(restOfIdTokenPayload).toEqual({
         sub: "userId",

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -117,13 +117,6 @@ describe("password-flow", () => {
         iat,
         sid,
         sub,
-        //
-        family_name,
-        given_name,
-        name,
-        nickname,
-        picture,
-        locale,
         ...restOfIdTokenPayload
       } = silentAuthIdTokenPayload;
       expect(sub).toContain("email|");
@@ -261,16 +254,8 @@ describe("password-flow", () => {
           "unique-nonce",
           "clientId",
         );
-      const {
-        exp,
-        iat,
-        sid,
-
-        family_name,
-        given_name,
-        locale,
-        ...restOfIdTokenPayload
-      } = silentAuthIdTokenPayload;
+      const { exp, iat, sid, ...restOfIdTokenPayload } =
+        silentAuthIdTokenPayload;
       expect(restOfIdTokenPayload).toEqual({
         sub: "userId",
         aud: "clientId",

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -171,16 +171,6 @@ describe("social sign on", () => {
           created_at,
           updated_at,
           last_login,
-          // again, investigate this
-          app_metadata,
-          family_name,
-          given_name,
-          linked_to,
-          locale,
-          nickname,
-          picture,
-          // this is a new one to destructure... might actually be a SQLite issue OR a production issue that we weren't picking up
-          tags,
           ...newSocialUserWithoutDates
         } = newSocialUser;
         expect(newSocialUserWithoutDates).toEqual(EXPECTED_NEW_USER);
@@ -277,16 +267,6 @@ describe("social sign on", () => {
           created_at,
           updated_at,
           last_login,
-          //
-          app_metadata,
-          family_name,
-          given_name,
-          linked_to,
-          locale,
-          nickname,
-          picture,
-          //
-          tags,
           ...newSocialUserWithoutDates
         } = newSocialUser;
         expect(newSocialUserWithoutDates).toEqual(EXPECTED_NEW_USER);

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -55,6 +55,15 @@ const EXPECTED_NEW_USER = {
   is_social: true,
   profileData: JSON.stringify(EXPECTED_PROFILE_DATA),
   user_id: "demo-social-provider|123456789012345678901",
+  // these fields will be returned as null. What do we want? It's a mgmt-api route so check Auth0
+  app_metadata: null,
+  family_name: null,
+  given_name: null,
+  nickname: null,
+  linked_to: null,
+  locale: null,
+  tags: null,
+  picture: null,
 };
 
 describe("social sign on", () => {


### PR DESCRIPTION
~I had to add a lot of extra destructuring... Maybe this is actually what our code is doing and the wrangler tests weren't running the whole flow...~

~Either way, I'll check what we get on production and investigate here~


Ahhhhhh, I hadn't considered this!
* In TypeScript we give the SQL datatypes optional keys to mean they can be `undefined`
* SQL doesn't `undefined`, it has `null`, so this is what is returned
And I think
* in our JS testing, if we get `undefined` back for a value, then the test doesn't complain if our expect object _doesn't_ have e.g. the key `foo: undefined`
_BUT_ it will complain about `foo: null` not being present

:exploding_head: 