### PR TITLE
chore: add index to name column on users table

### DIFF
--- a/migrate/migrations/2024-02-13T11:25:00_users-table-name-index.ts
+++ b/migrate/migrations/2024-02-13T11:25:00_users-table-name-index.ts
@@ -1,0 +1,14 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .createIndex("users_name_index")
+    .on("users")
+    .column("name")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.dropIndex("users_name_index").execute();
+}

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -24,6 +24,7 @@ import * as n23_dropUsersFields from "./2024-02-02T15:55:00_drop-users-fields";
 import * as n24_logsIndexes from "./2024-02-02T16:55:00_logs-indexes";
 import * as n25_logDescMaxLength from "./2024-02-05T18:35:00_log-desc-max-length";
 import * as n26_logsTableExtraFields from "./2024-02-08T12:45:00_logs-table-extra-fields";
+import * as n27_usersTableNameIndex from "./2024-02-13T11:25:00_users-table-name-index";
 
 // These need to be in alphabetic order
 export default {
@@ -53,4 +54,5 @@ export default {
   n24_logsIndexes,
   n25_logDescMaxLength,
   n26_logsTableExtraFields,
+  n27_usersTableNameIndex,
 };


### PR DESCRIPTION
Let's see if this fixes this

![Screenshot 2024-02-13 at 10 06 39](https://github.com/sesamyab/auth/assets/8496063/0da39fc8-f861-4f73-92a8-060266d7dc04)

This must be from queries to the users list endpoint which filter by name and email (`LIKE` queries)
