### PR TITLE
test: show that unverified password accounts are being linked to on social and code signups!

### DIFF
--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -54,12 +54,21 @@ export async function getPrimaryUserByEmail({
   tenant_id,
   email,
 }: GetPrimaryUserByEmailParams): Promise<User | undefined> {
-  const { users } = await userAdapter.list(tenant_id, {
-    page: 0,
-    per_page: 10,
-    include_totals: false,
-    q: `email:${email}`,
-  });
+  const { users: usersWithUnverifiedPasswordAccounts } = await userAdapter.list(
+    tenant_id,
+    {
+      page: 0,
+      per_page: 10,
+      include_totals: false,
+      q: `email:${email}`,
+    },
+  );
+
+  // filter out unverified accounts
+  const users = usersWithUnverifiedPasswordAccounts.filter(
+    // maybe we should do this for all providers
+    (user) => !(user.provider === "auth2" && !user.email_verified),
+  );
 
   if (users.length === 0) {
     return;

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -1548,12 +1548,10 @@ describe("code-flow", () => {
       const accessToken = searchParams.get("access_token");
 
       const accessTokenPayload = parseJwt(accessToken!);
-      // this shows that we are linking to an unverified password account
       expect(accessTokenPayload.sub).not.toBe(unverifiedPasswordUser._id);
 
       const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
-      // these shows that we are linking to an unverified password account
       expect(idTokenPayload.sub).not.toBe(unverifiedPasswordUser._id);
       expect(idTokenPayload.email_verified).toBe(true);
     });

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -692,12 +692,10 @@ describe("magic link flow", () => {
       const accessToken = searchParams.get("access_token");
 
       const accessTokenPayload = parseJwt(accessToken!);
-      // this shows that we are linking to an unverified password account
       expect(accessTokenPayload.sub).not.toBe(unverifiedPasswordUser._id);
 
       const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
-      // these shows that we are linking to an unverified password account
       expect(idTokenPayload.sub).not.toBe(unverifiedPasswordUser._id);
       expect(idTokenPayload.email_verified).toBe(true);
     });

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -639,7 +639,7 @@ describe("social sign on", () => {
       expect(accessTokenPayload.sub).toBe("email|7575757575757");
     });
 
-    it("should ignore un-verified account when linking to an existing email account", async () => {
+    it("should ignore un-verified password account when signing up with social account", async () => {
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
 

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -687,7 +687,6 @@ describe("social sign on", () => {
       const idToken = socialCallbackQuery2.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.sub).toBe(
-        // this shows no account linking is being done to the unvalidated email account...
         "demo-social-provider|123456789012345678901",
       );
       expect(idTokenPayload.email_verified).toBe(true);


### PR DESCRIPTION
~#### Next~
* ~rebase when https://github.com/sesamyab/auth/pull/547is merged, I think will still fail the same!~  :x:  as expected
 
--------------------------------------------------------------------------------------
#### Simple flow: _doing on this PR_
* do sign up for an email _but not_ email verification
* sign up with social/code account with same email
* assert that not erroneously linked to unverified email account
*I'll do the fix for this here as well* :construction: :construction_worker: :building_construction: 

#### More complex permutations - _doing following on upcoming PR_
* do _another_ sign up with social/code (whichever didn't)
* verify that correctly linked to existing social/code


#### And another one
* then verify the email account and assert that linked to the primary account :upside_down_face: 