### PR TITLE
feat: use name if sent to user POST else fallback to email

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -180,9 +180,9 @@ export class UsersMgmtController extends Controller {
     const email = emailRaw.toLowerCase();
 
     const data = await env.data.users.create(tenantId, {
+      ...user,
       email,
       id: `email|${userIdGenerate()}`,
-      name: email,
       provider: "email",
       connection: "email",
       email_verified: false,

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -180,9 +180,9 @@ export class UsersMgmtController extends Controller {
     const email = emailRaw.toLowerCase();
 
     const data = await env.data.users.create(tenantId, {
-      ...user,
       email,
       id: `email|${userIdGenerate()}`,
+      name: user.name || email,
       provider: "email",
       connection: "email",
       email_verified: false,

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -356,7 +356,7 @@ describe("social sign on", () => {
       // This is the big change here
       expect(idTokenPayload.sub).not.toBe("demo-social-provider|1234567890");
       expect(idTokenPayload.sub).toBe(createEmailUser.user_id);
-      expect(idTokenPayload.name).toBeNull();
+      expect(idTokenPayload.name).toBe("örjan.lindström@example.com");
       expect(idTokenPayload.email).toBe("örjan.lindström@example.com");
       // TODO - we are pretending that the email is always verified
       // expect(idTokenPayload.email_verified).toBe(true);

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -356,7 +356,7 @@ describe("social sign on", () => {
       // This is the big change here
       expect(idTokenPayload.sub).not.toBe("demo-social-provider|1234567890");
       expect(idTokenPayload.sub).toBe(createEmailUser.user_id);
-      expect(idTokenPayload.name).toBe("örjan.lindström@example.com");
+      expect(idTokenPayload.name).toBeNull();
       expect(idTokenPayload.email).toBe("örjan.lindström@example.com");
       // TODO - we are pretending that the email is always verified
       // expect(idTokenPayload.email_verified).toBe(true);
@@ -431,7 +431,6 @@ describe("social sign on", () => {
         // testing this means it must be working
         sub: createEmailUser.user_id,
         aud: "clientId",
-        name: "örjan.lindström@example.com",
         email: "örjan.lindström@example.com",
         email_verified: false,
         nonce: "nonce",

--- a/test/integration/management-api/users-by-email.spec.ts
+++ b/test/integration/management-api/users-by-email.spec.ts
@@ -91,6 +91,7 @@ describe("users by email", () => {
     const createDuplicateUserResponse = await client.api.v2.users.$post(
       {
         json: {
+          name: "Åkesson Þorsteinsson",
           email: "foo@example.com",
           connection: "Username-Password-Authentication",
           // seems odd that this isn't allowed... I think this endpoint needs looking at
@@ -150,7 +151,7 @@ describe("users by email", () => {
     expect(users[1]).toMatchObject({
       email: "foo@example.com",
       tenant_id: "tenantId",
-      name: "foo@example.com",
+      name: "Åkesson Þorsteinsson",
       provider: "email",
       connection: "email",
       email_verified: false,

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -370,6 +370,34 @@ describe("users", () => {
     const fetchedUser = (await newUser.json()) as UserResponse;
     expect(fetchedUser.email).toBe("fooz@bar.com");
   });
+  // TODO - split these tests up into a new test suite one for each HTTP verb!
+  it("should use email for name if not name is not passed", async () => {
+    const token = await getAdminToken();
+    const env = await getEnv();
+    const client = testClient(tsoaApp, env);
+
+    const createUserResponse = await client.api.v2.users.$post(
+      {
+        json: {
+          email: "foo@bar.com",
+          connection: "email",
+        },
+      },
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      },
+    );
+
+    expect(createUserResponse.status).toBe(201);
+
+    const createdUser = (await createUserResponse.json()) as UserResponse;
+
+    expect(createdUser.name).toBe("foo@bar.com");
+  });
 
   describe("search for user", () => {
     it("should search for a user with wildcard search on email", async () => {


### PR DESCRIPTION
~We're throwing away params that we're receiving in the POST!~


Step 1. I'll do more PRs next as mentioned in the comments