### PR TITLE
fix: do not allow multiple use of magic links

### DIFF
--- a/src/adapters/interfaces/OTP.ts
+++ b/src/adapters/interfaces/OTP.ts
@@ -3,4 +3,5 @@ import { OTP } from "../../types/OTP";
 export interface OTPAdapter {
   create: (authCode: OTP) => Promise<void>;
   list: (tenant_id: string, email: string) => Promise<OTP[]>;
+  remove: (tenant_id: string, id: string) => Promise<void>;
 }

--- a/src/adapters/kysely/otps/index.ts
+++ b/src/adapters/kysely/otps/index.ts
@@ -2,11 +2,13 @@ import { OTPAdapter } from "../../interfaces/OTP";
 import { Database } from "../../../types";
 import { list } from "./list";
 import { create } from "./create";
+import { remove } from "./remove";
 import { Kysely } from "kysely";
 
 export function createOTPAdapter(db: Kysely<Database>): OTPAdapter {
   return {
     create: create(db),
     list: list(db),
+    remove: remove(db),
   };
 }

--- a/src/adapters/kysely/otps/list.ts
+++ b/src/adapters/kysely/otps/list.ts
@@ -11,6 +11,7 @@ export function list(db: Kysely<Database>) {
       .where("otps.email", "=", email)
       .where("otps.used_at", "is", null)
       .where("otps.expires_at", ">", now)
+      .where("otps.used_at", "is", null)
       .selectAll()
       .execute();
 

--- a/src/adapters/kysely/otps/remove.ts
+++ b/src/adapters/kysely/otps/remove.ts
@@ -1,0 +1,15 @@
+import { Database, OTP } from "../../../types";
+import { Kysely } from "kysely";
+
+export function remove(db: Kysely<Database>) {
+  return async (tenant_id: string, id: string) => {
+    await db
+      .updateTable("otps")
+      .set({
+        used_at: new Date().toISOString(),
+      })
+      .where("otps.tenant_id", "=", tenant_id)
+      .where("otps.id", "=", id)
+      .execute();
+  };
+}

--- a/src/authentication-flows/passwordless.ts
+++ b/src/authentication-flows/passwordless.ts
@@ -30,6 +30,8 @@ export async function validateCode(
     throw new HTTPException(403, { message: "Code not found or expired" });
   }
 
+  await env.data.OTP.remove(client.tenant_id, otp.id);
+
   const emailUser = await getPrimaryUserByEmailAndProvider({
     userAdapter: env.data.users,
     tenant_id: client.tenant_id,

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -542,8 +542,13 @@ describe("magic link flow", () => {
       await client.passwordless.verify_redirect.$get({
         query,
       });
-    // what code should this be?
-    expect(authenticateResponse2.status).toBe(400);
+    expect(authenticateResponse2.status).toBe(302);
+    const redirectUri2 = new URL(
+      authenticateResponse2.headers.get("location")!,
+    );
+    expect(redirectUri2.hostname).toBe("login2.sesamy.dev");
+    // we also show this page if the code is incorrect
+    expect(redirectUri2.pathname).toBe("/expired-code");
   });
 
   it("should not accept any invalid params on the magic link", async () => {

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -489,7 +489,7 @@ describe("magic link flow", () => {
       });
     });
   });
-  it("should log in with the same magic link multiple times", async () => {
+  it("should only allow a magic link to be used once", async () => {
     const env = await getEnv();
     const client = testClient(tsoaApp, env);
 
@@ -527,7 +527,7 @@ describe("magic link flow", () => {
     const query = Object.fromEntries(querySearchParams.entries());
 
     // ------------
-    // Authenticate using the magic link the first time
+    // Use the magic link
     // ----------------
     const authenticateResponse = await client.passwordless.verify_redirect.$get(
       {
@@ -536,13 +536,14 @@ describe("magic link flow", () => {
     );
     expect(authenticateResponse.status).toBe(302);
     // ------------
-    // Authenticate using the magic link the second time
+    // Try using the magic link twice
     // ----------------
     const authenticateResponse2 =
       await client.passwordless.verify_redirect.$get({
         query,
       });
-    expect(authenticateResponse2.status).toBe(302);
+    // what code should this be?
+    expect(authenticateResponse2.status).toBe(400);
   });
 
   it("should not accept any invalid params on the magic link", async () => {


### PR DESCRIPTION
#### Fixed to only allow one usage of:
* magic link: :heavy_check_mark: 

What should we do here? There's a `used_at` field in OTPs so I'll set that to the current date *but*
* then I'll need to modify all the adapters to not select this
* we'll probably have to update the index on this table to include this field!

##### TODO
A. write failing test
B. fix implementation!
C. agree if this is the correct approach

##### Future PRs
* code login, codes as in the database entity..., tickets?... what else?