### PR TITLE
fix: login2 expired code no locale subpath

### DIFF
--- a/src/routes/tsoa/passwordless.ts
+++ b/src/routes/tsoa/passwordless.ts
@@ -35,12 +35,6 @@ export interface PasswordlessOptions {
   authParams: Omit<AuthParams, "client_id">;
 }
 
-function getLocalePath(locale: string) {
-  if (locale === "en") return "";
-
-  return `/${locale}`;
-}
-
 @Route("passwordless")
 @Tags("passwordless")
 export class PasswordlessController extends Controller {
@@ -193,15 +187,15 @@ export class PasswordlessController extends Controller {
       // Ideally here only catch AuthenticationCodeExpiredError
       // redirect here always to login2.sesamy.dev/expired-code
 
-      const localePath = getLocalePath(client.tenant.language || "sv");
+      const locale = client.tenant.language || "sv";
 
-      const login2ExpiredCodeUrl = new URL(
-        `${env.LOGIN2_URL}${localePath}/expired-code`,
-      );
+      const login2ExpiredCodeUrl = new URL(`${env.LOGIN2_URL}/expired-code`);
 
       const stateDecoded = new URLSearchParams(state);
 
       login2ExpiredCodeUrl.searchParams.set("email", encodeURIComponent(email));
+
+      login2ExpiredCodeUrl.searchParams.set("lang", locale);
 
       const redirectUri = stateDecoded.get("redirect_uri");
       if (redirectUri) {

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -589,7 +589,7 @@ describe("code-flow", () => {
         authenticateResponse.headers.get("location")!,
       );
       expect(redirectUri.hostname).toBe("login2.sesamy.dev");
-      expect(redirectUri.pathname).toBe("/sv/expired-code");
+      expect(redirectUri.pathname).toBe("/expired-code");
       expect(redirectUri.searchParams.get("email")).toBe(
         encodeURIComponent("test@example.com"),
       );
@@ -610,10 +610,11 @@ describe("code-flow", () => {
         authenticateResponse2.headers.get("location")!,
       );
       expect(redirectUri2.hostname).toBe("login2.sesamy.dev");
-      expect(redirectUri2.pathname).toBe("/sv/expired-code");
+      expect(redirectUri2.pathname).toBe("/expired-code");
       expect(redirectUri2.searchParams.get("email")).toBe(
         encodeURIComponent("another@email.com"),
       );
+      expect(redirectUri2.searchParams.get("lang")).toBe("sv");
     });
   });
 });


### PR DESCRIPTION
Ooops! :smile: 

*lucky I did what @markusahlstrand  asked* :smile: 


Login2 isn't testing a non-english incorrect code

I'll update the test on login2 as well to be in swedish 