### PR TITLE
fix: increase max length of otps state column

### DIFF
--- a/migrate/migrations/2024-03-11T12:45:00_increase-otp-state-length.ts
+++ b/migrate/migrations/2024-03-11T12:45:00_increase-otp-state-length.ts
@@ -1,0 +1,27 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // Uncomment this for planetscale migration
+  //   await db.schema
+  //     .alterTable("otps")
+  //     // column this long working on planetscale on logs column
+  //     .modifyColumn("state", "varchar(8192)")
+  //     .execute();
+
+  // In SQLite we have to drop and recreate the column
+  await db.schema.alterTable("otps").dropColumn("state").execute();
+  await db.schema
+    .alterTable("otps")
+    .addColumn("state", "varchar(8192)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("otps").dropColumn("state").execute();
+
+  await db.schema
+    .alterTable("otps")
+    .addColumn("state", "varchar(2048)")
+    .execute();
+}

--- a/migrate/migrations/2024-03-11T12:45:00_increase-otp-state-length.ts
+++ b/migrate/migrations/2024-03-11T12:45:00_increase-otp-state-length.ts
@@ -22,6 +22,6 @@ export async function down(db: Kysely<Database>): Promise<void> {
 
   await db.schema
     .alterTable("otps")
-    .addColumn("state", "varchar(2048)")
+    .addColumn("state", "varchar(1024)")
     .execute();
 }

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -26,6 +26,7 @@ import * as n25_logDescMaxLength from "./2024-02-05T18:35:00_log-desc-max-length
 import * as n26_logsTableExtraFields from "./2024-02-08T12:45:00_logs-table-extra-fields";
 import * as n27_usersTableNameIndex from "./2024-02-13T11:25:00_users-table-name-index";
 import * as n28_usersEmailConstrain from "./2024-02-19T20:14:00_users-email-constrain";
+import * as n29_increaseOtpStateLength from "./2024-03-11T12:45:00_increase-otp-state-length";
 
 // These need to be in alphabetic order
 export default {
@@ -57,4 +58,5 @@ export default {
   n26_logsTableExtraFields,
   n27_usersTableNameIndex,
   n28_usersEmailConstrain,
+  n29_increaseOtpStateLength,
 };

--- a/migrate/planetscale.ts
+++ b/migrate/planetscale.ts
@@ -9,8 +9,8 @@ const dialect = new PlanetScaleDialect({
     fetch(new Request(opts, { ...init, cache: undefined })),
 });
 
-migrateToLatest(dialect)
-  // migrateDown(dialect)
+// migrateToLatest(dialect)
+migrateDown(dialect)
   .then(() => {
     console.log("migrated");
   })


### PR DESCRIPTION
:exclamation: uncomment out the planetscale bit when running the production migration :exclamation: 

Else all the users midflow will lose their codes... which could cause problems for the next 30 mins :see_no_evil: 