### PR TITLE
test: assert patching non-existent users returns a 404

### DIFF
--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -253,8 +253,11 @@ export class UsersMgmtController extends Controller {
     // we need to check if the user is linked
     const userToPatch = await env.data.users.get(tenant_id, user_id);
 
-    // this seems wrong! check auth0!
-    if (userToPatch && userToPatch.linked_to) {
+    if (!userToPatch) {
+      throw new HTTPException(404);
+    }
+
+    if (userToPatch.linked_to) {
       throw new HTTPException(404, {
         // not the auth0 error message but I'd rather deviate here
         message: "User is linked to another user",

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -250,7 +250,7 @@ export class UsersMgmtController extends Controller {
       }
     }
 
-    // new code to not run this if a linked user - TODO - test this more
+    // we need to check if the user is linked
     const userToPatch = await env.data.users.get(tenant_id, user_id);
 
     // this seems wrong! check auth0!
@@ -264,14 +264,13 @@ export class UsersMgmtController extends Controller {
     const result = await env.data.users.update(tenant_id, user_id, userFields);
 
     if (!result) {
-      // is this the mysterious 500? TODO - see what this is doing
+      // is this the mysterious 500? TODO - why would this fail?
       throw new HTTPException(500);
     }
 
     const patchedUser = await env.data.users.get(tenant_id, user_id);
 
     if (!patchedUser) {
-      // how could this be true? the update call is a patch not an update... hmmmmm
       throw new HTTPException(404);
     }
 

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -250,7 +250,6 @@ export class UsersMgmtController extends Controller {
       }
     }
 
-    // we need to check if the user is linked
     const userToPatch = await env.data.users.get(tenant_id, user_id);
 
     if (!userToPatch) {
@@ -267,7 +266,7 @@ export class UsersMgmtController extends Controller {
     const result = await env.data.users.update(tenant_id, user_id, userFields);
 
     if (!result) {
-      // is this the mysterious 500? TODO - why would this fail?
+      // TODO - why would this fail?
       throw new HTTPException(500);
     }
 

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -274,7 +274,8 @@ export class UsersMgmtController extends Controller {
     const patchedUser = await env.data.users.get(tenant_id, user_id);
 
     if (!patchedUser) {
-      throw new HTTPException(404);
+      // we should never reach here UNLESS there's some race condition where another service deletes the users after the update...
+      throw new HTTPException(500);
     }
 
     const userResponse: UserResponse = await enrichUser(

--- a/test/integration/management-api/users.spec.ts
+++ b/test/integration/management-api/users.spec.ts
@@ -394,6 +394,35 @@ describe("users management API endpoint", () => {
 
       expect(updateUserResponse.status).toBe(404);
     });
+
+    it("should return a 404 when trying to patch a non existent user", async () => {
+      const token = await getAdminToken();
+
+      const env = await getEnv();
+      const client = testClient(tsoaApp, env);
+
+      const params2 = {
+        param: {
+          user_id: "email|i-do-not-exist",
+        },
+        json: {
+          name: "new name",
+        },
+      };
+
+      const updateUserResponse = await client.api.v2.users[":user_id"].$patch(
+        params2,
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            "tenant-id": "tenantId",
+            "content-type": "application/json",
+          },
+        },
+      );
+
+      expect(updateUserResponse.status).toBe(404);
+    });
   });
 
   describe("DELETE", () => {


### PR DESCRIPTION
Confirmed behaviour on auth0. We already had this working so there's only a test here


![image](https://github.com/authhero/auth/assets/8496063/f4217417-b8fd-4f48-ab7c-e123ae8cb3fc)
