### PR TITLE
fix: uri encode state part of fragment

### DIFF
--- a/src/helpers/apply-token-response.ts
+++ b/src/helpers/apply-token-response.ts
@@ -77,7 +77,7 @@ function applyTokenResponseAsFragment(
   anchorLinks.set("token_type", "Bearer");
 
   if (state) {
-    anchorLinks.set("state", state);
+    anchorLinks.set("state", encodeURIComponent(state));
   }
 
   if (authParams.scope) {

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -124,7 +124,9 @@ describe("social sign on", () => {
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
         expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
-        expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
+        expect(socialCallbackQuery2.get("state")).toBe(
+          encodeURIComponent(LOGIN2_STATE),
+        );
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
         expect(idTokenPayload.aud).toBe("clientId");
@@ -224,7 +226,9 @@ describe("social sign on", () => {
         expect(socialCallbackQuery2.get("access_token")).toBeDefined();
         expect(socialCallbackQuery2.get("id_token")).toBeDefined();
         expect(socialCallbackQuery2.get("expires_in")).toBe("86400");
-        expect(socialCallbackQuery2.get("state")).toBe(LOGIN2_STATE);
+        expect(socialCallbackQuery2.get("state")).toBe(
+          encodeURIComponent(LOGIN2_STATE),
+        );
         const idToken = socialCallbackQuery2.get("id_token");
         const idTokenPayload = parseJwt(idToken!);
         expect(idTokenPayload.aud).toBe("clientId");


### PR DESCRIPTION
I figure we merge this and then I'll keep running the login2 playwright tests :see_no_evil: 