### PR TITLE
fix: should not be able to patch a linked user

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -250,15 +250,28 @@ export class UsersMgmtController extends Controller {
       }
     }
 
+    // new code to not run this if a linked user - TODO - test this more
+    const userToPatch = await env.data.users.get(tenant_id, user_id);
+
+    // this seems wrong! check auth0!
+    if (userToPatch && !!userToPatch.linked_to) {
+      throw new HTTPException(404, {
+        // not the auth0 error message but I'd rather deviate here
+        message: "User is linked to another user",
+      });
+    }
+
     const result = await env.data.users.update(tenant_id, user_id, userFields);
 
     if (!result) {
+      // is this the mysterious 500? TODO - see what this is doing
       throw new HTTPException(500);
     }
 
     const patchedUser = await env.data.users.get(tenant_id, user_id);
 
     if (!patchedUser) {
+      // how could this be true? the update call is a patch not an update... hmmmmm
       throw new HTTPException(404);
     }
 

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -254,7 +254,7 @@ export class UsersMgmtController extends Controller {
     const userToPatch = await env.data.users.get(tenant_id, user_id);
 
     // this seems wrong! check auth0!
-    if (userToPatch && !!userToPatch.linked_to) {
+    if (userToPatch && userToPatch.linked_to) {
       throw new HTTPException(404, {
         // not the auth0 error message but I'd rather deviate here
         message: "User is linked to another user",

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -362,13 +362,19 @@ describe("users management API endpoint", () => {
 
       expect(linkUserResponse.status).toBe(201);
 
+      // sanity check that we have linked the correct user!
+      const linkedUser = await env.data.users.get(
+        "tenantId",
+        secondaryUser.user_id,
+      );
+      expect(linkedUser!.linked_to).toBe("userId");
+
       // ----------------------
       // now try and patch the linked user
       // ----------------------
-
       const params2 = {
         param: {
-          user_id: "userId",
+          user_id: secondaryUser.user_id,
         },
         json: {
           name: "new name",


### PR DESCRIPTION
Confirmed with auth0 management API

![image](https://github.com/sesamyab/auth/assets/8496063/1cb7eb3d-158b-4ef2-a5b3-3cd7ac7372e3)


#### NEXT STEPS FOR ME AFTER THIS PR!
* see all comments on diff! More work to do on patching endpoint
* I'll reverse engineer a bit more and see how it handles the `PATCH` endpoint - if our implementation is correctly, I'll write tests. If not, I'll change it _and_ write tests


