### PR TITLE
feat: only allow email connections in POST to users endpoint

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -177,12 +177,18 @@ export class UsersMgmtController extends Controller {
       throw new HTTPException(400, { message: "Email is required" });
     }
 
+    if (user.connection !== "email") {
+      throw new HTTPException(400, {
+        message: "Only email connections are supported",
+      });
+    }
+
     const email = emailRaw.toLowerCase();
 
     const data = await env.data.users.create(tenantId, {
       email,
       id: `email|${userIdGenerate()}`,
-      name: email,
+      name: user.name,
       provider: "email",
       connection: "email",
       email_verified: false,

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -188,7 +188,7 @@ export class UsersMgmtController extends Controller {
     const data = await env.data.users.create(tenantId, {
       email,
       id: `email|${userIdGenerate()}`,
-      name: user.name,
+      name: email,
       provider: "email",
       connection: "email",
       email_verified: false,

--- a/test/integration/management-api/users-by-email.spec.ts
+++ b/test/integration/management-api/users-by-email.spec.ts
@@ -92,7 +92,7 @@ describe("users by email", () => {
       {
         json: {
           email: "foo@example.com",
-          connection: "Username-Password-Authentication",
+          connection: "email",
           // seems odd that this isn't allowed... I think this endpoint needs looking at
           // maybe it's good we have to use the mgmt API for our test fixtures
           // provider: "auth2",
@@ -167,7 +167,7 @@ describe("users by email", () => {
       {
         json: {
           email: "bar@example.com",
-          connection: "Username-Password-Authentication",
+          connection: "email",
         },
       },
       {


### PR DESCRIPTION
We don't support username-password for production users, and it seems wrong that the profile service was doing this! (which has since been changed)

I'd rather throw an error so we know about this (see comments)