### PR TITLE
fix: get logging working

### DIFF
--- a/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
+++ b/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
@@ -21,7 +21,9 @@ export async function up(db: Kysely<Database>): Promise<void> {
 
   await db.schema
     .alterTable("logs")
-    .addColumn("details", "varchar(16383)")
+    // too long and exceeds the planetscale max length for the row
+    // .addColumn("details", "varchar(16383)")
+    .addColumn("details", "varchar(8192)")
     .execute();
 }
 

--- a/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
+++ b/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
@@ -21,7 +21,7 @@ export async function up(db: Kysely<Database>): Promise<void> {
 
   await db.schema
     .alterTable("logs")
-    .addColumn("details", "varchar(65535)")
+    .addColumn("details", "varchar(16383)")
     .execute();
 }
 

--- a/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
+++ b/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
@@ -1,0 +1,19 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // when I try and alter the column I get SQL errors...
+  await db.schema.alterTable("logs").dropColumn("details").execute();
+
+  await db.schema
+    .alterTable("logs")
+    .addColumn("details", "varchar(65535)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("logs")
+    .modifyColumn("details", "varchar(2048)")
+    .execute();
+}

--- a/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
+++ b/migrate/migrations/2024-02-05T18:35:00_log-desc-max-length.ts
@@ -2,7 +2,21 @@ import { Kysely } from "kysely";
 import { Database } from "../../src/types";
 
 export async function up(db: Kysely<Database>): Promise<void> {
-  // when I try and alter the column I get SQL errors...
+  // This does not work
+  // await db.schema
+  //   .alterTable("logs")
+  //   .modifyColumn("details", "varchar(65535)")
+  //   .execute();
+
+  // // This also does not work
+  // await db.schema
+  //   .alterTable("logs")
+  //   .alterColumn("details", (column) => {
+  //     return column.setDataType("varchar(65535)");
+  //   })
+  //   .execute();
+
+  // Just drop the column and recreate it
   await db.schema.alterTable("logs").dropColumn("details").execute();
 
   await db.schema
@@ -12,8 +26,10 @@ export async function up(db: Kysely<Database>): Promise<void> {
 }
 
 export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("logs").dropColumn("details").execute();
+
   await db.schema
     .alterTable("logs")
-    .modifyColumn("details", "varchar(2048)")
+    .addColumn("details", "varchar(2048)")
     .execute();
 }

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -22,6 +22,7 @@ import * as n21_sessionDeletedAt from "./2024-01-17T10:51:00_session-deleted-at"
 import * as n22_dropLogsFields from "./2024-01-31T09:00:00_drop-logs-fields";
 import * as n23_dropUsersFields from "./2024-02-02T15:55:00_drop-users-fields";
 import * as n24_logsIndexes from "./2024-02-02T16:55:00_logs-indexes";
+import * as n25_logDescMaxLength from "./2024-02-05T18:35:00_log-desc-max-length";
 
 // These need to be in alphabetic order
 export default {
@@ -49,4 +50,5 @@ export default {
   n22_dropLogsFields,
   n23_dropUsersFields,
   n24_logsIndexes,
+  n25_logDescMaxLength,
 };

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -45,9 +45,13 @@ export function loggerMiddleware(logType: string, description?: string) {
 
     try {
       if (!ctx.var.tenantId) throw new Error("No tenant id");
+      // This is a required field in SQL so without this the log won't write
+      if (!ctx.var.userId) throw new Error("No user id");
+
       await env.data.logs.create({
         tenant_id: ctx.var.tenantId,
-        user_id: ctx.var.userId,
+        // TODO - can we make these nullable to reflect the runtime?
+        user_id: ctx.var.userId || "",
         description: description || ctx.var.description || "",
         ip: ctx.req.header("x-real-ip") || "",
         type: ctx.var.logType || logType,

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -44,10 +44,6 @@ export function loggerMiddleware(logType: string, description?: string) {
     }
 
     try {
-      if (!ctx.var.tenantId) throw new Error("No tenant id");
-      // This is a required field in SQL so without this the log won't write
-      if (!ctx.var.userId) throw new Error("No user id");
-
       await env.data.logs.create({
         tenant_id: ctx.var.tenantId,
         // TODO - can we make these nullable to reflect the runtime?


### PR DESCRIPTION
We were missing logs for a few reasons


As we're stringifying an object into `details`, the column wasn't long enough

![image](https://github.com/sesamyab/auth/assets/8496063/45984fd8-a462-42ff-ac20-68a41e103302)
