### PR TITLE
TODO - test CORS headers for requests from auth-admin

### DIFF
--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -6,6 +6,26 @@ import { getEnv } from "../helpers/test-client";
 import createTestUsers from "../helpers/createTestUsers";
 
 describe("users", () => {
+  it("should return CORS headers", async () => {
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
+
+    const token = await getAdminToken();
+    const response = await client.api.v2.users.$get(
+      {},
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "otherTenant",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    console.log(response.headers);
+  });
+
   it("should return an empty list of users for a tenant", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);


### PR DESCRIPTION
Let's not point fingers, but one of the devs on this project keeps breaking auth-admin!

Better to test in here than try and trigger playwright tests on auth-admin (which don't exist)

*BUT* how can we do a request with the correct headers and get the correct headers back? I haven't tried yet!