### PR TITLE
feat: translation strings in footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "dotenv": "16.4.5",
     "eslint": "8.57.0",
     "husky": "9.0.11",
+    "i18next": "^23.10.1",
     "i18nexus-cli": "3.3.0",
     "isomorphic-fetch": "3.0.0",
     "jest": "29.7.0",

--- a/src/locales/en/default.json
+++ b/src/locales/en/default.json
@@ -1,13 +1,15 @@
 {
+  "codeEmailEnterCode": "Enter the code at {{vendorName}} to complete the login",
+  "codeEmailTitle": "Welcome to {{vendorName}}! {{code}} is the login code",
+  "codeValid30Mins": "The code is valid for 30 minutes",
+  "contact_support": "Need Help?",
   "contactUs": "Contact us",
   "copyright": "Copyright © 2023 SESAMY. All rights reserved.",
-  "supportInfo": "If you have questions or need assistance, you can contact our support team",
-  "codeEmailTitle": "Welcome to {{vendorName}}! {{code}} is the login code",
+  "copyright_sesamy": "©2023 Sesamy",
+  "linkEmailClickToLogin": "Click the button to log in",
   "linkEmailLogin": "Sign in",
-  "codeValid30Mins": "The code is valid for 30 minutes",
-  "codeEmailEnterCode": "Enter the code at {{vendorName}} to complete the login",
-  "passwordResetTitle": "Change password for your {{vendorName}} account",
   "linkEmailOrEnterCode": "Or enter the code at {{vendorName}} to complete the login.",
-  "welcomeToYourAccount": "Welcome to your {{vendorName}} account!",
-  "linkEmailClickToLogin": "Click the button to log in"
+  "passwordResetTitle": "Change password for your {{vendorName}} account",
+  "supportInfo": "If you have questions or need assistance, you can contact our support team",
+  "welcomeToYourAccount": "Welcome to your {{vendorName}} account!"
 }

--- a/src/locales/it/default.json
+++ b/src/locales/it/default.json
@@ -1,13 +1,15 @@
 {
+  "codeEmailEnterCode": "Inserite il codice all'indirizzo {{vendorName}} per completare il login.",
+  "codeEmailTitle": "Benvenuti su {{vendorName}}! {{code}} è il codice di accesso",
+  "codeValid30Mins": "Il codice è valido per 30 minuti",
+  "contact_support": "Avete bisogno di aiuto?",
   "contactUs": "Contattateci",
   "copyright": "Copyright © 2023 SESAMY. Tutti i diritti riservati.",
-  "supportInfo": "Se avete domande o bisogno di assistenza, potete contattare il nostro team di supporto",
-  "codeEmailTitle": "Benvenuti su {{vendorName}}! {{code}} è il codice di accesso",
+  "copyright_sesamy": "©2023 Sesamy",
+  "linkEmailClickToLogin": "Fare clic sul pulsante per accedere",
   "linkEmailLogin": "Accedi",
-  "codeValid30Mins": "Il codice è valido per 30 minuti",
-  "codeEmailEnterCode": "Inserite il codice all'indirizzo {{vendorName}} per completare il login.",
-  "passwordResetTitle": "Modifica della password dell'account {{vendorName}} ",
   "linkEmailOrEnterCode": "Oppure inserire il codice all'indirizzo {{vendorName}} per completare il login.",
-  "welcomeToYourAccount": "Benvenuto nel tuo account {{vendorName}}!",
-  "linkEmailClickToLogin": "Fare clic sul pulsante per accedere"
+  "passwordResetTitle": "Modifica della password dell'account {{vendorName}} ",
+  "supportInfo": "Se avete domande o bisogno di assistenza, potete contattare il nostro team di supporto",
+  "welcomeToYourAccount": "Benvenuto nel tuo account {{vendorName}}!"
 }

--- a/src/locales/nb/default.json
+++ b/src/locales/nb/default.json
@@ -1,13 +1,15 @@
 {
+  "codeEmailEnterCode": "Skriv inn koden på {{vendorName}} for å fullføre påloggingen",
+  "codeEmailTitle": "Velkommen til {{vendorName}} ! {{code}} er påloggingskoden",
+  "codeValid30Mins": "Koden er gyldig i 30 minutter",
+  "contact_support": "Trenger du hjelp?",
   "contactUs": "Kontakt oss",
   "copyright": "Copyright © 2023 SESAMY. Alle rettigheter forbeholdt.",
-  "supportInfo": "Hvis du har spørsmål eller trenger hjelp, kan du kontakte supportteamet vårt",
-  "codeEmailTitle": "Velkommen til {{vendorName}} ! {{code}} er påloggingskoden",
+  "copyright_sesamy": "©2023 Sesamy",
+  "linkEmailClickToLogin": "Klikk på knappen for å logge inn",
   "linkEmailLogin": "Logg inn",
-  "codeValid30Mins": "Koden er gyldig i 30 minutter",
-  "codeEmailEnterCode": "Skriv inn koden på {{vendorName}} for å fullføre påloggingen",
-  "passwordResetTitle": "Endre passord for {{vendorName}} kontoen din",
   "linkEmailOrEnterCode": "Eller skriv inn koden på {{vendorName}} for å fullføre påloggingen.",
-  "welcomeToYourAccount": "Velkommen til din brukerkonto hos {{vendorName}} !",
-  "linkEmailClickToLogin": "Klikk på knappen for å logge inn"
+  "passwordResetTitle": "Endre passord for {{vendorName}} kontoen din",
+  "supportInfo": "Hvis du har spørsmål eller trenger hjelp, kan du kontakte supportteamet vårt",
+  "welcomeToYourAccount": "Velkommen til din brukerkonto hos {{vendorName}} !"
 }

--- a/src/locales/sv/default.json
+++ b/src/locales/sv/default.json
@@ -1,13 +1,15 @@
 {
+  "codeEmailEnterCode": "Skriv in koden på {{vendorName}} för att slutföra inloggningen.",
+  "codeEmailTitle": "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
+  "codeValid30Mins": "Koden är giltig i 30 minuter",
+  "contact_support": "Behöver du hjälp?",
   "contactUs": "Kontakta oss",
   "copyright": "Copyright © 2023 SESAMY. Alla rättigheter förbehållna.",
-  "supportInfo": "Om du har frågor eller behöver assistans kan du kontakta vårt supportteam",
-  "codeEmailTitle": "Välkommen till {{vendorName}}! {{code}} är koden för att logga in",
+  "copyright_sesamy": "©2023 Sesamy",
+  "linkEmailClickToLogin": "Klicka på knappen för att logga in",
   "linkEmailLogin": "Logga in",
-  "codeValid30Mins": "Koden är giltig i 30 minuter",
-  "codeEmailEnterCode": "Skriv in koden på {{vendorName}} för att slutföra inloggningen.",
-  "passwordResetTitle": "Byt lösenord för ditt {{vendorName}} konto",
   "linkEmailOrEnterCode": "Eller skriv in koden på {{vendorName}} för att slutföra inloggningen.",
-  "welcomeToYourAccount": "Välkommen till ditt {{vendorName}}-konto!",
-  "linkEmailClickToLogin": "Klicka på knappen för att logga in"
+  "passwordResetTitle": "Byt lösenord för ditt {{vendorName}} konto",
+  "supportInfo": "Om du har frågor eller behöver assistans kan du kontakta vårt supportteam",
+  "welcomeToYourAccount": "Välkommen till ditt {{vendorName}}-konto!"
 }

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -1,6 +1,9 @@
 import type { FC } from "hono/jsx";
 import { VendorSettings } from "../../types";
 import AppLogo from "./AppLogo";
+import i18next from "i18next";
+// TODO - import others and actually switch language!
+import en from "../../locales/en/default.json";
 
 type LayoutProps = {
   title: string;
@@ -18,6 +21,15 @@ const globalDocStyle = (vendorSettings: VendorSettings) => {
     }
   `;
 };
+
+i18next.init({
+  // TODO - will this come from vendor settings?
+  lng: "en",
+  debug: true,
+  resources: {
+    en,
+  },
+});
 
 const DEFAULT_BG = "https://assets.sesamy.com/images/login-bg.jpg";
 

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -120,9 +120,7 @@ const Layout: FC<LayoutProps> = ({ title, children, vendorSettings }) => {
                 <div class="flex justify-center space-x-2 text-xs text-white sm:justify-normal md:text-xs">
                   <a
                     class="text-xs text-white hover:underline md:text-xs"
-                    // use this now we have vendor settings!
-                    // href={supportUrl}
-                    href="https://sesamy.com"
+                    href={vendorSettings.supportUrl}
                   >
                     {i18next.t("contact_support")}
                   </a>

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -111,6 +111,7 @@ const Layout: FC<LayoutProps> = ({ title, children, vendorSettings }) => {
                 </div>
                 <div class="flex flex-1 flex-col">
                   {children}
+                  {/* // do this on the next PR! */}
                   {/* <Footer vendorSettings={vendorSettings} /> */}
                 </div>
               </div>
@@ -119,13 +120,14 @@ const Layout: FC<LayoutProps> = ({ title, children, vendorSettings }) => {
                 <div class="flex justify-center space-x-2 text-xs text-white sm:justify-normal md:text-xs">
                   <a
                     class="text-xs text-white hover:underline md:text-xs"
+                    // use this now we have vendor settings!
                     // href={supportUrl}
                     href="https://sesamy.com"
                   >
-                    contact_support
+                    {i18next.t("contact_support")}
                   </a>
                   <span class="text-gray-300">|</span>{" "}
-                  <span>copyright_sesamy</span>
+                  <span>{i18next.t("copyright_sesamy")}</span>
                 </div>
               </div>
             </div>

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -27,7 +27,7 @@ i18next.init({
   lng: "en",
   debug: true,
   resources: {
-    en,
+    en: { translation: en },
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,6 +280,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.23.2":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.1.tgz#431f9a794d173b53720e69a6464abc6f0e2a5c57"
+  integrity sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.23.9":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
@@ -4646,6 +4653,13 @@ husky@9.0.11:
   version "9.0.11"
   resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
   integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+
+i18next@^23.10.1:
+  version "23.10.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.10.1.tgz#217ce93b75edbe559ac42be00a20566b53937df6"
+  integrity sha512-NDiIzFbcs3O9PXpfhkjyf7WdqFn5Vq6mhzhtkXzj51aOcNuPNcTwuYNuXCpHsanZGHlHKL35G7huoFeVic1hng==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
 
 i18nexus-cli@3.3.0:
   version "3.3.0"


### PR DESCRIPTION
This is actually a working solution for how to do translations in our React components :sunglasses: 


#### TO NOTE
I've manually copied over these translation strings from `login2`.  We could also pull the login2 translation strings and use them in the React components...
*THOUGHTS?*  

https://github.com/sesamyab/auth/pull/594 I've gone ahead and pulled down the login2 translations on the next PR


