### PR TITLE
feat: log incorrect code as failed login

### DIFF
--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -73,7 +73,6 @@ export class AuthenticateController extends Controller {
       const otps = await env.data.OTP.list(client.tenant_id, email);
       const otp = otps.find((otp) => otp.code === body.otp);
 
-      // TODO - release this and see what happens...
       request.ctx.set("logType", LogTypes.FAILED_LOGIN_WRONG_PASSWORD);
 
       if (!otp) {

--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -5,6 +5,7 @@ import randomString from "../../utils/random-string";
 import { Ticket } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { getClient } from "../../services/clients";
+import { LogTypes } from "../../tsoa-middlewares/logger";
 
 const TICKET_EXPIRATION_TIME = 30 * 60 * 1000;
 
@@ -71,6 +72,9 @@ export class AuthenticateController extends Controller {
     if ("otp" in body) {
       const otps = await env.data.OTP.list(client.tenant_id, email);
       const otp = otps.find((otp) => otp.code === body.otp);
+
+      // TODO - release this and see what happens...
+      request.ctx.set("logType", LogTypes.FAILED_LOGIN_WRONG_PASSWORD);
 
       if (!otp) {
         throw new HTTPException(403, {

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -14,6 +14,7 @@ export enum LogTypes {
   SUCCESS_LOGOUT = "slo",
   SUCCESS_SILENT_AUTH = "ssa",
   SUCCESS_CROSS_ORIGIN_AUTHENTICATION = "scoa",
+  FAILED_LOGIN_WRONG_PASSWORD = "flwp",
 }
 
 export function loggerMiddleware(logType: string, description?: string) {


### PR DESCRIPTION
Matching Auth0

![image](https://github.com/sesamyab/auth/assets/8496063/bdcb513d-f2e0-4d04-a909-709fd8066299)


I'm not sure what will happen here because our logger only logs when `!!response.ok` :thinking: 

