### PR TITLE
fix: rename css to tailwind everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ data/
 .vscode
 db.sqlite
 
-src/styles/output.css
+src/styles/tailwind.css

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "type-check": "tsc",
     "pull-translations": "i18nexus pull -k EWI52U0e8j13AX31kLcS-A --path ./src/locales && prettier --write ./src/locales/**/*.json",
     "knip": "knip",
-    "tailwind": "tailwindcss -i ./src/styles/input.css -o ./src/styles/output.css",
-    "tailwind:watch": "tailwindcss -i ./src/styles/input.css -o ./src/styles/output.css --watch"
+    "tailwind": "tailwindcss -i ./src/styles/input.css -o ./src/styles/tailwind.css",
+    "tailwind:watch": "tailwindcss -i ./src/styles/input.css -o ./src/styles/tailwind.css --watch"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/upload-css.sh
+++ b/scripts/upload-css.sh
@@ -1,5 +1,5 @@
 # ideally we would not do this but for now... let's do this!
 yarn tailwind
-npx wrangler r2 object put auth-templates/templates/static/stylesheets/tailwind.css -f src/styles/output.css
+npx wrangler r2 object put auth-templates/templates/static/stylesheets/tailwind.css -f src/styles/tailwind.css
 # note inconsistent naming! is served from /css/default.css, is uploaded to tailwind.css, is built as output.css
 # Call it one name everywhere!

--- a/src/app.ts
+++ b/src/app.ts
@@ -77,7 +77,7 @@ app.get("/u/reset-password", getResetPassword);
 app.post("/u/reset-password", postResetPassword);
 
 app.get(
-  "/css/default.css",
+  "/css/tailwind.css",
   async (ctx: Context<{ Bindings: Env; Variables: Var }>) => {
     const response = await ctx.env.AUTH_TEMPLATES.get(
       "templates/static/stylesheets/tailwind.css",

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -49,7 +49,7 @@ const Layout: FC<LayoutProps> = ({ title, children, vendorSettings }) => {
           type="font/woff2"
           crossOrigin="anonymous"
         />
-        <link rel="stylesheet" href="/css/default.css" />
+        <link rel="stylesheet" href="/css/tailwind.css" />
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"


### PR DESCRIPTION
### QA  :heavy_check_mark: 
I just made these changes for the previous PR :sunglasses: 

Would be great to have some proper tests for this but we don't actually serve the real CSS file in our tests... so loading this output into playwright to render HTML would not make sense...

Going forward I can test this in the login2 playwright tests and read the *real* emails