### PR TITLE
fix: add separate api docs page for openapi

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { Var } from "./types/Var";
 import { login } from "./routes/tsx/routes";
 import { wellKnown } from "./routes/oauth2/well-known";
 import { users } from "./routes/management-api/users";
+import { registerComponent } from "./middlewares/register-component";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -28,6 +29,8 @@ const ALLOWED_ORIGINS = [
 ];
 
 const rootApp = new OpenAPIHono<{ Bindings: Env }>();
+
+registerComponent(rootApp);
 
 export const app = rootApp
   .onError((err, ctx) => {

--- a/src/middlewares/register-component.ts
+++ b/src/middlewares/register-component.ts
@@ -5,7 +5,7 @@ import { Env } from "../types/Env";
 let inititated = false;
 
 /**
- * This registers the security scheme for the application. As it uses an environment variable, it can only be registerd once the first request arrives.
+ * This registers the security scheme for the application. As it uses an environment variable, it can only be registered once the first request arrives.
  * @param app
  */
 export function registerComponent(app: OpenAPIHono<{ Bindings: Env }>) {

--- a/src/middlewares/register-component.ts
+++ b/src/middlewares/register-component.ts
@@ -1,0 +1,39 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { Context, Next } from "hono";
+import { Env } from "../types/Env";
+
+let inititated = false;
+
+/**
+ * This registers the security scheme for the application. As it uses an environment variable, it can only be registerd once the first request arrives.
+ * @param app
+ */
+export function registerComponent(app: OpenAPIHono<{ Bindings: Env }>) {
+  app.use(async (ctx: Context<{ Bindings: Env }>, next: Next) => {
+    if (!inititated) {
+      app.openAPIRegistry.registerComponent("securitySchemes", "Bearer", {
+        type: "oauth2",
+        scheme: "bearer",
+        flows: {
+          implicit: {
+            authorizationUrl: `${ctx.env.AUTH_URL}/authorize`,
+            scopes: {
+              openid: "Basic user information",
+              email: "User email",
+              profile: "User profile information",
+            },
+          },
+        },
+      });
+
+      app.openAPIRegistry.registerComponent("securitySchemes", "Basic", {
+        type: "http",
+        scheme: "basic",
+      });
+
+      inititated = true;
+    }
+
+    return await next();
+  });
+}

--- a/src/routes/swagger-ui.ts
+++ b/src/routes/swagger-ui.ts
@@ -49,7 +49,16 @@ function getSwaggerHtml() {
       window.onload = function () {
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({
-          url: "/spec",
+          urls: [
+            {
+              url: "/spec",
+              name: "TSOA Spec"
+            },
+            {
+              url: "/u/doc",
+              name: "OpenAPI Spec"
+            }
+          ],
           dom_id: "#swagger-ui",
           deepLinking: true,
           presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],

--- a/src/types/Env.ts
+++ b/src/types/Env.ts
@@ -12,6 +12,7 @@ export type Env = {
   DATABASE_PASSWORD: string;
   DATABASE_USERNAME: string;
   TOKEN_SERVICE: Fetcher;
+  AUTH_URL: string;
   AUTH_TEMPLATES: R2Bucket;
   EMAIL_TEMPLATES: R2Bucket;
   READ_PERMISSION?: string;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,7 @@ route = { pattern = "auth2.sesamy.dev/*", zone_id = "b56a76d859fe2ed6a8d77270cd2
 IMAGE_PROXY_URL = "https://imgproxy.prod.sesamy.cloud"
 ISSUER = "https://auth2.sesamy.dev/"
 LOGIN2_URL = 'https://login2.sesamy.dev'
+AUTH_URL = 'https://token.sesamy.dev'
 JWKS_URL = "https://token.sesamy.dev/.well-known/jwks.json"
 READ_PERMISSION = "auth:read"
 WRITE_PERMISSION = "auth:write"
@@ -53,6 +54,7 @@ route = { pattern = "auth2.sesamy.com/*", zone_id = "b944b5871689ada6ce48e380968
 [env.production.vars]
 ISSUER = "https://auth2.sesamy.com/"
 LOGIN2_URL = 'https://login2.sesamy.com'
+AUTH_URL = 'https://token.sesamy.com'
 JWKS_URL = "https://token.sesamy.com/.well-known/jwks.json"
 READ_PERMISSION = 'auth:read'
 WRITE_PERMISSION = 'auth:write'
@@ -71,11 +73,3 @@ bucket_name = 'auth-templates'
 
 [env.production.triggers]
 crons = ["0 3 * * *"]
-
-[env.test.vars]
-ISSUER = "https://example.com/"
-LOGIN2_URL = 'https://login2.sesamy.com'
-JWKS_URL = "https://example.com/.well-known/jwks.json"
-READ_PERMISSION = 'auth:read'
-WRITE_PERMISSION = 'auth:write'
-IMAGE_PROXY_URL = "https://imgproxy.prod.sesamy.cloud"


### PR DESCRIPTION
Added a drop down to the docs page for the tsoa vs openapi spec pages. At some point we should separate the management api page and the oauth2 endpoints instead.

Added a kind of hacky middleware to get the authentication in. Haven't found a better way of doing it.