### PR TITLE
fix: make logging optional if no logtype passed in

### DIFF
--- a/src/routes/tsoa/authenticate.ts
+++ b/src/routes/tsoa/authenticate.ts
@@ -56,7 +56,7 @@ export class AuthenticateController extends Controller {
    * @returns
    */
   @Post("authenticate")
-  @Middlewares(loggerMiddleware(LogTypes.SUCCESS_CROSS_ORIGIN_AUTHENTICATION))
+  @Middlewares(loggerMiddleware())
   public async authenticate(
     @Body() body: CodeAuthenticateParams | PasswordAuthenticateParams,
     @Request() request: RequestWithContext,
@@ -118,7 +118,6 @@ export class AuthenticateController extends Controller {
       const [user] = await env.data.users.getByEmail(client.tenant_id, email);
 
       if (!user) {
-        request.ctx.set("logType", LogTypes.FAILED_CROSS_ORIGIN_AUTHENTICATION);
         throw new HTTPException(403);
       }
 

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -207,7 +207,7 @@ function createTypeLog(
 const DEBUG_LOG_TYPES = false;
 
 export function loggerMiddleware(
-  logTypeInitial: LogType,
+  logTypeInitial?: LogType,
   description?: string,
 ) {
   return async (
@@ -220,6 +220,8 @@ export function loggerMiddleware(
       const response = await next();
 
       const logType = ctx.var.logType || logTypeInitial;
+      // ir no logtype set then do not log
+      if (!logType) return response;
 
       if (DEBUG_LOG_TYPES && !ctx.var.tenantId)
         throw new Error("tenantId is required for logging");


### PR DESCRIPTION
The middleware solution is very noisy and doesn't match what Auth0 does