### PR TITLE
fix: remove log field _category_

### DIFF
--- a/migrate/migrations/2024-01-31T09:00:00_drop-logs-fields.ts
+++ b/migrate/migrations/2024-01-31T09:00:00_drop-logs-fields.ts
@@ -1,0 +1,13 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("logs").dropColumn("category").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("logs")
+    .addColumn("category", "varchar(255)", (col) => col.notNull())
+    .execute();
+}

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -19,6 +19,7 @@ import * as n18_logsFields from "./2024-01-06T16:23:00_logs-fields";
 import * as n19_connectionsUserinfo from "./2024-01-10T23:19:00_connections-userinfo";
 import * as n20_missingFields from "./2024-01-11T10:58:00_missing-fields";
 import * as n21_sessionDeletedAt from "./2024-01-17T10:51:00_session-deleted-at";
+import * as n22_dropLogsFields from "./2024-01-31T09:00:00_drop-logs-fields";
 
 // These need to be in alphabetic order
 export default {
@@ -43,4 +44,5 @@ export default {
   n19_connectionsUserinfo,
   n20_missingFields,
   n21_sessionDeletedAt,
+  n22_dropLogsFields,
 };

--- a/src/adapters/interfaces/Logs.ts
+++ b/src/adapters/interfaces/Logs.ts
@@ -3,7 +3,6 @@ import { LogsResponse, SqlLog } from "../../types/";
 import { ListParams } from "./ListParams";
 
 export interface CreateLogParams {
-  category: string;
   type: string;
   description: string;
   tenant_id: string;

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -50,7 +50,6 @@ export function loggerMiddleware(logType: string, description?: string) {
           tenant_id: ctx.var.tenantId,
           user_id: ctx.var.userId,
           description: description || ctx.var.description || "",
-          category: logType,
           ip: ctx.req.header("x-real-ip") || "",
           type: ctx.var.logType || logType,
           client_id: ctx.var.client_id,


### PR DESCRIPTION
#### Description
As discussed, I think we just one log type (called `event` on the Auth0 dashboard).  Using `/authorize` as an example, we have no idea what category this is when the method is called. It could be silent auth, a top level redirect, even a sign up

#### Note
:exclamation: Requires migration script running on planetscale :exclamation: 
_ALTHOUGH_ it won't break anything if we don't run it for a while as it's just removing a field


#### Next
~I'll change the logger function to not require a param initially. As mentioned on Slack~
~I will update auth-admin (along with other changes to the logs page to make it look more like Auth0)~
_Nah I disagree with this change. I started doing it but there are a lot of changes to make *and* it looks much tidier to use a decorator for the expected log type and description_