### PR TITLE
chore: tell renovate bot to never upgrade node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,6 @@
     "before 5am every weekday",
     "every weekend"
   ],
-  "branchConcurrentLimit": 2
+  "branchConcurrentLimit": 2,
+  "ignoreDeps": ["node"]
 }


### PR DESCRIPTION
Renovate bot can never do this because it will never run on cloudflare :smile: 

Where are we actually using node if we're running on bun? We're using Node 18.13 as a way to enforce a JavaScript that will run on cloudflare right?