### PR TITLE
fix: emails endpoint should not 404 its a query

### DIFF
--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -28,16 +28,8 @@ export class UsersByEmailController extends Controller {
     request.ctx.set("tenantId", tenant_id);
 
     const users = await env.data.users.getByEmail(tenant_id, email);
-    if (users.length === 0) {
-      throw new HTTPException(404, { message: "User not found" });
-    }
 
     const primarySqlUsers = users.filter((user) => !user.linked_to);
-
-    if (primarySqlUsers.length === 0) {
-      this.setStatus(404);
-      return [];
-    }
 
     const response: UserResponse[] = await Promise.all(
       primarySqlUsers.map(async (primarySqlUser) => {

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -38,7 +38,8 @@ describe("code-flow", () => {
         },
       },
     );
-    expect(resInitialQuery.status).toBe(404);
+    const results = await resInitialQuery.json();
+    expect(results).toEqual([]);
 
     // -----------------
     // Start the passwordless flow

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -36,7 +36,6 @@ describe("code-flow", () => {
           },
         },
       );
-      // expect(resInitialQuery.status).toBe(404);
       const results = await resInitialQuery.json();
       expect(results).toHaveLength(0);
 

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -36,7 +36,9 @@ describe("code-flow", () => {
           },
         },
       );
-      expect(resInitialQuery.status).toBe(404);
+      // expect(resInitialQuery.status).toBe(404);
+      const results = await resInitialQuery.json();
+      expect(results).toHaveLength(0);
 
       const response = await client.passwordless.start.$post(
         {

--- a/test/integration/management-api/users-by-email.spec.ts
+++ b/test/integration/management-api/users-by-email.spec.ts
@@ -6,7 +6,7 @@ import { UserResponse } from "../../../src/types/auth0";
 import { Identity } from "../../../src/types/auth0/Identity";
 
 describe("users by email", () => {
-  it("should return 404 for non existent email address?", async () => {
+  it("should return empty list if there are no users with queried email address", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);
 
@@ -25,7 +25,9 @@ describe("users by email", () => {
       },
     );
 
-    expect(response.status).toBe(404);
+    const users = (await response.json()) as UserResponse[];
+
+    expect(users).toBe([]);
   });
 
   it("should return a single user for a simple get by email - no linked accounts", async () => {
@@ -306,7 +308,9 @@ describe("users by email", () => {
         },
       },
     );
-    expect(barEmailAfterLink.status).toBe(404);
+    const barEmailAfterLinkUsers =
+      (await barEmailAfterLink.json()) as UserResponse[];
+    expect(barEmailAfterLinkUsers).toHaveLength(0);
 
     // ALSO TO TEST
     // - unlink accounts

--- a/test/integration/management-api/users-by-email.spec.ts
+++ b/test/integration/management-api/users-by-email.spec.ts
@@ -27,7 +27,7 @@ describe("users by email", () => {
 
     const users = (await response.json()) as UserResponse[];
 
-    expect(users).toBe([]);
+    expect(users).toHaveLength(0);
   });
 
   it("should return a single user for a simple get by email - no linked accounts", async () => {


### PR DESCRIPTION
This endpoint was already correctly not returning linked accounts (secondary accounts) *but* it was returning a 404 when it should return no results