### PR TITLE
fix: list endpoint should return linked users

### DIFF
--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -406,6 +406,89 @@ describe("users management API endpoint", () => {
       expect(body.length).toBe(0);
     });
 
+    it.only("should return linked users as identities in primary user, and not in list of results", async () => {
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+
+      const token = await getAdminToken();
+
+      const createSecondaryUserResponse = await client.api.v2.users.$post(
+        {
+          json: {
+            // use a different email here to make sure our implementation is not taking shortcuts
+            email: "secondary-user@example.com",
+            connection: "email",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+            "content-type": "application/json",
+          },
+        },
+      );
+
+      expect(createSecondaryUserResponse.status).toBe(201);
+      const secondaryUser =
+        (await createSecondaryUserResponse.json()) as UserResponse;
+
+      // link the accounts
+      const params = {
+        param: {
+          user_id: "userId",
+        },
+        json: {
+          link_with: secondaryUser.user_id,
+        },
+      };
+      const linkUserResponse = await client.api.v2.users[
+        ":user_id"
+      ].identities.$post(params, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          "tenant-id": "tenantId",
+          "content-type": "application/json",
+        },
+      });
+
+      expect(linkUserResponse.status).toBe(201);
+
+      // Now we should only get one result from the get endpoint but with nested identities
+      const response = await client.api.v2.users.$get(
+        {},
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = (await response.json()) as UserResponse[];
+      expect(body.length).toBe(1);
+
+      expect(body[0].identities).toEqual([
+        {
+          connection: "Username-Password-Authentication",
+          user_id: "userId",
+          provider: "auth2",
+          isSocial: false,
+        },
+        {
+          connection: "email",
+          user_id: secondaryUser.user_id.split("|")[1],
+          provider: "email",
+          isSocial: false,
+          profileData: {
+            email: "secondary-user@example.com",
+          },
+        },
+      ]);
+    });
+
     describe("search for user", () => {
       it("should search for a user with wildcard search on email", async () => {
         const token = await getAdminToken();

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -384,7 +384,8 @@ describe("users management API endpoint", () => {
 
   describe("GET", () => {
     // TO TEST
-    //  - should return CORS headers! Dan broke this on auth-admin. Check from a synthetic auth-admin request we get CORS headers back
+    // - should return CORS headers! Dan broke this on auth-admin. Check from a synthetic auth-admin request we get CORS headers back
+    // - pagination! What I've done won't work of course unless we overfetch...
     it("should return an empty list of users for a tenant", async () => {
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
@@ -406,7 +407,7 @@ describe("users management API endpoint", () => {
       expect(body.length).toBe(0);
     });
 
-    it.only("should return linked users as identities in primary user, and not in list of results", async () => {
+    it("should return linked users as identities in primary user, and not in list of results", async () => {
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
 
@@ -484,6 +485,7 @@ describe("users management API endpoint", () => {
           isSocial: false,
           profileData: {
             email: "secondary-user@example.com",
+            email_verified: false,
           },
         },
       ]);

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -490,14 +490,65 @@ describe("users management API endpoint", () => {
         },
       ]);
     });
+  });
 
-    describe("search for user", () => {
-      it("should search for a user with wildcard search on email", async () => {
+  describe("search for user", () => {
+    it("should search for a user with wildcard search on email", async () => {
+      const token = await getAdminToken();
+
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+
+      const createUserResponse = await client.api.v2.users.$post(
+        {
+          json: {
+            email: "test@example.com",
+            connection: "email",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+            "content-type": "application/json",
+          },
+        },
+      );
+
+      expect(createUserResponse.status).toBe(201);
+
+      const usersResponse = await client.api.v2.users.$get(
+        {
+          query: {
+            per_page: 2,
+            q: "test",
+          },
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+          },
+        },
+      );
+
+      expect(usersResponse.status).toBe(200);
+
+      const body = (await usersResponse.json()) as UserResponse[];
+      expect(body.length).toBe(1);
+    });
+    describe("lucene queries", () => {
+      /*
+       
+       we need to be careful that we're not returning all the users here, and because we only have one user, we get false positives...
+       probably worth adding several test users, with similarish emails...
+       and we want to make sure we're seraching for the field we specify...
+
+      */
+      it("should search for a user by email when lucene query uses colon as separator", async () => {
         const token = await getAdminToken();
-
         const env = await getEnv();
         const client = testClient(tsoaApp, env);
-
         const createUserResponse = await client.api.v2.users.$post(
           {
             json: {
@@ -513,14 +564,12 @@ describe("users management API endpoint", () => {
             },
           },
         );
-
         expect(createUserResponse.status).toBe(201);
-
         const usersResponse = await client.api.v2.users.$get(
           {
             query: {
               per_page: 2,
-              q: "test",
+              q: "email:test@example.com",
             },
           },
           {
@@ -530,145 +579,96 @@ describe("users management API endpoint", () => {
             },
           },
         );
-
         expect(usersResponse.status).toBe(200);
-
         const body = (await usersResponse.json()) as UserResponse[];
         expect(body.length).toBe(1);
+        expect(body[0].email).toBe("test@example.com");
       });
-      describe("lucene queries", () => {
-        /*
-       
-       we need to be careful that we're not returning all the users here, and because we only have one user, we get false positives...
-       probably worth adding several test users, with similarish emails...
-       and we want to make sure we're seraching for the field we specify...
-
-      */
-        it("should search for a user by email when lucene query uses colon as separator", async () => {
-          const token = await getAdminToken();
-          const env = await getEnv();
-          const client = testClient(tsoaApp, env);
-          const createUserResponse = await client.api.v2.users.$post(
-            {
-              json: {
-                email: "test@example.com",
-                connection: "email",
-              },
+      it("should search for a user by email when lucene query uses equal char as separator", async () => {
+        const token = await getAdminToken();
+        const env = await getEnv();
+        const client = testClient(tsoaApp, env);
+        const createUserResponse = await client.api.v2.users.$post(
+          {
+            json: {
+              email: "test@example.com",
+              connection: "email",
             },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-                "content-type": "application/json",
-              },
+          },
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              "tenant-id": "tenantId",
+              "content-type": "application/json",
             },
-          );
-          expect(createUserResponse.status).toBe(201);
-          const usersResponse = await client.api.v2.users.$get(
-            {
-              query: {
-                per_page: 2,
-                q: "email:test@example.com",
-              },
+          },
+        );
+        expect(createUserResponse.status).toBe(201);
+        const usersResponse = await client.api.v2.users.$get(
+          {
+            query: {
+              per_page: 2,
+              q: "email=test@example.com",
             },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-              },
+          },
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              "tenant-id": "tenantId",
             },
-          );
-          expect(usersResponse.status).toBe(200);
-          const body = (await usersResponse.json()) as UserResponse[];
-          expect(body.length).toBe(1);
-          expect(body[0].email).toBe("test@example.com");
-        });
-        it("should search for a user by email when lucene query uses equal char as separator", async () => {
-          const token = await getAdminToken();
-          const env = await getEnv();
-          const client = testClient(tsoaApp, env);
-          const createUserResponse = await client.api.v2.users.$post(
-            {
-              json: {
-                email: "test@example.com",
-                connection: "email",
-              },
-            },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-                "content-type": "application/json",
-              },
-            },
-          );
-          expect(createUserResponse.status).toBe(201);
-          const usersResponse = await client.api.v2.users.$get(
-            {
-              query: {
-                per_page: 2,
-                q: "email=test@example.com",
-              },
-            },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-              },
-            },
-          );
-          expect(usersResponse.status).toBe(200);
-          const body = (await usersResponse.json()) as UserResponse[];
-          expect(body.length).toBe(1);
-          expect(body[0].email).toBe("test@example.com");
-        });
-        it("should search for a user by email and provider when lucene query uses equal char as separator", async () => {
-          const token = await getAdminToken();
-          const env = await getEnv();
-          const client = testClient(tsoaApp, env);
-          const createUserResponse = await client.api.v2.users.$post(
-            {
-              json: {
-                // we already have a username-password user in our fixtures
-                email: "foo@example.com",
-                connection: "email",
-              },
-            },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-                "content-type": "application/json",
-              },
-            },
-          );
-          expect(createUserResponse.status).toBe(201);
-
-          const usersResponse = await client.api.v2.users.$get(
-            {
-              query: {
-                per_page: 2,
-                q: "provider=email",
-              },
-            },
-            {
-              headers: {
-                authorization: `Bearer ${token}`,
-                "tenant-id": "tenantId",
-              },
-            },
-          );
-          expect(usersResponse.status).toBe(200);
-          const body = (await usersResponse.json()) as UserResponse[];
-          expect(body.length).toBe(1);
-          expect(body[0].email).toBe("foo@example.com");
-          expect(body[0].provider).toBe("email");
-        });
+          },
+        );
+        expect(usersResponse.status).toBe(200);
+        const body = (await usersResponse.json()) as UserResponse[];
+        expect(body.length).toBe(1);
+        expect(body[0].email).toBe("test@example.com");
       });
-      // TO TEST - linked accounts!
-      // especially when the primary and secondary accounts have different email addresses!
-      // we need to check what auth0 does
+      it("should search for a user by email and provider when lucene query uses equal char as separator", async () => {
+        const token = await getAdminToken();
+        const env = await getEnv();
+        const client = testClient(tsoaApp, env);
+        const createUserResponse = await client.api.v2.users.$post(
+          {
+            json: {
+              // we already have a username-password user in our fixtures
+              email: "foo@example.com",
+              connection: "email",
+            },
+          },
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              "tenant-id": "tenantId",
+              "content-type": "application/json",
+            },
+          },
+        );
+        expect(createUserResponse.status).toBe(201);
+
+        const usersResponse = await client.api.v2.users.$get(
+          {
+            query: {
+              per_page: 2,
+              q: "provider=email",
+            },
+          },
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              "tenant-id": "tenantId",
+            },
+          },
+        );
+        expect(usersResponse.status).toBe(200);
+        const body = (await usersResponse.json()) as UserResponse[];
+        expect(body.length).toBe(1);
+        expect(body[0].email).toBe("foo@example.com");
+        expect(body[0].provider).toBe("email");
+      });
     });
+    // TO TEST - linked accounts!
+    // especially when the primary and secondary accounts have different email addresses!
+    // we need to check what auth0 does
   });
 
   describe("link user", () => {


### PR DESCRIPTION
I wonder how much slower this will make the endpoint... As discussed, we want to do this in SQL to not have so many fetches _BUT_ the public won't be using this endpoint