### PR TITLE
feat: social get primary user

### DIFF
--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -31,7 +31,7 @@ export async function getUserByEmailAndProvider({
 }: GetPrimaryUserByEmailAndProviderParams): Promise<User | null> {
   const { users } = await userAdapter.list(tenant_id, {
     page: 0,
-    per_page: 1,
+    per_page: 10,
     include_totals: false,
     q: `email:${email} provider:${provider}`,
   });
@@ -54,11 +54,12 @@ export async function getPrimaryUserByEmail({
 }: GetPrimaryUserByEmailParams): Promise<User | undefined> {
   const { users } = await userAdapter.list(tenant_id, {
     page: 0,
-    per_page: 1,
+    per_page: 10,
     include_totals: false,
     q: `email:${email}`,
   });
 
+  // we should do this in SQL so we don't get issues with pagination!
   return users.find((user) => !user.linked_to);
 }
 

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -285,7 +285,7 @@ describe("social sign on", () => {
   });
 
   describe("Secondary user", () => {
-    it("should return existing primary account when logging in with new social sign ons with same email address", async () => {
+    it("should return existing primary account when logging in with new social sign on with same email address", async () => {
       // ---------------------------------------------
       // create new user with same email as we have hardcoded on the mock id_token responses
       // ---------------------------------------------
@@ -534,6 +534,80 @@ describe("social sign on", () => {
           },
         },
       ]);
+    });
+    // TO TEST
+    // ii. existing secondary linked user + primary user NOT for this social sign on AND can get the unlinked user first in the response?  we want to trigger an error
+    // where the get is returning the secondary user...
+    it.only("should return existing primary account when logging in with new social sign on with same email address AND there is already another linked social account", async () => {
+      const token = await getAdminToken();
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+
+      // What I want here is for the linked social account to be returned FIRST!
+      // so this is a bit synthetic by manually writing the users...
+      await env.data.users.create("tenantId", {
+        name: "örjan.lindström@example.com",
+        provider: "other-social-provider",
+        connection: "other-social-provider",
+        email: "örjan.lindström@example.com",
+        email_verified: true,
+        last_ip: "",
+        login_count: 0,
+        is_social: true,
+        profileData: JSON.stringify(EXPECTED_PROFILE_DATA),
+        id: "other-social-provider|123456789012345678901",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+
+      await env.data.users.create("tenantId", {
+        name: "örjan.lindström@example.com",
+        provider: "email",
+        connection: "email",
+        email: "örjan.lindström@example.com",
+        email_verified: true,
+        last_ip: "",
+        login_count: 0,
+        is_social: true,
+        id: "email|7575757575757",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+
+      // ---------------------------------------------
+      // now link first social account to this email account
+      // ---------------------------------------------
+
+      await env.data.users.update(
+        "tenantId",
+        "demo-social-provider|123456789012345678901",
+        {
+          linked_to: "email|7575757575757",
+        },
+      );
+
+      // ---------------------------------------------
+      // now do social sign on with same email - new user registered
+      // ---------------------------------------------
+      const socialCallbackQuery = {
+        state: SOCIAL_STATE_PARAM,
+        code: "code",
+      };
+
+      const socialCallbackResponse = await client.callback.$get({
+        query: socialCallbackQuery,
+      });
+
+      const socialCallbackResponseQuery = new URLSearchParams(
+        socialCallbackResponse.headers.get("location")?.split("#")[1]!,
+      );
+
+      const accessTokenPayload = parseJwt(
+        socialCallbackResponseQuery.get("access_token")!,
+      );
+
+      // on main this is returning the wrong user! Nice
+      expect(accessTokenPayload.sub).toBe("email|7575757575757");
     });
   });
 

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -586,6 +586,27 @@ describe("social sign on", () => {
       );
 
       // ---------------------------------------------
+      // fetch this linked user to sanity check rest of test
+      // ---------------------------------------------
+      const linkedUserRes = await client.api.v2.users[":user_id"].$get(
+        {
+          param: { user_id: "other-social-provider|123456789012345678901" },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
+
+      const linkedUser = (await linkedUserRes.json()) as UserResponse;
+      // This is not true... should it be? TODO
+      // expect(linkedUser.user_id).toBe("email|7575757575757");
+      // We can assert this at least...
+      expect(linkedUser.linked_to).toBe("email|7575757575757");
+
+      // ---------------------------------------------
       // now do social sign on with same email - new user registered
       // ---------------------------------------------
       const socialCallbackQuery = {

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -577,10 +577,9 @@ describe("social sign on", () => {
       // ---------------------------------------------
       // now link first social account to this email account
       // ---------------------------------------------
-
       await env.data.users.update(
         "tenantId",
-        "demo-social-provider|123456789012345678901",
+        "other-social-provider|123456789012345678901",
         {
           linked_to: "email|7575757575757",
         },


### PR DESCRIPTION
Note the first commit test actually fails. It's a bit of a synthetic test as in reality the first user added to the db would be the primary user *BUT* we shouldn't be relying on record-order in the database _especially_ given since we're filling the db with Auth0 data...