### PR TITLE
Fix/change password input to text

### DIFF
--- a/src/templates/universal/signup.ts
+++ b/src/templates/universal/signup.ts
@@ -11,7 +11,7 @@ export const signup = `<div class="wrap-login100 p-l-55 p-r-55 p-t-65 p-b-54">
     </div>
     <div class="wrap-input100 validate-input" data-validate="Password is required">
         <span class="label-input100">Password</span>
-        <input class="input100" type="password" name="password" placeholder="Type your password" required />
+        <input class="input100" type="text" name="password" placeholder="Type your password" required />
         <span class="focus-input100" data-symbol=""></span>
     </div>
     <div>

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -6,6 +6,26 @@ import { getEnv } from "../helpers/test-client";
 import createTestUsers from "../helpers/createTestUsers";
 
 describe("users", () => {
+  it("should return CORS headers", async () => {
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
+
+    const token = await getAdminToken();
+    const response = await client.api.v2.users.$get(
+      {},
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "otherTenant",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    console.log(response.headers);
+  });
+
   it("should return an empty list of users for a tenant", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);


### PR DESCRIPTION
@markusahlstrand this turns the password input into a normal text

This is a nightmare to work with currently as I entered the wrong password (I suffix `-auth2` on auth2, but didn't here because chrome prefilled), and it's several steps to remove the password. deleting the user isn't enough it seems

I'm burning time here so I'm going to force merge this as I imagine something will happen where I'll have to spend a few hours recreating users again

Seems like I should have written migration scripts all that time ago