### PR TITLE
fix: pass back login2's state on error to /callback

### DIFF
--- a/src/routes/tsoa/callback.ts
+++ b/src/routes/tsoa/callback.ts
@@ -53,7 +53,9 @@ export class CallbackController extends Controller {
       redirectUri.searchParams.set("error_description", errorDescription!);
       redirectUri.searchParams.set("error_code", errorCode!);
       redirectUri.searchParams.set("error_reason", errorReason!);
-      redirectUri.searchParams.set("state", state);
+      if (loginState.authParams.state) {
+        redirectUri.searchParams.set("state", loginState.authParams.state);
+      }
 
       this.setStatus(302);
       this.setHeader(headers.location, redirectUri.href);

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -6,10 +6,12 @@ import { testClient } from "hono/testing";
 import { tsoaApp } from "../../../src/app";
 import { getEnv } from "../helpers/test-client";
 
+const LOGIN2_STATE = "client_id=clientId&connection=auth2";
+
 const SOCIAL_STATE_PARAM_AUTH_PARAMS = {
   redirect_uri: "https://login2.sesamy.dev/callback",
   scope: "openid profile email",
-  state: "_7lvvz2iVJ7bQBqayN9ZsER5mt1VdGcx",
+  state: LOGIN2_STATE,
   client_id: "clientId",
   nonce: "MnjcTg0ay3xqf3JVqIL05ib.n~~eZcL_",
   response_type: "token id_token",
@@ -118,9 +120,7 @@ describe("social sign on", () => {
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
         expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
-        expect(socialCallbackQuery2.get("state")).toBe(
-          "_7lvvz2iVJ7bQBqayN9ZsER5mt1VdGcx",
-        );
+        expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
         expect(idTokenPayload.aud).toBe("clientId");
@@ -228,9 +228,7 @@ describe("social sign on", () => {
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
         expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
-        expect(socialCallbackQuery2.get("state")).toBe(
-          "_7lvvz2iVJ7bQBqayN9ZsER5mt1VdGcx",
-        );
+        expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
         expect(idTokenPayload.aud).toBe("clientId");
@@ -645,7 +643,7 @@ describe("social sign on", () => {
       );
       expect(location.searchParams.get("error_code")).toBe("200");
       expect(location.searchParams.get("error_reason")).toBe("user_denied");
-      expect(location.searchParams.get("state")).toBe(SOCIAL_STATE_PARAM);
+      expect(location.searchParams.get("state")).toBe(LOGIN2_STATE);
     });
   });
 });


### PR DESCRIPTION
I thought I'd manually tested this *but* now I've released everything, I've noticed I'm not passing back the original caller's state

![image](https://github.com/sesamyab/auth/assets/8496063/9415b18c-8e48-4f47-b383-03324d9be79d)
