### PR TITLE
fix: tenant_id casing issues on patch routes when using `Partial`

### DIFF
--- a/src/routes/tsoa/domains.ts
+++ b/src/routes/tsoa/domains.ts
@@ -121,7 +121,7 @@ export class DomainsController extends Controller {
     const db = getDbFromEnv(env);
     const domain = {
       ...body,
-      tenantId,
+      tenant_id: tenantId,
       updated_at: new Date().toISOString(),
     };
 


### PR DESCRIPTION
Same issue we had on the connections route