### PR TITLE
fix: move existing edited new fields into new migration scripts

### DIFF
--- a/migrate/migrations/2023-11-02T23:18:12_sessions.ts
+++ b/migrate/migrations/2023-11-02T23:18:12_sessions.ts
@@ -66,8 +66,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("created_at", "varchar(255)", (col) => col.notNull())
     .addColumn("expires_at", "varchar(255)", (col) => col.notNull())
     .addColumn("used_at", "varchar(255)")
-    // another new column that might not be on planetscale... CHECK!
-    .addColumn("audience", "varchar(255)")
     .execute();
 
   await db.schema

--- a/migrate/migrations/2023-11-19T20:53:00_univeral-login-session.ts
+++ b/migrate/migrations/2023-11-19T20:53:00_univeral-login-session.ts
@@ -21,8 +21,6 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .addColumn("created_at", "varchar(255)", (col) => col.notNull())
     .addColumn("updated_at", "varchar(255)", (col) => col.notNull())
     .addColumn("expires_at", "varchar(255)", (col) => col.notNull())
-    // is this column on planetscale? check! added for SQLite tests
-    .addColumn("nonce", "varchar(255)")
     .execute();
 }
 

--- a/migrate/migrations/2024-01-11T10:58:00_missing-fields.ts
+++ b/migrate/migrations/2024-01-11T10:58:00_missing-fields.ts
@@ -13,4 +13,11 @@ export async function up(db: Kysely<Database>): Promise<void> {
     .execute();
 }
 
-export async function down(db: Kysely<Database>): Promise<void> {}
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("otps").dropColumn("audience").execute();
+
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .dropColumn("nonce")
+    .execute();
+}

--- a/migrate/migrations/2024-01-11T10:58:00_missing-fields.ts
+++ b/migrate/migrations/2024-01-11T10:58:00_missing-fields.ts
@@ -1,0 +1,16 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("otps")
+    .addColumn("audience", "varchar(255)")
+    .execute();
+
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .addColumn("nonce", "varchar(255)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {}

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -16,6 +16,7 @@ import * as n15_userEmailIndex from "./2023-12-08T15:59:00_user-linked-to-index"
 import * as n16_userLocale from "./2023-12-21T15:05:00_user-locale";
 import * as n17_signingKeys from "./2023-12-26T10:58:00_signing-keys";
 import * as n18_logsFields from "./2024-01-06T16:23:00_logs-fields";
+import * as n19_missingFields from "./2024-01-11T10:58:00_missing-fields";
 
 // These need to be in alphabetic order
 export default {
@@ -37,4 +38,5 @@ export default {
   n16_userLocale,
   n17_signingKeys,
   n18_logsFields,
+  n19_missingFields,
 };

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -16,7 +16,7 @@ import * as n15_userEmailIndex from "./2023-12-08T15:59:00_user-linked-to-index"
 import * as n16_userLocale from "./2023-12-21T15:05:00_user-locale";
 import * as n17_signingKeys from "./2023-12-26T10:58:00_signing-keys";
 import * as n18_logsFields from "./2024-01-06T16:23:00_logs-fields";
-import * as n19_missingFields from "./2024-01-11T10:58:00_missing-fields";
+import * as n20_missingFields from "./2024-01-11T10:58:00_missing-fields";
 
 // These need to be in alphabetic order
 export default {
@@ -38,5 +38,5 @@ export default {
   n16_userLocale,
   n17_signingKeys,
   n18_logsFields,
-  n19_missingFields,
+  n20_missingFields,
 };


### PR DESCRIPTION
Edits done in https://github.com/sesamyab/auth/pull/403#event-11448207074 moved into new scripts


I'll rename my migration as https://github.com/sesamyab/auth/pull/409 had this number first