### PR TITLE
fix: ticket step - use primary user helpers in ticket flow

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -56,8 +56,6 @@ export async function ticketAuth(
   // Maybe this is where we should set email_verified to true!
   // we could do this check in a few places...
   if (realm === "Username-Password-Authentication" && !user?.email_verified) {
-    console.log("OK WE SHOULD BE HERE!");
-
     // TBD - should this page be on login2 like the expired code one? we're already adding a few universal auth pages...
     // BUT this route will be more frequently used so we probably want the styling totally matching
     return "Email address not verified. We have sent a validation email to your address. Please click the link in the email to continue.";

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -43,8 +43,6 @@ export async function ticketAuth(
     throw new HTTPException(403, { message: "Ticket not found" });
   }
 
-  console.log("TICKET", ticket);
-
   const provider = getProviderFromRealm(realm);
 
   let user = await getPrimaryUserByEmailAndProvider({
@@ -53,8 +51,6 @@ export async function ticketAuth(
     email: ticket.email,
     provider,
   });
-
-  console.log("USER", user);
 
   // this will trigger on the code and password flows BUT shouldn't the code accounts be validated as they've signed in?
   // Maybe this is where we should set email_verified to true!


### PR DESCRIPTION
I'm realising while fixing the tests on the password flow that it will be easier to use the primary user helpers everywhere first