### PR TITLE
feat: install buntypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/
 **/.DS_Store
 .vscode
 db.sqlite
+bun.lockb

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/jest": "^29.5.5",
     "@types/node": "18.13.0",
     "@types/service-worker-mock": "^2.0.2",
+    "bun-types": "^1.0.22",
     "cloudworker-router": "^4.1.5",
     "dotenv": "^16.3.1",
     "eslint": "^8.51.0",

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -1,5 +1,4 @@
 import { BunSqliteDialect } from "kysely-bun-sqlite";
-// @ts-ignore
 import * as bunSqlite from "bun:sqlite";
 import app from "../src/app";
 import { oAuth2ClientFactory } from "../src/services/oauth2-client";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2020", "DOM"],
+    "lib": [
+      "es2020",
+      "DOM"
+    ],
     "module": "CommonJS",
     "target": "ES6",
     "strict": true,
@@ -21,11 +24,19 @@
     "types": [
       "@cloudflare/workers-types",
       "@types/jest",
-      "@types/service-worker-mock"
+      "@types/service-worker-mock",
+      "bun-types"
     ],
     "paths": {
-      "*": ["node_modules/*"]
+      "*": [
+        "node_modules/*"
+      ]
     }
   },
-  "include": ["src/**/*", "test/**/*", "integration-test/**/*", "scripts/**/*"]
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "integration-test/**/*",
+    "scripts/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "es2020",
-      "DOM"
-    ],
+    "lib": ["es2020", "DOM"],
     "module": "CommonJS",
     "target": "ES6",
     "strict": true,
@@ -28,15 +25,8 @@
       "bun-types"
     ],
     "paths": {
-      "*": [
-        "node_modules/*"
-      ]
+      "*": ["node_modules/*"]
     }
   },
-  "include": [
-    "src/**/*",
-    "test/**/*",
-    "integration-test/**/*",
-    "scripts/**/*"
-  ]
+  "include": ["src/**/*", "test/**/*", "integration-test/**/*", "scripts/**/*"]
 }


### PR DESCRIPTION
So we don't need to ignore the types when importing `bun:sqlite` *BUT* now we get other type errors... Which make sense as bun is a slightly different environment


#### Issue
Now we actually have the Bun types we're getting complaints because they're slightly different to Node types (suffixed with `Like` it seems :smile: )

e.g. `Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.` 