### PR TITLE
fix: return fragment by default

### DIFF
--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -97,14 +97,15 @@ export function applyTokenResponse(
   authParams: AuthParams,
 ) {
   switch (authParams.response_mode) {
+    // Auth0 does not allow query if response_type is token
+    case AuthorizationResponseMode.QUERY:
+      return applyTokenResponseAsQuery(controller, tokenResponse, authParams);
     case AuthorizationResponseMode.FRAGMENT:
+    default:
       return applyTokenResponseAsFragment(
         controller,
         tokenResponse,
         authParams,
       );
-    case AuthorizationResponseMode.QUERY:
-    default:
-      return applyTokenResponseAsQuery(controller, tokenResponse, authParams);
   }
 }

--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -78,10 +78,10 @@ function applyTokenResponseAsFragment(
     if (tokenResponse.id_token) {
       anchorLinks.set("id_token", tokenResponse.id_token);
     }
+    anchorLinks.set("expires_in", tokenResponse.expires_in.toString());
   }
 
   anchorLinks.set("token_type", "Bearer");
-  anchorLinks.set("expires_in", "28800");
 
   if (state) {
     anchorLinks.set("state", state);

--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -65,13 +65,6 @@ function applyTokenResponseAsFragment(
 
   const anchorLinks = new URLSearchParams();
 
-  if ("code" in tokenResponse) {
-    anchorLinks.set("code", tokenResponse.code);
-    if (authParams.state) {
-      anchorLinks.set("state", authParams.state);
-    }
-  }
-
   if ("access_token" in tokenResponse) {
     anchorLinks.set("access_token", tokenResponse.access_token);
 

--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -65,6 +65,13 @@ function applyTokenResponseAsFragment(
 
   const anchorLinks = new URLSearchParams();
 
+  if ("code" in tokenResponse) {
+    anchorLinks.set("code", tokenResponse.code);
+    if (authParams.state) {
+      anchorLinks.set("state", authParams.state);
+    }
+  }
+
   if ("access_token" in tokenResponse) {
     anchorLinks.set("access_token", tokenResponse.access_token);
 

--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -103,6 +103,14 @@ export function applyTokenResponse(
   tokenResponse: TokenResponse | CodeResponse,
   authParams: AuthParams,
 ) {
+  if (authParams.response_type?.includes("token")) {
+    return applyTokenResponseAsFragment(controller, tokenResponse, authParams);
+  }
+
+  if (authParams.response_type?.includes("code")) {
+    return applyTokenResponseAsQuery(controller, tokenResponse, authParams);
+  }
+
   switch (authParams.response_mode) {
     // Auth0 does not allow query if response_type is token
     case AuthorizationResponseMode.QUERY:

--- a/test/authentication-flows/ticket.spec.ts
+++ b/test/authentication-flows/ticket.spec.ts
@@ -76,7 +76,7 @@ describe("passwordlessAuth", () => {
     });
     expect(hashParams.get("id_token")).toBe(null);
     expect(hashParams.get("token_type")).toBe("Bearer");
-    expect(hashParams.get("expires_in")).toBe("28800");
+    expect(hashParams.get("expires_in")).toBe("86400");
     expect(hashParams.get("state")).toBe(state);
     expect(hashParams.get("scope")).toBe("openid profile email");
   });

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -114,16 +114,19 @@ describe("code-flow", () => {
     const redirectUri = new URL(tokenResponse.headers.get("location")!);
 
     expect(redirectUri.hostname).toBe("login.example.com");
-    expect(redirectUri.searchParams.get("state")).toBe("state");
 
-    const accessToken = redirectUri.searchParams.get("access_token");
+    const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+
+    expect(searchParams.get("state")).toBe("state");
+
+    const accessToken = searchParams.get("access_token");
 
     const accessTokenPayload = parseJwt(accessToken!);
     expect(accessTokenPayload.aud).toBe("default");
     expect(accessTokenPayload.iss).toBe("https://example.com/");
     expect(accessTokenPayload.scope).toBe("openid profile email");
 
-    const idToken = redirectUri.searchParams.get("id_token");
+    const idToken = searchParams.get("id_token");
     const idTokenPayload = parseJwt(idToken!);
     expect(idTokenPayload.email).toBe("test@example.com");
     expect(idTokenPayload.aud).toBe("clientId");
@@ -324,13 +327,15 @@ describe("code-flow", () => {
     });
 
     const redirectUri = new URL(tokenResponse.headers.get("location")!);
-    const accessToken = redirectUri.searchParams.get("access_token");
+    const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+
+    const accessToken = searchParams.get("access_token");
     const accessTokenPayload = parseJwt(accessToken!);
 
     // this is the id of the primary account
     expect(accessTokenPayload.sub).toBe("userId");
 
-    const idToken = redirectUri.searchParams.get("id_token");
+    const idToken = searchParams.get("id_token");
     const idTokenPayload = parseJwt(idToken!);
 
     expect(idTokenPayload.sub).toBe("userId");
@@ -463,9 +468,9 @@ describe("code-flow", () => {
     });
 
     const accessToken2 = parseJwt(
-      new URL(tokenResponse2.headers.get("location")!).searchParams.get(
-        "access_token",
-      )!,
+      new URLSearchParams(
+        tokenResponse2.headers.get("location")!.split("#")[1]!,
+      ).get("access_token")!,
     );
 
     // this is the id of the primary account

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -92,14 +92,16 @@ describe("code-flow", () => {
       );
       expect(redirectUri.hostname).toBe("login.example.com");
 
-      const accessToken = redirectUri.searchParams.get("access_token");
+      const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+
+      const accessToken = searchParams.get("access_token");
 
       const accessTokenPayload = parseJwt(accessToken!);
       expect(accessTokenPayload.aud).toBe("default");
       expect(accessTokenPayload.iss).toBe("https://example.com/");
       expect(accessTokenPayload.scope).toBe("openid profile email");
 
-      const idToken = redirectUri.searchParams.get("id_token");
+      const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.email).toBe("new-user@example.com");
       expect(idTokenPayload.aud).toBe("clientId");
@@ -215,7 +217,9 @@ describe("code-flow", () => {
       );
       expect(redirectUri.hostname).toBe("login.example.com");
 
-      const accessToken = redirectUri.searchParams.get("access_token");
+      const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+
+      const accessToken = searchParams.get("access_token");
 
       const accessTokenPayload = parseJwt(accessToken!);
       expect(accessTokenPayload.aud).toBe("default");
@@ -223,7 +227,7 @@ describe("code-flow", () => {
       expect(accessTokenPayload.scope).toBe("openid profile email");
       expect(accessTokenPayload.sub).toBe("userId");
 
-      const idToken = redirectUri.searchParams.get("id_token");
+      const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.email).toBe("foo@example.com");
       expect(idTokenPayload.aud).toBe("clientId");

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -91,14 +91,17 @@ describe("password-flow", () => {
       expect(tokenResponse.status).toBe(302);
       expect(await tokenResponse.text()).toBe("Redirecting");
       const redirectUri = new URL(tokenResponse.headers.get("location")!);
+
+      const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+
       expect(redirectUri.hostname).toBe("login.example.com");
-      expect(redirectUri.searchParams.get("state")).toBe("state");
-      const accessToken = redirectUri.searchParams.get("access_token");
+      expect(searchParams.get("state")).toBe("state");
+      const accessToken = searchParams.get("access_token");
       const accessTokenPayload = parseJwt(accessToken!);
       expect(accessTokenPayload.aud).toBe("default");
       expect(accessTokenPayload.iss).toBe("https://example.com/");
       expect(accessTokenPayload.scope).toBe("");
-      const idToken = redirectUri.searchParams.get("id_token");
+      const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.email).toBe("password-login-test@example.com");
       expect(idTokenPayload.aud).toBe("clientId");
@@ -229,15 +232,17 @@ describe("password-flow", () => {
 
       const redirectUri = new URL(tokenResponse.headers.get("location")!);
       expect(redirectUri.hostname).toBe("login.example.com");
-      expect(redirectUri.searchParams.get("state")).toBe("state");
+      const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
 
-      const accessToken = redirectUri.searchParams.get("access_token");
+      expect(searchParams.get("state")).toBe("state");
+
+      const accessToken = searchParams.get("access_token");
       const accessTokenPayload = parseJwt(accessToken!);
       expect(accessTokenPayload.aud).toBe("default");
       expect(accessTokenPayload.iss).toBe("https://example.com/");
       expect(accessTokenPayload.scope).toBe("");
 
-      const idToken = redirectUri.searchParams.get("id_token");
+      const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.email).toBe("foo@example.com");
       expect(idTokenPayload.aud).toBe("clientId");

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -115,7 +115,6 @@ describe("social sign on", () => {
         const location2 = new URL(
           socialCallbackResponse.headers.get("location")!,
         );
-        // OK! have not changed this test hyet. cool. breathe deeply
         expect(location2.host).toBe("login2.sesamy.dev");
 
         const socialCallbackQuery2 = new URLSearchParams(
@@ -224,7 +223,6 @@ describe("social sign on", () => {
         );
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
-        // why has this changed?
         expect(socialCallbackQuery2.get("expires_in")).toBe("28800");
         expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -123,7 +123,7 @@ describe("social sign on", () => {
 
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
-        expect(socialCallbackQuery2.get("expires_in")).toBe("28800");
+        expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
         expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
@@ -223,7 +223,7 @@ describe("social sign on", () => {
         );
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
-        expect(socialCallbackQuery2.get("expires_in")).toBe("28800");
+        expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
         expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -275,7 +275,7 @@ describe("social sign on", () => {
   });
 
   describe("Secondary user", () => {
-    it("should return existing primary account when logging in with new social sign ons with same email address", async () => {
+    it.only("should return existing primary account when logging in with new social sign ons with same email address", async () => {
       // ---------------------------------------------
       // create new user with same email as we have hardcoded on the mock id_token responses
       // ---------------------------------------------
@@ -329,9 +329,9 @@ describe("social sign on", () => {
         query: socialCallbackQuery,
       });
 
-      const socialCallbackResponseQuery = new URL(
-        socialCallbackResponse.headers.get("location")!,
-      ).searchParams;
+      const socialCallbackResponseQuery = new URLSearchParams(
+        socialCallbackResponse.headers.get("location")?.split("#")[1]!,
+      );
       const accessTokenPayload = parseJwt(
         socialCallbackResponseQuery.get("access_token")!,
       );
@@ -434,9 +434,9 @@ describe("social sign on", () => {
         query: socialCallbackQuery,
       });
 
-      const socialCallbackResponse2Query = new URL(
-        socialCallbackResponse2.headers.get("location")!,
-      ).searchParams;
+      const socialCallbackResponse2Query = new URLSearchParams(
+        socialCallbackResponse2.headers.get("location")?.split("#")[1]!,
+      );
       expect(
         parseJwt(socialCallbackResponse2Query.get("access_token")!).sub,
       ).toBe(createEmailUser.user_id);
@@ -455,9 +455,12 @@ describe("social sign on", () => {
       const socialCallbackResponseAnotherSSO = await client.callback.$get({
         query: socialCallbackQueryAnotherSSO,
       });
-      const socialCallbackResponseAnotherSSOQuery = new URL(
-        socialCallbackResponseAnotherSSO.headers.get("location")!,
-      ).searchParams;
+
+      const socialCallbackResponseAnotherSSOQuery = new URLSearchParams(
+        socialCallbackResponseAnotherSSO.headers
+          .get("location")
+          ?.split("#")[1]!,
+      );
       // these confirm we are still signing in with the primary user
       expect(
         parseJwt(socialCallbackResponseAnotherSSOQuery.get("access_token")!)

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -115,11 +115,16 @@ describe("social sign on", () => {
         const location2 = new URL(
           socialCallbackResponse.headers.get("location")!,
         );
+        // OK! have not changed this test hyet. cool. breathe deeply
         expect(location2.host).toBe("login2.sesamy.dev");
-        const socialCallbackQuery2 = location2.searchParams;
+
+        const socialCallbackQuery2 = new URLSearchParams(
+          location2.hash.slice(1),
+        );
+
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
-        expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
+        expect(socialCallbackQuery2.get("expires_in")).toBe("28800");
         expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
@@ -214,10 +219,13 @@ describe("social sign on", () => {
           socialCallbackResponse.headers.get("location")!,
         );
         expect(location2.host).toBe("login2.sesamy.dev");
-        const socialCallbackQuery2 = location2.searchParams;
+        const socialCallbackQuery2 = new URLSearchParams(
+          location2.hash.slice(1),
+        );
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
-        expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
+        // why has this changed?
+        expect(socialCallbackQuery2.get("expires_in")).toBe("28800");
         expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
@@ -275,7 +283,7 @@ describe("social sign on", () => {
   });
 
   describe("Secondary user", () => {
-    it.only("should return existing primary account when logging in with new social sign ons with same email address", async () => {
+    it("should return existing primary account when logging in with new social sign ons with same email address", async () => {
       // ---------------------------------------------
       // create new user with same email as we have hardcoded on the mock id_token responses
       // ---------------------------------------------

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -83,7 +83,6 @@ describe("Login with code on liquidjs template", () => {
     const redirectUrl = new URL(codeLoginRedirectUri);
     expect(redirectUrl.pathname).toBe("/callback");
     const hash = new URLSearchParams(redirectUrl.hash.slice(1));
-
     const accessToken = hash.get("access_token");
     expect(accessToken).toBeTruthy();
     const idToken = hash.get("id_token");

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -82,9 +82,11 @@ describe("Login with code on liquidjs template", () => {
     }
     const redirectUrl = new URL(codeLoginRedirectUri);
     expect(redirectUrl.pathname).toBe("/callback");
-    const accessToken = redirectUrl.searchParams.get("access_token");
+    const hash = new URLSearchParams(redirectUrl.hash.slice(1));
+
+    const accessToken = hash.get("access_token");
     expect(accessToken).toBeTruthy();
-    const idToken = redirectUrl.searchParams.get("id_token");
+    const idToken = hash.get("id_token");
     expect(idToken).toBeTruthy();
   });
 });

--- a/test/integration/login/login-password.spec.ts
+++ b/test/integration/login/login-password.spec.ts
@@ -59,9 +59,12 @@ describe("Login with password user", () => {
 
     const redirectUrl = new URL(loginLocation);
     expect(redirectUrl.pathname).toBe("/callback");
-    const accessToken = redirectUrl.searchParams.get("access_token");
+
+    const hash = new URLSearchParams(redirectUrl.hash.slice(1));
+
+    const accessToken = hash.get("access_token");
     expect(accessToken).toBeTruthy();
-    const idToken = redirectUrl.searchParams.get("id_token");
+    const idToken = hash.get("id_token");
     expect(idToken).toBeTruthy();
   });
 });

--- a/test/integration/login/register-password-user.spec.ts
+++ b/test/integration/login/register-password-user.spec.ts
@@ -76,9 +76,11 @@ describe("Register password user", () => {
     const signupLocation: string = postSignupResponse.headers.get("location")!;
     const redirectUrl = new URL(signupLocation);
     expect(redirectUrl.pathname).toBe("/callback");
-    const accessToken = redirectUrl.searchParams.get("access_token");
+    const hash = new URLSearchParams(redirectUrl.hash.slice(1));
+
+    const accessToken = hash.get("access_token");
     expect(accessToken).toBeTruthy();
-    const idToken = redirectUrl.searchParams.get("id_token");
+    const idToken = hash.get("id_token");
     expect(idToken).toBeTruthy();
   });
 });

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -597,7 +597,7 @@ describe("authorize", () => {
         userId: "email|testid-5",
       });
 
-      expect(redirectUrl.searchParams.get("state")).toBe("state");
+      expect(searchParams.get("state")).toBe("state");
       expect(actual).toBe("Redirecting");
       expect(controller.getStatus()).toBe(302);
     });

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -564,9 +564,10 @@ describe("authorize", () => {
       const redirectUrl = new URL(locationHeader);
 
       expect(redirectUrl.host).toBe("example.com");
-      const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
 
-      const stateObj = JSON.parse(atob(searchParams.get("code") as string));
+      const stateObj = JSON.parse(
+        atob(redirectUrl.searchParams.get("code") as string),
+      );
 
       expect(stateObj).toEqual({
         authParams: {
@@ -597,7 +598,7 @@ describe("authorize", () => {
         userId: "email|testid-5",
       });
 
-      expect(searchParams.get("state")).toBe("state");
+      expect(redirectUrl.searchParams.get("state")).toBe("state");
       expect(actual).toBe("Redirecting");
       expect(controller.getStatus()).toBe(302);
     });

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -464,7 +464,7 @@ describe("authorize", () => {
       });
 
       expect(searchParams.get("state")).toBe("state");
-      expect(searchParams.get("expires_in")).toBe("28800");
+      expect(searchParams.get("expires_in")).toBe("86400");
       expect(searchParams.get("id_token")).toBe(null);
       expect(searchParams.get("state")).toBe("state");
 

--- a/test/routes/tsoa/authorize.spec.ts
+++ b/test/routes/tsoa/authorize.spec.ts
@@ -450,9 +450,9 @@ describe("authorize", () => {
 
       expect(redirectUrl.searchParams.get("id_token")).toBeNull();
 
-      const accessToken = parseJwt(
-        redirectUrl.searchParams.get("access_token") as string,
-      );
+      const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
+
+      const accessToken = parseJwt(searchParams.get("access_token")!);
 
       expect(accessToken).toEqual({
         aud: "default",
@@ -463,10 +463,10 @@ describe("authorize", () => {
         exp: Math.floor(date.getTime() / 1000) + 86400,
       });
 
-      expect(redirectUrl.searchParams.get("state")).toBe("state");
-      expect(redirectUrl.searchParams.get("expires_in")).toBe("86400");
-      expect(redirectUrl.searchParams.get("id_token")).toBe(null);
-      expect(redirectUrl.searchParams.get("state")).toBe("state");
+      expect(searchParams.get("state")).toBe("state");
+      expect(searchParams.get("expires_in")).toBe("28800");
+      expect(searchParams.get("id_token")).toBe(null);
+      expect(searchParams.get("state")).toBe("state");
 
       expect(actual).toBe("Redirecting");
       expect(controller.getStatus()).toBe(302);
@@ -514,10 +514,9 @@ describe("authorize", () => {
 
       const locationHeader = controller.getHeader("location") as string;
       const redirectUrl = new URL(locationHeader);
+      const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
 
-      const idToken = parseJwt(
-        redirectUrl.searchParams.get("id_token") as string,
-      );
+      const idToken = parseJwt(searchParams.get("id_token") as string);
 
       expect(idToken).toEqual({
         aud: "clientId",
@@ -565,10 +564,9 @@ describe("authorize", () => {
       const redirectUrl = new URL(locationHeader);
 
       expect(redirectUrl.host).toBe("example.com");
+      const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
 
-      const stateObj = JSON.parse(
-        atob(redirectUrl.searchParams.get("code") as string),
-      );
+      const stateObj = JSON.parse(atob(searchParams.get("code") as string));
 
       expect(stateObj).toEqual({
         authParams: {

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -128,7 +128,7 @@ describe("Passwordless", () => {
       const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
 
       expect(searchParams.get("state")).toBe("state");
-      expect(searchParams.get("expires_in")).toBe("28800");
+      expect(searchParams.get("expires_in")).toBe("86400");
 
       const token = parseJwt(searchParams.get("access_token") as string);
       expect(token).toEqual({

--- a/test/routes/tsoa/passwordless.spec.ts
+++ b/test/routes/tsoa/passwordless.spec.ts
@@ -125,12 +125,12 @@ describe("Passwordless", () => {
 
       const redirectUrl = new URL(controller.getHeader("location") as string);
 
-      expect(redirectUrl.searchParams.get("state")).toBe("state");
-      expect(redirectUrl.searchParams.get("expires_in")).toBe("86400");
+      const searchParams = new URLSearchParams(redirectUrl.hash.slice(1));
 
-      const token = parseJwt(
-        redirectUrl.searchParams.get("access_token") as string,
-      );
+      expect(searchParams.get("state")).toBe("state");
+      expect(searchParams.get("expires_in")).toBe("28800");
+
+      const token = parseJwt(searchParams.get("access_token") as string);
       expect(token).toEqual({
         aud: "https://example.com",
         iat: Math.floor(date.getTime() / 1000),


### PR DESCRIPTION
I noticed this yesterday when playing around, that we're always putting the tokens into the querystring (which is then sent across the network)

If I'm pointing login2 to auth0 and I set `responseMode: "query"` when ` responseType: "token id_token"` _then_ on the call to `auth0/authorize` I get

![image](https://github.com/sesamyab/auth/assets/8496063/f4fccb3d-3ea0-491d-b3b6-66ec18099b76)

The logs say `Unsupported response mode: query`

![image](https://github.com/sesamyab/auth/assets/8496063/4667c64c-2e20-4b11-8e9f-fac42d7ed0f7)

  
#### BUT
On login2 I'm not setting a `responseMode` so we should default to fragment, _BUT_ we could put in a check in auth2  
