### PR TITLE
test: change every users test to use default tenant id

### DIFF
--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -17,7 +17,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -44,7 +44,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -69,7 +69,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -91,7 +91,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -128,7 +128,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -146,7 +146,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -170,7 +170,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -196,7 +196,7 @@ describe("users", () => {
         headers: {
           authorization: `Bearer ${token}`,
           "content-type": "application/json",
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -212,7 +212,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -240,7 +240,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       },
@@ -253,7 +253,7 @@ describe("users", () => {
     // ----------------------
     // Check directly in the database that the email is lower case
     // ----------------------
-    const user = await env.data.users.get("otherTenant", createdUser.user_id);
+    const user = await env.data.users.get("tenantId", createdUser.user_id);
     expect(user!.email).toBe("fooz@bar.com");
 
     // ----------------------
@@ -269,7 +269,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
         },
       },
     );
@@ -296,7 +296,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
             "content-type": "application/json",
           },
         },
@@ -314,7 +314,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -346,7 +346,7 @@ describe("users", () => {
           {
             headers: {
               authorization: `Bearer ${token}`,
-              "tenant-id": "otherTenant",
+              "tenant-id": "tenantId",
               "content-type": "application/json",
             },
           },
@@ -362,7 +362,7 @@ describe("users", () => {
           {
             headers: {
               authorization: `Bearer ${token}`,
-              "tenant-id": "otherTenant",
+              "tenant-id": "tenantId",
             },
           },
         );
@@ -385,7 +385,7 @@ describe("users", () => {
           {
             headers: {
               authorization: `Bearer ${token}`,
-              "tenant-id": "otherTenant",
+              "tenant-id": "tenantId",
               "content-type": "application/json",
             },
           },
@@ -401,7 +401,7 @@ describe("users", () => {
           {
             headers: {
               authorization: `Bearer ${token}`,
-              "tenant-id": "otherTenant",
+              "tenant-id": "tenantId",
             },
           },
         );
@@ -419,7 +419,7 @@ describe("users", () => {
 
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
-      const [newUser1, newUser2] = await createTestUsers(env, "otherTenant");
+      const [newUser1, newUser2] = await createTestUsers(env, "tenantId");
 
       const params = {
         param: {
@@ -434,7 +434,7 @@ describe("users", () => {
       ].identities.$post(params, {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       });
@@ -447,7 +447,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -467,7 +467,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -506,7 +506,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -519,7 +519,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -543,7 +543,7 @@ describe("users", () => {
 
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
-      const [newUser1, newUser2] = await createTestUsers(env, "otherTenant");
+      const [newUser1, newUser2] = await createTestUsers(env, "tenantId");
 
       const [provider] = newUser2.id.split("|");
       const params = {
@@ -559,7 +559,7 @@ describe("users", () => {
       ].identities.$post(params, {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "otherTenant",
+          "tenant-id": "tenantId",
           "content-type": "application/json",
         },
       });
@@ -577,7 +577,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
           },
         },
       );
@@ -614,7 +614,7 @@ describe("users", () => {
 
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
-      const [newUser1, newUser2] = await createTestUsers(env, "otherTenant");
+      const [newUser1, newUser2] = await createTestUsers(env, "tenantId");
 
       const params = {
         param: { user_id: newUser1.id },
@@ -628,7 +628,7 @@ describe("users", () => {
         {
           headers: {
             authorization: `Bearer ${token}`,
-            "tenant-id": "otherTenant",
+            "tenant-id": "tenantId",
             "content-type": "application/json",
           },
         },

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -6,7 +6,8 @@ import { getEnv } from "../helpers/test-client";
 import createTestUsers from "../helpers/createTestUsers";
 
 describe("users", () => {
-  // TO TEST - should return CORS headers! Dan broke this on auth-admin. Check from a synthetic auth-admin request we get CORS headers back
+  // TO TEST
+  //  - should return CORS headers! Dan broke this on auth-admin. Check from a synthetic auth-admin request we get CORS headers back
   it("should return an empty list of users for a tenant", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);
@@ -17,7 +18,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "tenantId",
+          "tenant-id": "otherTenant",
         },
       },
     );
@@ -53,7 +54,7 @@ describe("users", () => {
     expect(createUserResponse.status).toBe(400);
   });
 
-  it("should create a new user for a tenant", async () => {
+  it("should create a new user for an empty tenant", async () => {
     const token = await getAdminToken();
 
     const env = await getEnv();
@@ -69,7 +70,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "tenantId",
+          "tenant-id": "otherTenant",
           "content-type": "application/json",
         },
       },
@@ -91,7 +92,7 @@ describe("users", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "tenant-id": "tenantId",
+          "tenant-id": "otherTenant",
         },
       },
     );
@@ -218,8 +219,8 @@ describe("users", () => {
     );
 
     const body = (await usersResponse.json()) as UserResponse[];
-    expect(body.length).toBe(1);
-    expect(body[0].email_verified).toBe(true);
+    expect(body.length).toBe(2);
+    expect(body[1].email_verified).toBe(true);
   });
 
   it("should lowercase email when creating a  user", async () => {
@@ -280,7 +281,7 @@ describe("users", () => {
   });
 
   describe("search for user", () => {
-    it("should search for a user with wildcard search", async () => {
+    it("should search for a user with wildcard search on email", async () => {
       const token = await getAdminToken();
 
       const env = await getEnv();
@@ -308,7 +309,7 @@ describe("users", () => {
         {
           query: {
             per_page: 2,
-            q: "example",
+            q: "test",
           },
         },
         {
@@ -455,8 +456,8 @@ describe("users", () => {
       expect(listUsersResponse.status).toBe(200);
 
       const usersList = (await listUsersResponse.json()) as UserResponse[];
-      expect(usersList.length).toBe(1);
-      expect(usersList[0].user_id).toBe(newUser2.user_id);
+      expect(usersList.length).toBe(2);
+      expect(usersList[1].user_id).toBe(newUser2.user_id);
 
       // Fetch a single users
       const userResponse = await client.api.v2.users[":user_id"].$get(


### PR DESCRIPTION
I've just noticed that we are `otherTenant` for the mgmt API users endpoint

We have a real danger of false positives here as we're populating this tenant with just one user, and then we're searching in different ways to return this same user...  so there's no actual difference between searching and returning all users for that tenant

*going forward* I would like to create another `getEnv` helper that adds 50+ randomish users to *really* test this (maybe some that are even similar), else we could really lose the battle for Troy!

![image](https://github.com/sesamyab/auth/assets/8496063/43b7899e-dc67-43e6-a7a3-6b143c158762)
