### PR TITLE
test: fix unlinking accounts

### DIFF
--- a/src/adapters/interfaces/Users.ts
+++ b/src/adapters/interfaces/Users.ts
@@ -17,4 +17,5 @@ export interface UserDataAdapter {
     id: string,
     user: Partial<BaseUser>,
   ): Promise<boolean>;
+  unlink(tenantId: string, id: string): Promise<boolean>;
 }

--- a/src/adapters/kysely/users/index.ts
+++ b/src/adapters/kysely/users/index.ts
@@ -7,6 +7,7 @@ import { getByEmail } from "./getByEmail";
 import { listUsers } from "./list";
 import { remove } from "./remove";
 import { update } from "./update";
+import { unlink } from "./unlink";
 
 export function createUsersAdapter(db: Kysely<Database>): UserDataAdapter {
   return {
@@ -16,5 +17,7 @@ export function createUsersAdapter(db: Kysely<Database>): UserDataAdapter {
     getByEmail: getByEmail(db),
     list: listUsers(db),
     update: update(db),
+    // TODO - think about this more when other issues fixed
+    unlink: unlink(db),
   };
 }

--- a/src/adapters/kysely/users/unlink.ts
+++ b/src/adapters/kysely/users/unlink.ts
@@ -1,0 +1,17 @@
+import { Kysely } from "kysely";
+import { Database, SqlUser, PostUsersBody } from "../../../types";
+
+export function unlink(db: Kysely<Database>) {
+  return async (tenant_id: string, id: string): Promise<boolean> => {
+    const unsafeTypeUser: any = { linked_to: null };
+
+    const results = await db
+      .updateTable("users")
+      .set(unsafeTypeUser)
+      .where("users.tenant_id", "=", tenant_id)
+      .where("users.id", "=", id)
+      .execute();
+
+    return results.length === 1;
+  };
+}

--- a/src/adapters/kysely/users/update.ts
+++ b/src/adapters/kysely/users/update.ts
@@ -9,6 +9,13 @@ function getEmailVerified(user: Partial<PostUsersBody>): number | undefined {
   return user.email_verified ? 1 : 0;
 }
 
+function getLinkedTo(user: Partial<PostUsersBody>): string | null {
+  if (user.linked_to === undefined) {
+    return null;
+  }
+  return user.linked_to;
+}
+
 export function update(db: Kysely<Database>) {
   return async (
     tenant_id: string,
@@ -18,6 +25,7 @@ export function update(db: Kysely<Database>) {
     const sqlUser: Partial<SqlUser> = {
       ...user,
       email_verified: getEmailVerified(user),
+      linked_to: getLinkedTo(user),
       updated_at: new Date().toISOString(),
     };
 

--- a/src/adapters/kysely/users/update.ts
+++ b/src/adapters/kysely/users/update.ts
@@ -9,13 +9,6 @@ function getEmailVerified(user: Partial<PostUsersBody>): number | undefined {
   return user.email_verified ? 1 : 0;
 }
 
-function getLinkedTo(user: Partial<PostUsersBody>): string | null {
-  if (user.linked_to === undefined) {
-    return null;
-  }
-  return user.linked_to;
-}
-
 export function update(db: Kysely<Database>) {
   return async (
     tenant_id: string,
@@ -25,9 +18,13 @@ export function update(db: Kysely<Database>) {
     const sqlUser: Partial<SqlUser> = {
       ...user,
       email_verified: getEmailVerified(user),
-      linked_to: getLinkedTo(user),
       updated_at: new Date().toISOString(),
     };
+
+    const unsafeTypeUser = sqlUser as any;
+    if (unsafeTypeUser.linked_to === undefined) {
+      unsafeTypeUser.linked_to = null;
+    }
 
     const results = await db
       .updateTable("users")

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -320,9 +320,7 @@ export class UsersMgmtController extends Controller {
     const { env } = request.ctx;
     request.ctx.set("tenantId", tenantId);
 
-    await env.data.users.update(tenantId, user_id, {
-      linked_to: undefined,
-    });
+    await env.data.users.unlink(tenantId, user_id);
 
     this.setStatus(200);
     return "ok";

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -7,7 +7,7 @@ export interface BaseUser {
   name?: string;
   picture?: string;
   locale?: string;
-  linked_to?: string | null;
+  linked_to?: string;
   profileData?: string;
 }
 

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -7,7 +7,7 @@ export interface BaseUser {
   name?: string;
   picture?: string;
   locale?: string;
-  linked_to?: string;
+  linked_to?: string | null;
   profileData?: string;
 }
 

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -647,6 +647,10 @@ describe("users", () => {
 
       expect(unlinkUserResponse.status).toBe(200);
 
+      // manually check in the db that the linked_to field has been reset
+      const user1Updated = await env.data.users.get("tenantId", newUser1.id);
+      expect(user1Updated!.linked_to).toBeUndefined();
+
       // now fetch user 2 again to check doesn't have user2 as identity
       const userResponse2 = await client.api.v2.users[":user_id"].$get(
         { param: { user_id: newUser2.user_id } },

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -647,9 +647,9 @@ describe("users", () => {
 
       expect(unlinkUserResponse.status).toBe(200);
 
-      // now fetch user 1 again to check doesn't have user2 as identity
-      const userResponse1 = await client.api.v2.users[":user_id"].$get(
-        { param: { user_id: newUser1.user_id } },
+      // now fetch user 2 again to check doesn't have user2 as identity
+      const userResponse2 = await client.api.v2.users[":user_id"].$get(
+        { param: { user_id: newUser2.user_id } },
         {
           headers: {
             authorization: `Bearer ${token}`,
@@ -658,12 +658,12 @@ describe("users", () => {
         },
       );
 
-      expect(userResponse1.status).toBe(200);
-      const user1 = (await userResponse1.json()) as UserResponse;
+      expect(userResponse2.status).toBe(200);
+      const user1 = (await userResponse2.json()) as UserResponse;
       expect(user1.identities).toEqual([
         {
           connection: "email",
-          user_id: newUser1.user_id.split("|")[1],
+          user_id: newUser2.user_id.split("|")[1],
           provider: "email",
           isSocial: false,
         },

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -659,8 +659,8 @@ describe("users", () => {
       );
 
       expect(userResponse2.status).toBe(200);
-      const user1 = (await userResponse2.json()) as UserResponse;
-      expect(user1.identities).toEqual([
+      const user2 = (await userResponse2.json()) as UserResponse;
+      expect(user2.identities).toEqual([
         {
           connection: "email",
           user_id: newUser2.user_id.split("|")[1],
@@ -669,7 +669,7 @@ describe("users", () => {
         },
       ]);
       // this shows we have unlinked
-      expect(user1.identities.length).toBe(1);
+      expect(user2.identities.length).toBe(1);
     });
 
     it("should link two users using user_id and provider parameter", async () => {


### PR DESCRIPTION
*LOL*.  If we pass `key: undefined` into kysely to update, we just ignore that :smile: 

Found while trying to do this PR! https://github.com/sesamyab/auth/pull/523

~I'm sure we had that issue elsewhere... At least on SQLite anyway~ :thinking: 
Indeed. We fixed this for the get users. SQL has no concept of `undefined`! where as `null` is tedious in typescript and means something different

So we're swapping `null` for `undefined` when reading

At some point we could do this for other fields because _we have no way to clear fields in auth-admin_

I don't see this as a huge issue for now so this PR does the minimum to fix what *may* be a production bug, but probably isn't :smile:   (I doubt we're unlinking accounts ever - I'd like to check our production logs to see which of the endpoitnts we're actually using)