### PR TITLE
fix: get user helper

### DIFF
--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -31,7 +31,10 @@ import { applyTokenResponse } from "../../helpers/apply-token-response";
 import { sendResetPassword } from "../../controllers/email";
 import { validateCode } from "../../authentication-flows/passwordless";
 import { UniversalLoginSession } from "../../adapters/interfaces/UniversalLoginSession";
-import { getUsersByEmail } from "../../utils/users";
+import {
+  getUserByEmailAndConnection,
+  getUsersByEmail,
+} from "../../utils/users";
 
 // duplicated from /passwordless route
 const CODE_EXPIRATION_TIME = 30 * 60 * 1000;
@@ -463,12 +466,12 @@ export class LoginController extends Controller {
       await env.data.universalLoginSessions.update(session.id, session);
     }
 
-    // TODO - filter by primary user
-    const [user] = await getUsersByEmail(
-      env.data.users,
-      client.tenant_id,
-      params.username,
-    );
+    const user = await getUserByEmailAndConnection({
+      userAdapter: env.data.users,
+      tenant_id: client.tenant_id,
+      email: params.username,
+      connection: "Username-Password-Authentication",
+    });
 
     if (user) {
       const code = generateOTP();

--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -15,3 +15,52 @@ export async function getUsersByEmail(
 
   return response.users;
 }
+
+interface GetPrimaryUserByEmailAndConnectionParams {
+  userAdapter: UserDataAdapter;
+  tenant_id: string;
+  email: string;
+  connection: string;
+}
+
+export async function getUserByEmailAndConnection({
+  userAdapter,
+  tenant_id,
+  email,
+  connection,
+}: GetPrimaryUserByEmailAndConnectionParams): Promise<User | null> {
+  const { users } = await userAdapter.list(tenant_id, {
+    page: 0,
+    per_page: 1,
+    include_totals: false,
+    q: `email:${email} AND connection:${connection}`,
+  });
+
+  const [user] = users;
+
+  return user || null;
+}
+
+export async function getPrimaryUserByEmailAndConnection({
+  userAdapter,
+  tenant_id,
+  email,
+  connection,
+}: GetPrimaryUserByEmailAndConnectionParams): Promise<User | null> {
+  const user = await getUserByEmailAndConnection({
+    userAdapter,
+    tenant_id,
+    email,
+    connection,
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  if (!user.linked_to) {
+    return user;
+  }
+
+  return userAdapter.get(tenant_id, user.linked_to);
+}


### PR DESCRIPTION
Added some helpers that fetches the user based on connection and email that eventually should be able to replace the adapter for users.getByEmail.

I got two questions that I'm not sure about:
- should we really get i by email and provider rather than connection?
- should the id in the user be prefixed by the provider? I can't remember what we said.. It's a bit on in the tests now because it doesn't look like the sub in the token has the pipe which is odd, so I'm thinking that the fixture actually is wrong.