### PR TITLE
feat: log filtering by ip

### DIFF
--- a/src/adapters/kysely/logs/list.ts
+++ b/src/adapters/kysely/logs/list.ts
@@ -10,7 +10,7 @@ export function listLogs(db: Kysely<Database>) {
     let query = db.selectFrom("logs").where("logs.tenant_id", "=", tenantId);
 
     if (params.q) {
-      query = luceneFilter(db, query, params.q, ["user_id"]);
+      query = luceneFilter(db, query, params.q, ["user_id", "ip"]);
     }
 
     // TEMP FIX - hardcoded date desc for now

--- a/src/adapters/kysely/users/list.ts
+++ b/src/adapters/kysely/users/list.ts
@@ -12,6 +12,7 @@ export function listUsers(db: Kysely<Database>) {
   ): Promise<ListUsersResponse> => {
     let query = db.selectFrom("users").where("users.tenant_id", "=", tenantId);
     if (params.q) {
+      // NOTE - this isn't faithful to Auth0 as Auth0 does this in the dashboard - we can filter by any field on the Auth0 mgmt api
       query = luceneFilter(db, query, params.q, ["email", "name"]);
     }
 


### PR DESCRIPTION
*PR description copy pasted from:* https://github.com/sesamyab/auth-admin/pull/111



![image](https://github.com/sesamyab/auth-admin/assets/8496063/503b73e2-e312-4409-9d22-771790566368)

In the Auth0 dashboard we have to manually write out queries e.g. `ip:"2a02:586:7a37:fa8c:e296:c2c1:a6:f4bc"`

I noticed though that we're not doing the users endpoint filtering correctly though as we've hardcoded any `q` param to be `user_id` or `user_name` but on Auth0 we actually query `q: name:dan* OR email:dan*` (as opposed to how we are just sending up the query e.g. `q:dan`

*SO* I figure I'll just hardcode IP address for now? 