### PR TITLE
feat: switch translation based on tenant language

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -6,7 +6,6 @@ import validatePassword from "../../utils/validatePassword";
 import { getUserByEmailAndProvider } from "../../utils/users";
 import { getClient } from "../../services/clients";
 import { HTTPException } from "hono/http-exception";
-import { VendorSettings } from "../../types";
 import i18next from "i18next";
 import { Tenant } from "../../types";
 import en from "../../localesLogin2/en/default.json";
@@ -16,7 +15,7 @@ import sv from "../../localesLogin2/sv/default.json";
 
 function initI18n(lng: string) {
   i18next.init({
-    lng: "en",
+    lng,
     debug: true,
     resources: {
       en: { translation: en },

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -7,6 +7,25 @@ import { getUserByEmailAndProvider } from "../../utils/users";
 import { getClient } from "../../services/clients";
 import { HTTPException } from "hono/http-exception";
 import { VendorSettings } from "../../types";
+import i18next from "i18next";
+import { Tenant } from "../../types";
+import en from "../../localesLogin2/en/default.json";
+import it from "../../localesLogin2/it/default.json";
+import nb from "../../localesLogin2/nb/default.json";
+import sv from "../../localesLogin2/sv/default.json";
+
+function initI18n(lng: string) {
+  i18next.init({
+    lng: "en",
+    debug: true,
+    resources: {
+      en: { translation: en },
+      it: { translation: it },
+      nb: { translation: nb },
+      sv: { translation: sv },
+    },
+  });
+}
 
 export async function getResetPassword(
   ctx: Context<{ Bindings: Env; Variables: Var }>,
@@ -41,6 +60,7 @@ export async function getResetPassword(
   if (!session.authParams.username) {
     throw new HTTPException(400, { message: "Username required" });
   }
+  initI18n(tenant.language || "sv");
 
   return ctx.html(
     <ResetPasswordPage
@@ -76,6 +96,9 @@ export async function postResetPassword(
   if (!tenant) {
     throw new HTTPException(400, { message: "Tenant not found" });
   }
+
+  initI18n(tenant.language || "sv");
+
   const tenantNameInVendorStyles = tenant.name.toLowerCase();
 
   const vendorSettings = await env.fetchVendorSettings(

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -3,11 +3,6 @@ import { VendorSettings } from "../../types";
 import AppLogo from "./AppLogo";
 import i18next from "i18next";
 import Footer from "./Footer";
-import en from "../../localesLogin2/en/default.json";
-import it from "../../localesLogin2/it/default.json";
-import nb from "../../localesLogin2/nb/default.json";
-import sv from "../../localesLogin2/sv/default.json";
-import { Tenant } from "../../types";
 
 type LayoutProps = {
   title: string;
@@ -25,18 +20,6 @@ const globalDocStyle = (vendorSettings: VendorSettings) => {
     }
   `;
 };
-
-i18next.init({
-  // TODO - will this come from vendor settings?
-  lng: "en",
-  debug: true,
-  resources: {
-    en: { translation: en },
-    it: { translation: it },
-    nb: { translation: nb },
-    sv: { translation: sv },
-  },
-});
 
 const DEFAULT_BG = "https://assets.sesamy.com/images/login-bg.jpg";
 

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -3,8 +3,11 @@ import { VendorSettings } from "../../types";
 import AppLogo from "./AppLogo";
 import i18next from "i18next";
 import Footer from "./Footer";
-// TODO - import others and actually switch language!
 import en from "../../localesLogin2/en/default.json";
+import it from "../../localesLogin2/it/default.json";
+import nb from "../../localesLogin2/nb/default.json";
+import sv from "../../localesLogin2/sv/default.json";
+import { Tenant } from "../../types";
 
 type LayoutProps = {
   title: string;
@@ -29,6 +32,9 @@ i18next.init({
   debug: true,
   resources: {
     en: { translation: en },
+    it: { translation: it },
+    nb: { translation: nb },
+    sv: { translation: sv },
   },
 });
 


### PR DESCRIPTION
Check the footer! We have Swedish :smile: 


![image](https://github.com/sesamyab/auth/assets/8496063/eea90825-aefd-4625-9f2d-e313a143d770)


I'm pretty confident this solution is the way so I can do this for the rest of the text *I'll do this next*

