### PR TITLE
test: do not need node setup

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,11 +11,6 @@ jobs:
     container: mcr.microsoft.com/playwright:v1.43.1-focal
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Setup Node.js
-        uses: buildjet/setup-node@v4
-        with:
-          cache: "yarn"
-          node-version: "20.x"
       - uses: buildjet/cache@v3
         with:
           path: "**/node_modules"


### PR DESCRIPTION
This step can actually take a lot of time, especially the post-setupnode step

see this one. >50% of the test run is that

![image](https://github.com/sesamyab/auth/assets/8496063/3c3ed861-f0c1-43c8-8a24-2b44dd73b8f9)



We already have Node 20 on the playwright docker image (and it seems quicker to use a docker image with node preinstalled than installing it after)