### PR TITLE
feat: accept more params when connection is email

### DIFF
--- a/src/types/auth0/UserResponse.ts
+++ b/src/types/auth0/UserResponse.ts
@@ -27,3 +27,10 @@ export interface UserResponse extends BaseUser {
 export interface GetUserResponseWithTotals extends Totals {
   users: UserResponse[];
 }
+
+// I'll duplicate everything for now and we can de-dupe common types after...
+// this might be a lot simpler than I'm expecting
+// how to do validation though? Zod right? 8-)
+export interface CreateEmailUserParas {}
+
+// hmmmm. I'll come back to this PR


### PR DESCRIPTION
Auth0's POST `/api/v2/users` endpoint accepts different sets of params depending on the `connection`

As we're currently hardcoding this we could just hardcode all the accepted params *BUT* given we want to support `username-password` pretty imminently, I was thinking of using Zod to parse the params when `connection` is `email`