### PR TITLE
fix: correct error message on bad magic link redirect

### DIFF
--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -243,8 +243,7 @@ export class PasswordlessController extends Controller {
         login2ExpiredCodeUrl.searchParams.set("connection", connection2);
       }
 
-      // TODO - check what type Auth0 gives when we use an expired/invalid code, and use that here
-      // request.ctx.set('logType', LogTypes.ERROR_LOGIN);
+      request.ctx.set("logType", LogTypes.FAILED_LOGIN_WRONG_PASSWORD);
 
       this.setHeader(headers.location, login2ExpiredCodeUrl.toString());
 

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -14,6 +14,7 @@ export enum LogTypes {
   SUCCESS_LOGOUT = "slo",
   SUCCESS_SILENT_AUTH = "ssa",
   SUCCESS_CROSS_ORIGIN_AUTHENTICATION = "scoa",
+  FAILED_LOGIN_WRONG_PASSWORD = "flwp",
 }
 
 export function loggerMiddleware(logType: string, description?: string) {


### PR DESCRIPTION
This is from tampering with the magic link and setting the wrong code.  So we get the same error logged by Auth0 as if we had entered the wrong code manually

![image](https://github.com/sesamyab/auth/assets/8496063/73364498-14b7-49f1-b331-6777d5297d57)


