### PR TITLE
fix: hardcode log sorting by date desc for now

### DIFF
--- a/src/adapters/kysely/logs/list.ts
+++ b/src/adapters/kysely/logs/list.ts
@@ -22,10 +22,14 @@ export function listLogs(db: Kysely<Database>) {
       query = luceneFilter(db, query, params.q, ["user_id"]);
     }
 
-    if (params.sort && params.sort.sort_by) {
-      const { ref } = db.dynamic;
-      query = query.orderBy(ref(params.sort.sort_by), params.sort.sort_order);
-    }
+    // TEMP FIX - hardcoded date desc for now
+    query = query.orderBy("date", "desc");
+
+    // TODO - sorting not implemented anywhere yet
+    // if (params.sort && params.sort.sort_by) {
+    //   const { ref } = db.dynamic;
+    //   query = query.orderBy(ref(params.sort.sort_by), params.sort.sort_order);
+    // }
 
     const filteredQuery = query
       .offset(params.page * params.per_page)


### PR DESCRIPTION
We probably want to actually fix sorting on our mgmt API endpoints (although I haven't checked if Auth0 supports this)

_BUT_ for now, the easiest fix is to hardcode the logs to reverse date order