### PR TITLE
test: if email is altered then do not accept magic link as login

### DIFF
--- a/test/integration/flows/magic-link-flow.spec.ts
+++ b/test/integration/flows/magic-link-flow.spec.ts
@@ -659,7 +659,7 @@ describe("magic link flow", () => {
 
     const link = magicLink!;
     // ------------
-    // Overwrite the magic link with a bad email, and try and use it
+    // Overwrite the magic link with a different email, and try and use it
     // ----------------
     const magicLinkWithBadEmail = new URL(link!);
     magicLinkWithBadEmail.searchParams.set("email", "another@email.com");


### PR DESCRIPTION
This was previously in a test but then the fix to only allow single uses of login tickets meant this test was really a false positive

This is now actually asserting what we want on a fresh login ticket