### PR TITLE
fix: application path

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -81,7 +81,7 @@ export const app = rootApp
 export const loginApp = rootApp
   .route("/u", login)
   .route("/.well-known", wellKnown)
-  .route("/api/v2/applications", applications)
+  .route("/tenants", applications)
   .route("/api/v2/users", users)
   .route("/api/v2/tenants", tenants);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,10 @@ import { wellKnown } from "./routes/oauth2/well-known";
 import { users } from "./routes/management-api/users";
 import { registerComponent } from "./middlewares/register-component";
 import { tenants } from "./routes/management-api/tenants";
-import { applications } from "./routes/management-api/applications";
+import {
+  applications,
+  applicationsFallback,
+} from "./routes/management-api/applications";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",
@@ -81,7 +84,8 @@ export const app = rootApp
 export const loginApp = rootApp
   .route("/u", login)
   .route("/.well-known", wellKnown)
-  .route("/tenants", applications)
+  .route("/tenants", applicationsFallback)
+  .route("/applications", applications)
   .route("/api/v2/users", users)
   .route("/api/v2/tenants", tenants);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,10 +16,8 @@ import { wellKnown } from "./routes/oauth2/well-known";
 import { users } from "./routes/management-api/users";
 import { registerComponent } from "./middlewares/register-component";
 import { tenants } from "./routes/management-api/tenants";
-import {
-  applications,
-  applicationsFallback,
-} from "./routes/management-api/applications";
+import { applications } from "./routes/management-api/applications";
+import { applicationsFallback } from "./routes/management-api/applications-fallback";
 
 const ALLOWED_ORIGINS = [
   "http://localhost:3000",

--- a/src/routes/management-api/applications-fallback.ts
+++ b/src/routes/management-api/applications-fallback.ts
@@ -7,7 +7,7 @@ import { Env } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
 
-export const applications = new OpenAPIHono<{ Bindings: Env }>()
+export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /tenants/{tenant_id}/applications
   // --------------------------------

--- a/src/routes/management-api/applications-fallback.ts
+++ b/src/routes/management-api/applications-fallback.ts
@@ -7,19 +7,21 @@ import { Env } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
 
-export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
+export const applications = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
-  // GET /applications
+  // GET /tenants/{tenant_id}/applications
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "get",
-      path: "/",
+      path: "/{tenant_id}/applications",
       request: {
+        params: z.object({
+          tenant_id: z.string(),
+        }),
         headers: z.object({
           range: z.string().optional(),
-          tenant_id: z.string(),
         }),
       },
       security: [
@@ -39,7 +41,8 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id, range: rangeRequest } = ctx.req.valid("header");
+      const { range: rangeRequest } = ctx.req.valid("header");
+      const { tenant_id } = ctx.req.valid("param");
 
       const db = getDbFromEnv(ctx.env);
       const query = db
@@ -59,18 +62,16 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
     },
   )
   // --------------------------------
-  // GET /applications/:id
+  // GET /tenants/{tenant_id}/applications/:id
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "get",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         params: z.object({
           id: z.string(),
-        }),
-        headers: z.object({
           tenant_id: z.string(),
         }),
       },
@@ -91,8 +92,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id } = ctx.req.valid("header");
-      const { id } = ctx.req.valid("param");
+      const { tenant_id, id } = ctx.req.valid("param");
 
       const db = getDbFromEnv(ctx.env);
       const application = await db
@@ -112,18 +112,16 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
     },
   )
   // --------------------------------
-  // DELETE /applications/:id
+  // DELETE /tenants/{tenant_id}/applications/:id
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "delete",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         params: z.object({
           id: z.string(),
-        }),
-        headers: z.object({
           tenant_id: z.string(),
         }),
       },
@@ -139,8 +137,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id } = ctx.req.valid("header");
-      const { id } = ctx.req.valid("param");
+      const { tenant_id, id } = ctx.req.valid("param");
 
       const db = getDbFromEnv(ctx.env);
       await db
@@ -153,13 +150,13 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
     },
   )
   // --------------------------------
-  // PATCH /applications/:id
+  // PATCH /tenants/{tenant_id}/applications/:id
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "patch",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         body: {
           content: {
@@ -170,8 +167,6 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
         },
         params: z.object({
           id: z.string(),
-        }),
-        headers: z.object({
           tenant_id: z.string(),
         }),
       },
@@ -187,8 +182,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id } = ctx.req.valid("header");
-      const { id } = ctx.req.valid("param");
+      const { tenant_id, id } = ctx.req.valid("param");
       const body = ctx.req.valid("json");
 
       const db = getDbFromEnv(ctx.env);
@@ -208,13 +202,13 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
     },
   )
   // --------------------------------
-  // POST /applications
+  // POST /tenants/{tenant_id}/applications
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "post",
-      path: "/",
+      path: "/{tenant_id}/applications/",
       request: {
         body: {
           content: {
@@ -223,7 +217,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
             },
           },
         },
-        headers: z.object({
+        params: z.object({
           tenant_id: z.string(),
         }),
       },
@@ -244,7 +238,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id } = ctx.req.valid("header");
+      const { tenant_id } = ctx.req.valid("param");
       const body = ctx.req.valid("json");
 
       const application = await ctx.env.data.applications.create(tenant_id, {
@@ -257,13 +251,13 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
     },
   )
   // --------------------------------
-  // PUT /applications/:id
+  // PUT /tenants/{tenant_id}/applications/:id
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "put",
-      path: "/{:id}",
+      path: "/{tenant_id}/applications/{:id}",
       request: {
         body: {
           content: {
@@ -274,8 +268,6 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
         },
         params: z.object({
           id: z.string(),
-        }),
-        headers: z.object({
           tenant_id: z.string(),
         }),
       },
@@ -296,8 +288,7 @@ export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id } = ctx.req.valid("header");
-      const { id } = ctx.req.valid("param");
+      const { tenant_id, id } = ctx.req.valid("param");
       const body = ctx.req.valid("json");
 
       const application = {

--- a/src/routes/management-api/applications.ts
+++ b/src/routes/management-api/applications.ts
@@ -9,16 +9,18 @@ import { nanoid } from "nanoid";
 
 export const applications = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
-  // GET /applications
+  // GET /vendors/{vendor_id}/applications
   // --------------------------------
   .openapi(
     createRoute({
       tags: ["applications"],
       method: "get",
-      path: "/",
+      path: "/{tenant_id}/applications",
       request: {
-        headers: z.object({
+        params: z.object({
           tenant_id: z.string(),
+        }),
+        headers: z.object({
           range: z.string().optional(),
         }),
       },
@@ -39,7 +41,9 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
       },
     }),
     async (ctx) => {
-      const { tenant_id, range: rangeRequest } = ctx.req.valid("header");
+      console.log("got here");
+      const { range: rangeRequest } = ctx.req.valid("header");
+      const { tenant_id } = ctx.req.valid("param");
 
       const db = getDbFromEnv(ctx.env);
       const query = db
@@ -65,7 +69,7 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
     createRoute({
       tags: ["applications"],
       method: "get",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         params: z.object({
           id: z.string(),
@@ -118,7 +122,7 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
     createRoute({
       tags: ["applications"],
       method: "delete",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         params: z.object({
           id: z.string(),
@@ -159,7 +163,7 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
     createRoute({
       tags: ["applications"],
       method: "patch",
-      path: "/{id}",
+      path: "/{tenant_id}/applications/{id}",
       request: {
         body: {
           content: {
@@ -214,7 +218,7 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
     createRoute({
       tags: ["applications"],
       method: "post",
-      path: "/",
+      path: "/{tenant_id}/applications/",
       request: {
         body: {
           content: {
@@ -263,7 +267,7 @@ export const applications = new OpenAPIHono<{ Bindings: Env }>()
     createRoute({
       tags: ["applications"],
       method: "put",
-      path: "/{:id}",
+      path: "/{tenant_id}/applications/{:id}",
       request: {
         body: {
           content: {

--- a/src/routes/management-api/applications.ts
+++ b/src/routes/management-api/applications.ts
@@ -7,7 +7,7 @@ import { Env } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { nanoid } from "nanoid";
 
-export const applicationsFallback = new OpenAPIHono<{ Bindings: Env }>()
+export const applications = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /applications
   // --------------------------------


### PR DESCRIPTION
The old url structure doesn't really work with openapi. We need to pass the tenant-id in the header instead just like for auth0.
This PR adds a fallback route so we can move auth-admin of to the new paths. I don't map these to /api/v2 as they don't work like the auth0 routes.