### PR TITLE
fix: ignore all unverified accounts

### DIFF
--- a/src/utils/users.ts
+++ b/src/utils/users.ts
@@ -54,21 +54,15 @@ export async function getPrimaryUserByEmail({
   tenant_id,
   email,
 }: GetPrimaryUserByEmailParams): Promise<User | undefined> {
-  const { users: usersWithUnverifiedPasswordAccounts } = await userAdapter.list(
-    tenant_id,
-    {
-      page: 0,
-      per_page: 10,
-      include_totals: false,
-      q: `email:${email}`,
-    },
-  );
+  const { users: usersPossiblyUnverified } = await userAdapter.list(tenant_id, {
+    page: 0,
+    per_page: 10,
+    include_totals: false,
+    q: `email:${email}`,
+  });
 
   // filter out unverified accounts
-  const users = usersWithUnverifiedPasswordAccounts.filter(
-    // maybe we should do this for all providers
-    (user) => !(user.provider === "auth2" && !user.email_verified),
-  );
+  const users = usersPossiblyUnverified.filter((user) => user.email_verified);
 
   if (users.length === 0) {
     return;


### PR DESCRIPTION
### Done
In primary account helpers we are ignoring unverified accounts: _is that actually correct? have only done in one helper..._


### TODO
* what happens if a user tries to login with a social account with an unverified email? :thinking:  we should block them from doing so right?