### PR TITLE
fix: use tenant_id in adapter arg not in body

### DIFF
--- a/src/adapters/interfaces/Connections.ts
+++ b/src/adapters/interfaces/Connections.ts
@@ -1,6 +1,6 @@
 import { SqlConnection } from "../../types";
 
-export type CreateConnectionParams = SqlConnection;
+export type CreateConnectionParams = Omit<SqlConnection, "tenant_id">;
 
 export interface ConnectionsAdapter {
   create(

--- a/src/adapters/interfaces/Domains.ts
+++ b/src/adapters/interfaces/Domains.ts
@@ -1,6 +1,6 @@
 import { SqlDomain } from "../../types";
 
-export type CreateDomainParams = SqlDomain;
+export type CreateDomainParams = Omit<SqlDomain, "tenant_id">;
 
 export interface DomainsAdapter {
   create(tenant_id: string, params: CreateDomainParams): Promise<SqlDomain>;

--- a/src/adapters/kysely/connections/create.ts
+++ b/src/adapters/kysely/connections/create.ts
@@ -11,7 +11,7 @@ export function create(db: Kysely<Database>) {
       // inconsistency - some adapters add these fields, others already receive them...
       //   created_at: new Date().toISOString(),
       //   updated_at: new Date().toISOString(),
-      //   tenant_id,
+      tenant_id,
       ...params,
     };
 

--- a/src/adapters/kysely/domains/create.ts
+++ b/src/adapters/kysely/domains/create.ts
@@ -8,6 +8,7 @@ export function create(db: Kysely<Database>) {
     params: CreateDomainParams,
   ): Promise<SqlDomain> => {
     const domain: SqlDomain = {
+      tenant_id,
       ...params,
     };
 

--- a/src/routes/management-api/connections.ts
+++ b/src/routes/management-api/connections.ts
@@ -132,15 +132,12 @@ export class ConnectionsController extends Controller {
     const { ctx } = request;
     const { env } = ctx;
 
-    const connection: SqlConnection = {
+    const connection = await env.data.connections.create(tenantId, {
       ...body,
-      tenant_id: tenantId,
       id: nanoid(),
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-    };
-
-    await env.data.connections.create(tenantId, connection);
+    });
 
     this.setStatus(201);
     return connection;

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -71,7 +71,6 @@ export async function getEnv() {
   });
   data.connections.create("DEFAULT_SETTINGS", {
     id: "DEFAULT_CONNECTION",
-    tenant_id: "DEFAULT_SETTINGS",
     name: "demo-social-provider",
     client_id: "socialClientId",
     client_secret: "socialClientSecret",
@@ -85,7 +84,6 @@ export async function getEnv() {
   });
   data.connections.create("DEFAULT_SETTINGS", {
     id: "DEFAULT_CONNECTION2",
-    tenant_id: "DEFAULT_SETTINGS",
     name: "other-social-provider",
     client_id: "otherSocialClientId",
     client_secret: "otherSocialClientSecret",


### PR DESCRIPTION
`noUnusedParams` reminded me of this

When we call `create` on any of our data adapters, we pass the `tenant_id` in in two places, should we do this fix everywhere?