### PR TITLE
fix: dont pass undefined params back on error /callback

### DIFF
--- a/src/routes/tsoa/callback.ts
+++ b/src/routes/tsoa/callback.ts
@@ -50,9 +50,15 @@ export class CallbackController extends Controller {
       const redirectUri = new URL(redirect_uri);
 
       redirectUri.searchParams.set("error", error);
-      redirectUri.searchParams.set("error_description", errorDescription!);
-      redirectUri.searchParams.set("error_code", errorCode!);
-      redirectUri.searchParams.set("error_reason", errorReason!);
+      if (errorDescription) {
+        redirectUri.searchParams.set("error_description", errorDescription);
+      }
+      if (errorCode) {
+        redirectUri.searchParams.set("error_code", errorCode);
+      }
+      if (errorReason) {
+        redirectUri.searchParams.set("error_reason", errorReason);
+      }
       if (loginState.authParams.state) {
         redirectUri.searchParams.set("state", loginState.authParams.state);
       }


### PR DESCRIPTION
What we have released currently does work *but* better not to pass back `undefined` in the URL :+1: 