### PR TITLE
test: do not return linked account on get by id endpoint

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -133,7 +133,7 @@ export class UsersMgmtController extends Controller {
       throw new HTTPException(404);
     }
 
-    if (!!user.linked_to) {
+    if (user.linked_to) {
       throw new HTTPException(404, {
         message: "User is linked to another user",
       });

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -133,6 +133,12 @@ export class UsersMgmtController extends Controller {
       throw new HTTPException(404);
     }
 
+    if (!!user.linked_to) {
+      throw new HTTPException(404, {
+        message: "User is linked to another user",
+      });
+    }
+
     const userResponse: UserResponse = await enrichUser(env, tenant_id, user);
 
     return userResponse;

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -601,25 +601,14 @@ describe("social sign on", () => {
       );
 
       // ---------------------------------------------
-      // fetch this linked user to sanity check rest of test
+      // load this linked user to sanity check rest of test
       // ---------------------------------------------
-      const linkedUserRes = await client.api.v2.users[":user_id"].$get(
-        {
-          param: { user_id: "other-social-provider|123456789012345678901" },
-        },
-        {
-          headers: {
-            authorization: `Bearer ${token}`,
-            "tenant-id": "tenantId",
-          },
-        },
+      const linkedUser = await env.data.users.get(
+        "tenantId",
+        "other-social-provider|123456789012345678901",
       );
 
-      const linkedUser = (await linkedUserRes.json()) as UserResponse;
-      // This is not true... should it be? TODO
-      // expect(linkedUser.user_id).toBe("email|7575757575757");
-      // We can assert this at least...
-      expect(linkedUser.linked_to).toBe("email|7575757575757");
+      expect(linkedUser!.linked_to).toBe("email|7575757575757");
 
       // ---------------------------------------------
       // sanity check that users are entered in database in correct order
@@ -652,7 +641,6 @@ describe("social sign on", () => {
         socialCallbackResponseQuery.get("access_token")!,
       );
 
-      // Currently on the main branch this is returning the wrong user!
       expect(accessTokenPayload.sub).toBe("email|7575757575757");
     });
   });

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -810,10 +810,10 @@ describe("users", () => {
       // link the accounts
       const params = {
         param: {
-          user_id: secondaryUser.user_id,
+          user_id: "userId",
         },
         json: {
-          link_with: "userId",
+          link_with: secondaryUser.user_id,
         },
       };
       const linkUserResponse = await client.api.v2.users[
@@ -829,7 +829,6 @@ describe("users", () => {
       expect(linkUserResponse.status).toBe(201);
 
       // now pull the primary account down
-
       const userResponse = await client.api.v2.users[":user_id"].$get(
         {
           param: {
@@ -856,7 +855,6 @@ describe("users", () => {
           provider: "auth2",
           isSocial: false,
         },
-        // NICE! this is not done at all  8-)
         {
           connection: "email",
           user_id: secondaryUser.user_id.split("|")[1],
@@ -870,7 +868,6 @@ describe("users", () => {
       ]);
 
       // try getting the secondary user
-
       const secondaryUserResponse = await client.api.v2.users[":user_id"].$get(
         {
           param: {
@@ -885,7 +882,7 @@ describe("users", () => {
         },
       );
 
-      // nice! this is wrong!
+      // auth0 does not return linked accounts
       expect(secondaryUserResponse.status).toBe(404);
     });
   });


### PR DESCRIPTION
#### What this PR does
fixes the get by id endpoint to *not* return linked users!

The dream of having tests that run against auth0 and auth2 would be amazing, as opposed to having to trust my screenshots :smile: 

![image](https://github.com/sesamyab/auth/assets/8496063/bed6defb-4e72-4dea-9ebe-d6dc26d0f364)


#### TODO
~The linking accounts test fails when we unlink~ :exploding_head: 

~Interesting!  Maybe this exposes a bug there... I'll investigate now~ :thinking: 

Fixed on the destination branch of this PR :+1: 