### PR TITLE
feat: resetting password should be allowed on unverified accounts *AND* should also set the account as verified

### DIFF
--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -606,6 +606,7 @@ export class LoginController extends Controller {
         password: params.password,
       });
 
+      // we could do this on the GET...
       if (!user.email_verified) {
         await env.data.users.update(client.tenant_id, user.id, {
           email_verified: true,

--- a/src/routes/tsoa/login.ts
+++ b/src/routes/tsoa/login.ts
@@ -605,6 +605,12 @@ export class LoginController extends Controller {
         user_id: user.id,
         password: params.password,
       });
+
+      if (!user.email_verified) {
+        await env.data.users.update(client.tenant_id, user.id, {
+          email_verified: true,
+        });
+      }
     } catch (err) {
       return renderMessage(env, this, {
         ...session,

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -863,8 +863,7 @@ describe("password-flow", () => {
 
       expect(resetPassword.status).toBe(400);
     });
-    // This is a flow we want to support as we could lock a user out of their account if they forget their password before using it!
-    it.only("should send password reset email for new unvalidated signup AND set email_verified to true", async () => {
+    it("should send password reset email for new unvalidated signup AND set email_verified to true", async () => {
       const env = await getEnv();
       const client = testClient(tsoaApp, env);
 
@@ -957,24 +956,19 @@ describe("password-flow", () => {
         state: "state",
         realm: "Username-Password-Authentication",
       };
-      // Trade the ticket for token
       const tokenResponse = await client.authorize.$get({ query });
 
-      // THIS IS NOT WORKING! it allowing us to change the password I think
-      // but then we're getting an error message back telling us to verify our email
-      console.log(await tokenResponse.text());
+      // this proves that email_verified is set to true, and the new password has been set
       expect(tokenResponse.status).toBe(302);
-      // const redirectUri = new URL(tokenResponse.headers.get("location")!);
-      // const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
-      // const accessToken = searchParams.get("access_token");
-      // const accessTokenPayload = parseJwt(accessToken!);
-      // const idToken = searchParams.get("id_token");
-      // const idTokenPayload = parseJwt(idToken!);
-      // expect(idTokenPayload.email).toBe("foo@example.com");
-      // expect(idTokenPayload.aud).toBe("clientId");
+      const redirectUri = new URL(tokenResponse.headers.get("location")!);
+      const searchParams = new URLSearchParams(redirectUri.hash.slice(1));
+      const accessToken = searchParams.get("access_token");
+      expect(accessToken).toBeDefined();
 
-      // ------------------
-      // check that email_verified is set to true!
+      const idToken = searchParams.get("id_token");
+      const idTokenPayload = parseJwt(idToken!);
+      expect(idTokenPayload.email).toBe("reset-new-user@example.com");
+      expect(idTokenPayload.email_verified).toBe(true);
     });
   });
 


### PR DESCRIPTION
I might have gone rogue here but we *definitely* don't want to block password resetting before the email is verified (else we will force the user to know their password to then send a new email validation email out!)


_and I'm also thinking_ if the user has clicked the password reset link... well we know they own their email address!