### PR TITLE
test: use correct id format in tests

### DIFF
--- a/src/utils/userIdParse.ts
+++ b/src/utils/userIdParse.ts
@@ -1,7 +1,5 @@
 export default function userIdParse(userId: string) {
   if (!userId.includes("|")) {
-    // uncomment this to really fail tests
-    // throw new Error("Invalid user_id format");
     console.error("Invalid user_id format");
     return userId;
   }

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -163,7 +163,7 @@ describe("magic link flow", () => {
       // Create the user to log in with the magic link
       // -----------------
       env.data.users.create("tenantId", {
-        id: "userId2",
+        id: "email|userId2",
         email: "bar@example.com",
         email_verified: true,
         name: "",
@@ -252,13 +252,13 @@ describe("magic link flow", () => {
       expect(accessTokenPayload.aud).toBe("default");
       expect(accessTokenPayload.iss).toBe("https://example.com/");
       expect(accessTokenPayload.scope).toBe("openid profile email");
-      expect(accessTokenPayload.sub).toBe("userId2");
+      expect(accessTokenPayload.sub).toBe("email|userId2");
 
       const idToken = searchParams.get("id_token");
       const idTokenPayload = parseJwt(idToken!);
       expect(idTokenPayload.email).toBe("bar@example.com");
       expect(idTokenPayload.aud).toBe("clientId");
-      expect(idTokenPayload.sub).toBe("userId2");
+      expect(idTokenPayload.sub).toBe("email|userId2");
 
       const authCookieHeader = authenticateResponse.headers.get("set-cookie")!;
 
@@ -277,7 +277,7 @@ describe("magic link flow", () => {
         silentAuthIdTokenPayload;
 
       expect(restOfIdTokenPayload).toEqual({
-        sub: "userId2",
+        sub: "email|userId2",
         aud: "clientId",
         name: "",
         nickname: "",

--- a/test/utils/userIdParse.spec.ts
+++ b/test/utils/userIdParse.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vitest } from "vitest";
 import userIdParse from "../../src/utils/userIdParse";
 
 describe("userIdParse", () => {
@@ -8,8 +8,15 @@ describe("userIdParse", () => {
   });
 
   it("should return the id if user_id only only contains the id", () => {
+    // mock console.error
+    const error = console.error;
+    console.error = vitest.fn();
+
     // this is the defensive programming
     const result = userIdParse("1234567890");
     expect(result).toEqual("1234567890");
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith("Invalid user_id format");
   });
 });


### PR DESCRIPTION
Some final console warnings from the user id parser