### PR TITLE
fix: correct log type for cross-origin login

### DIFF
--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -1,11 +1,19 @@
-import { Body, Controller, Post, Request, Route, Tags } from "@tsoa/runtime";
+import {
+  Body,
+  Controller,
+  Post,
+  Request,
+  Route,
+  Tags,
+  Middlewares,
+} from "@tsoa/runtime";
 import { RequestWithContext } from "../../types/RequestWithContext";
 import { nanoid } from "nanoid";
 import randomString from "../../utils/random-string";
 import { Ticket } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { getClient } from "../../services/clients";
-import { LogTypes } from "../../tsoa-middlewares/logger";
+import { loggerMiddleware, LogTypes } from "../../tsoa-middlewares/logger";
 
 const TICKET_EXPIRATION_TIME = 30 * 60 * 1000;
 
@@ -47,6 +55,7 @@ export class AuthenticateController extends Controller {
    * @returns
    */
   @Post("authenticate")
+  @Middlewares(loggerMiddleware(LogTypes.SUCCESS_CROSS_ORIGIN_AUTHENTICATION))
   public async authenticate(
     @Body() body: CodeAuthenticateParams | PasswordAuthenticateParams,
     @Request() request: RequestWithContext,

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -45,7 +45,6 @@ function getLocalePath(locale: string) {
 @Tags("passwordless")
 export class PasswordlessController extends Controller {
   @Post("start")
-  @Middlewares(loggerMiddleware(LogTypes.CODE_LINK_SENT))
   public async startPasswordless(
     @Body() body: PasswordlessOptions,
     @Request() request: RequestWithContext,
@@ -120,6 +119,8 @@ export class PasswordlessController extends Controller {
     return "OK";
   }
 
+  // TODO - check this... how to test on auth0? we aren't sending out magic links right? Can we renable it for a bit?
+  // DO ON ANOTHER PR!
   @Get("verify_redirect")
   @Middlewares(loggerMiddleware(LogTypes.SUCCESS_LOGIN))
   public async verifyRedirect(

--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -119,8 +119,6 @@ export class PasswordlessController extends Controller {
     return "OK";
   }
 
-  // TODO - check this... how to test on auth0? we aren't sending out magic links right? Can we renable it for a bit?
-  // DO ON ANOTHER PR!
   @Get("verify_redirect")
   @Middlewares(loggerMiddleware(LogTypes.SUCCESS_LOGIN))
   public async verifyRedirect(

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -6,7 +6,6 @@ import instanceToJson from "../utils/instanceToJson";
 
 export enum LogTypes {
   API_OPERATION = "sapi",
-  CODE_LINK_SENT = "cls",
   FAILED_SILENT_AUTH = "fsa",
   SUCCESS_SIGNUP = "ss",
   // copying these from Auth0

--- a/test/integration/management-api/logs.spec.ts
+++ b/test/integration/management-api/logs.spec.ts
@@ -78,66 +78,6 @@ describe("logs", () => {
     expect(log.details?.request.method).toBe("POST");
   });
 
-  it("should log a passwordless start for a new user", async () => {
-    const env = await getEnv();
-    const client = testClient(tsoaApp, env);
-
-    const token = await getAdminToken();
-
-    const createUserResponse = await client.passwordless.start.$post(
-      {
-        json: {
-          email: "test@example.com",
-          client_id: "clientId",
-          connection: "email",
-          send: "link",
-          authParams: {
-            scope: "openid",
-            nonce: "nonce",
-            response_type: "code",
-            redirect_uri: "https://example.com",
-            state: "state",
-          },
-        },
-      },
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "tenantId",
-          "content-type": "application/json",
-          "x-real-ip": "1.2.3.4",
-          "user-agent": "ua",
-        },
-      },
-    );
-
-    expect(createUserResponse.status).toBe(200);
-
-    const response = await client.api.v2.logs.$get(
-      {},
-      {
-        headers: {
-          authorization: `Bearer ${token}`,
-          "tenant-id": "tenantId",
-        },
-      },
-    );
-
-    expect(response.status).toBe(200);
-
-    const body = (await response.json()) as LogsResponse[];
-    expect(body.length).toBe(1);
-    const [log] = body;
-    expect(log.type).toBe("cls");
-    expect(log.ip).toBe("1.2.3.4");
-    expect(log.description).toBe("test@example.com");
-    expect(typeof log.date).toBe("string");
-    expect(log.client_id).toBe("clientId");
-    expect(log.user_agent).toBe("ua");
-    expect(log.log_id).toContain("testid-");
-    expect(log.details?.request.method).toBe("POST");
-  });
-
   it("should log a failed silent auth request", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);


### PR DESCRIPTION
Matching Auth0 logging with `cross origin login` 

![image](https://github.com/sesamyab/auth/assets/8496063/9cd0b433-f353-458b-a3d0-948a243b91a0)


*AND ALSO* I removed code login sent because Auth0 doesn't log that