### PR TITLE
fix: import types properly

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -7,7 +7,7 @@ import { applyTokenResponse } from "../helpers/apply-token-response";
 import { HTTPException } from "hono/http-exception";
 import { Context } from "hono";
 import { Var } from "../types/Var";
-import { LogTypes } from "../tsoa-middlewares/logger";
+import { LogTypes } from "../types/auth0";
 
 function getProviderFromRealm(realm: string) {
   if (realm === "Username-Password-Authentication") {


### PR DESCRIPTION
I'm not sure how `main` got into a bad state as the CI/CD had ran on all the PRs...

I probably merged two in and we aren't forcing rebase of PRs. Which is fine. Just now and again we get this :smile: 