### PR TITLE
fix: pass on vendor id when redirecting to expired-code on login2

### DIFF
--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -259,6 +259,11 @@ export const passwordlessRoutes = new OpenAPIHono<{
           login2ExpiredCodeUrl.searchParams.set("connection", connection2);
         }
 
+        const vendorId = stateDecoded.get("vendor_id");
+        if (vendorId) {
+          login2ExpiredCodeUrl.searchParams.set("vendor_id", vendorId);
+        }
+
         return ctx.redirect(login2ExpiredCodeUrl.toString());
       }
     },

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -15,7 +15,8 @@ const AUTH_PARAMS = {
   redirect_uri: "https://login.example.com/callback",
   response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
   scope: "openid profile email",
-  state: "state",
+  state:
+    "client_id=clientId&redirect_uri=https://example.com/callback&vendor_id=vendorId&connection=auth2",
 };
 
 function getMagicLinkFromEmailBody(email: EmailOptions) {
@@ -572,9 +573,8 @@ describe("magic link flow", () => {
     expect(redirectUri2.pathname).toBe("/expired-code");
   });
 
-  it("should not accept any invalid params on the magic link", async () => {
+  it.only("should not accept an invalid code in the magic link", async () => {
     const env = await getEnv();
-    const client = testClient(tsoaApp, env);
     const loginClient = testClient(loginApp, env);
 
     // -----------
@@ -621,27 +621,40 @@ describe("magic link flow", () => {
     expect(redirectUri.hostname).toBe("login2.sesamy.dev");
     expect(redirectUri.pathname).toBe("/expired-code");
     expect(redirectUri.searchParams.get("email")).toBe("test@example.com");
-    // ------------
-    // Overwrite the magic link with a bad email, and try and use it
-    // ----------------
-    const magicLinkWithBadEmail = new URL(link!);
-    magicLinkWithBadEmail.searchParams.set("email", "another@email.com");
 
-    const authenticateResponse2 =
-      await loginClient.passwordless.verify_redirect.$get({
-        query: verifyCodeQuerySchema.parse(
-          Object.fromEntries(magicLinkWithBadEmail.searchParams.entries()),
-        ),
-      });
-    expect(authenticateResponse2.status).toBe(302);
-    const redirectUri2 = new URL(
-      authenticateResponse2.headers.get("location")!,
+    expect(redirectUri.searchParams.get("lang")).toBe("sv");
+    expect(redirectUri.searchParams.get("client_id")).toBe("clientId");
+    expect(redirectUri.searchParams.get("vendor_id")).toBe("vendorId");
+    expect(redirectUri.searchParams.get("connection")).toBe("auth2");
+    expect(redirectUri.searchParams.get("redirect_uri")).toBe(
+      "https://example.com/callback",
     );
-    expect(redirectUri2.hostname).toBe("login2.sesamy.dev");
-    expect(redirectUri2.pathname).toBe("/expired-code");
-    expect(redirectUri2.searchParams.get("email")).toBe("another@email.com");
-    expect(redirectUri2.searchParams.get("lang")).toBe("sv");
   });
+
+  // this test will give a false positive as we can only use each magic link once now... I can make a new test
+  // that rewrites a magic link before using it, and check that it doesn't work
+
+  // ------------
+  // Overwrite the magic link with a bad email, and try and use it
+  // ----------------
+  // const magicLinkWithBadEmail = new URL(link!);
+  // magicLinkWithBadEmail.searchParams.set("email", "another@email.com");
+
+  // const authenticateResponse2 =
+  //   await loginClient.passwordless.verify_redirect.$get({
+  //     query: verifyCodeQuerySchema.parse(
+  //       Object.fromEntries(magicLinkWithBadEmail.searchParams.entries()),
+  //     ),
+  //   });
+  // expect(authenticateResponse2.status).toBe(302);
+  // const redirectUri2 = new URL(
+  //   authenticateResponse2.headers.get("location")!,
+  // );
+  // expect(redirectUri2.hostname).toBe("login2.sesamy.dev");
+  // expect(redirectUri2.pathname).toBe("/expired-code");
+  // expect(redirectUri2.searchParams.get("email")).toBe("another@email.com");
+  // expect(redirectUri2.searchParams.get("lang")).toBe("sv");
+  // });
 
   describe("edge cases", () => {
     it("should ignore un-verified password account when signing up with magic link", async () => {

--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -573,7 +573,7 @@ describe("magic link flow", () => {
     expect(redirectUri2.pathname).toBe("/expired-code");
   });
 
-  it.only("should not accept an invalid code in the magic link", async () => {
+  it("should not accept an invalid code in the magic link", async () => {
     const env = await getEnv();
     const loginClient = testClient(loginApp, env);
 


### PR DESCRIPTION
I have no idea if this worked at one point and we've had a regression or (also likely) by not actually testing the full flow this never worked :smile: 

I've just tested this running auth2 locally on wrangler

*this is the first of a few fixes and PRs* as we're not actually sending out a new email either :smile: 

I figure we should fix login2 first before we migrate this expired-code page to auth2 (which would be great)