### PR TITLE
fix: callback route can get error

### DIFF
--- a/src/routes/tsoa/callback.ts
+++ b/src/routes/tsoa/callback.ts
@@ -12,6 +12,7 @@ import {
 import { socialAuthCallback } from "../../authentication-flows";
 import { LoginState, RequestWithContext } from "../../types";
 import { stateDecode } from "../../utils/stateEncode";
+import { headers } from "../../constants";
 @Route("callback")
 @Tags("callback")
 export class CallbackController extends Controller {
@@ -23,23 +24,48 @@ export class CallbackController extends Controller {
   public async getCallback(
     @Request() request: RequestWithContext,
     @Query("state") state: string,
-    @Query("code") code: string,
+    @Query("code") code?: string,
     @Query("scope") scope?: string,
     @Query("prompt") prompt?: string,
     @Query("authuser") authUser?: string,
     @Query("hd") hd?: string,
+    // optional error params
+    @Query("error") error?: string,
+    @Query("error_description") errorDescription?: string,
+    @Query("error_code") errorCode?: string,
+    @Query("error_reason") errorReason?: string,
   ): Promise<string> {
     const loginState: LoginState = stateDecode(state);
     if (!loginState) {
       throw new Error("State not found");
     }
 
-    return socialAuthCallback({
-      ctx: request.ctx,
-      controller: this,
-      state: loginState,
-      code,
-    });
+    if (error) {
+      const { redirect_uri } = loginState.authParams;
+
+      const redirectUri = new URL(redirect_uri!);
+
+      redirectUri.searchParams.set("error", error);
+      redirectUri.searchParams.set("error_description", errorDescription!);
+      redirectUri.searchParams.set("error_code", errorCode!);
+      redirectUri.searchParams.set("error_reason", errorReason!);
+      redirectUri.searchParams.set("state", state);
+
+      this.setStatus(302);
+      this.setHeader(headers.location, redirectUri.href);
+      return "Redirecting";
+    }
+
+    if (code) {
+      return socialAuthCallback({
+        ctx: request.ctx,
+        controller: this,
+        state: loginState,
+        code,
+      });
+    }
+
+    throw new Error("Invalid request");
   }
 
   /**

--- a/src/routes/tsoa/callback.ts
+++ b/src/routes/tsoa/callback.ts
@@ -43,7 +43,11 @@ export class CallbackController extends Controller {
     if (error) {
       const { redirect_uri } = loginState.authParams;
 
-      const redirectUri = new URL(redirect_uri!);
+      if (!redirect_uri) {
+        throw new Error("Redirect uri not found");
+      }
+
+      const redirectUri = new URL(redirect_uri);
 
       redirectUri.searchParams.set("error", error);
       redirectUri.searchParams.set("error_description", errorDescription!);

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -616,5 +616,36 @@ describe("social sign on", () => {
     // TO TEST
     // - bad params passed to us? e.g. bad redirect-uri, bad client_id?
     // - should not create a new social user IF WE DID NOT FIRST CALL THEM? e.g. check the nonce?
+
+    test("error callback from SSO", async () => {
+      // e.g. Facebook hit "not now" button
+
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+
+      const errorCallbackResponse = await client.callback.$get({
+        query: {
+          error: "access_denied",
+          error_code: "200",
+          error_description: "Permissions error",
+          error_reason: "user_denied",
+          state: SOCIAL_STATE_PARAM,
+        },
+      });
+
+      expect(errorCallbackResponse.status).toBe(302);
+
+      const location = new URL(errorCallbackResponse.headers.get("location")!);
+
+      expect(location.host).toBe("login2.sesamy.dev");
+      expect(location.pathname).toBe("/callback");
+      expect(location.searchParams.get("error")).toBe("access_denied");
+      expect(location.searchParams.get("error_description")).toBe(
+        "Permissions error",
+      );
+      expect(location.searchParams.get("error_code")).toBe("200");
+      expect(location.searchParams.get("error_reason")).toBe("user_denied");
+      expect(location.searchParams.get("state")).toBe(SOCIAL_STATE_PARAM);
+    });
   });
 });


### PR DESCRIPTION
A lot of SSO providers have _"back"_-style buttons that will then call us with 

https://auth2.sesamy.dev/callback?error=access_denied&error_code=200&error_description=Permissions+error&error_reason=user_denied&state=eyJhdXRoUGFyYW1zIjp7InJlZGlyZWN0X3VyaSI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMC9jYWxsYmFjayIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwiLCJzdGF0ZSI6InJlZGlyZWN0X3VyaT1odHRwcyUzQSUyRiUyRmV4YW1wbGUuY29tJmNsaWVudF9pZD1zZXNhbXkmcmVzcG9uc2VfdHlwZT10b2tlbitpZF90b2tlbiZzdGF0ZT0xMjM0NTY3OCZjb25uZWN0aW9uPWF1dGgyIiwiY2xpZW50X2lkIjoic2VzYW15Iiwibm9uY2UiOiJHNzRfSHF2VXBjTHM4dlV1NUNycH5aUDdmeGNxVkUtNyIsInJlc3BvbnNlX3R5cGUiOiJ0b2tlbiBpZF90b2tlbiJ9LCJjb25uZWN0aW9uIjoiZmFjZWJvb2sifQ


We need to then redirect back on like Auth0 does