### PR TITLE
fix: create user with apple

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,8 @@ registerComponent(rootApp);
 
 export const app = rootApp
   .onError((err, ctx) => {
+    console.error(err);
+
     if (err instanceof HTTPException) {
       // Get the custom response
       return err.getResponse();

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -264,20 +264,14 @@ export const users = new OpenAPIHono<{ Bindings: Env }>()
         throw new HTTPException(400, { message: "Email is required" });
       }
 
-      if (body?.connection !== "email") {
-        throw new HTTPException(400, {
-          message: "Only email connections are supported",
-        });
-      }
-
       const email = emailRaw.toLowerCase();
 
       const data = await ctx.env.data.users.create(tenant_id, {
         email,
-        id: `email|${userIdGenerate()}`,
+        id: `${body.provider}|${userIdGenerate()}`,
         name: body.name || email,
-        provider: "email",
-        connection: body.connection || "email",
+        provider: body.provider,
+        connection: body.connection,
         // we need to be careful with this as the profile service was setting this true in places where I don't think it's correct
         // AND when does the account linking happen then? here? first login?
         email_verified: body.email_verified || false,

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -19,8 +19,8 @@ export const userInsertSchema = baseUserSchema.extend({
   email_verified: z.boolean().default(false),
   last_ip: z.string().optional(),
   last_login: z.string().optional(),
-  provider: z.string().optional(),
-  connection: z.string(),
+  provider: z.string().default("email"),
+  connection: z.string().default("email"),
 });
 
 export const userSchema = userInsertSchema


### PR DESCRIPTION
I had to create an apple user and it was a bit of a pain since we only accepted email users. Was there a reason for this?