### PR TITLE
fix: refactor routes and fix users

### DIFF
--- a/src/adapters/kysely/clients/index.ts
+++ b/src/adapters/kysely/clients/index.ts
@@ -2,18 +2,7 @@ import { Kysely } from "kysely";
 import { Database, PartialClient } from "../../../types";
 import { connectionSchema } from "../../../types/Connection";
 import { HTTPException } from "hono/http-exception";
-
-function removeNullProperties<T = any>(obj: Record<string, any>) {
-  const clone = { ...obj };
-
-  for (const key in clone) {
-    if (clone[key] === null) {
-      delete clone[key];
-    }
-  }
-
-  return clone as T;
-}
+import { removeNullProperties } from "../helpers/remove-nulls";
 
 function splitUrls(value?: string) {
   if (!value?.length) {

--- a/src/adapters/kysely/helpers/remove-nulls.ts
+++ b/src/adapters/kysely/helpers/remove-nulls.ts
@@ -1,0 +1,11 @@
+export function removeNullProperties<T = any>(obj: Record<string, any>) {
+  const clone = { ...obj };
+
+  for (const key in clone) {
+    if (clone[key] === null) {
+      delete clone[key];
+    }
+  }
+
+  return clone as T;
+}

--- a/src/adapters/kysely/users/list.ts
+++ b/src/adapters/kysely/users/list.ts
@@ -4,6 +4,7 @@ import { Kysely } from "kysely";
 import { ListParams } from "../../interfaces/ListParams";
 import getCountAsInt from "../../../utils/getCountAsInt";
 import { luceneFilter } from "../helpers/filter";
+import { removeNullProperties } from "../helpers/remove-nulls";
 
 export function listUsers(db: Kysely<Database>) {
   return async (
@@ -34,11 +35,13 @@ export function listUsers(db: Kysely<Database>) {
     const countInt = getCountAsInt(count);
 
     return {
-      users: users.map((u) => ({
-        ...u,
-        email_verified: u.email_verified === 1,
-        is_social: u.is_social === 1,
-      })),
+      users: users.map((u) =>
+        removeNullProperties({
+          ...u,
+          email_verified: u.email_verified === 1,
+          is_social: u.is_social === 1,
+        }),
+      ),
       start: params.page * params.per_page,
       limit: params.per_page,
       length: countInt,

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,8 +43,6 @@ const ALLOWED_ORIGINS = [
 
 const rootApp = new OpenAPIHono<{ Bindings: Env; Variables: Var }>();
 
-registerComponent(rootApp);
-
 const app = rootApp
   .onError((err, ctx) => {
     if (err instanceof HTTPException) {
@@ -123,6 +121,8 @@ export const managementApp = new OpenAPIHono<{
   .route("/api/v2/tenants", tenants)
   .route("/api/v2/logs", logs)
   .route("/api/v2/connections", connections);
+
+registerComponent(managementApp);
 
 managementApp.doc("/api/v2/spec", {
   openapi: "3.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,7 +89,7 @@ const app = rootApp
     });
   });
 
-export const loginApp = rootApp
+export const oauthApp = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
   .route("/u", login)
   .route("/.well-known", wellKnown)
   .route("/authorize", authorizeRoutes)
@@ -99,7 +99,22 @@ export const loginApp = rootApp
   .route("/dbconnections", dbConnectionRoutes)
   .route("/passwordless", passwordlessRoutes)
   .route("/co/authenticate", authenticateRoutes)
-  .route("/v2/logout", logoutRoutes)
+  .route("/v2/logout", logoutRoutes);
+
+oauthApp.doc("/spec", {
+  openapi: "3.0.0",
+  info: {
+    version: "1.0.0",
+    title: "Oauth endpoints",
+  },
+});
+
+rootApp.route("/", oauthApp);
+
+export const managementApp = new OpenAPIHono<{
+  Bindings: Env;
+  Variables: Var;
+}>()
   .route("/api/v2/domains", domains)
   .route("/api/v2/users", users)
   .route("/api/v2/keys/signing", keys)
@@ -109,13 +124,15 @@ export const loginApp = rootApp
   .route("/api/v2/logs", logs)
   .route("/api/v2/connections", connections);
 
-loginApp.doc("/u/doc", {
+managementApp.doc("/api/v2/spec", {
   openapi: "3.0.0",
   info: {
     version: "1.0.0",
-    title: "Login spec",
+    title: "Management api",
   },
 });
+
+rootApp.route("/", oauthApp).route("/", managementApp);
 
 app.get(
   "/css/tailwind.css",

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -142,13 +142,6 @@ export const users = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         );
       }
 
-      try {
-        return ctx.json(z.array(auth0UserResponseSchema).parse(users));
-      } catch (e: any) {
-        console.error(e);
-        throw new HTTPException(503, { message: e.message });
-      }
-
       return ctx.json(z.array(auth0UserResponseSchema).parse(users));
     },
   )

--- a/src/routes/swagger-ui.ts
+++ b/src/routes/swagger-ui.ts
@@ -52,7 +52,7 @@ function getSwaggerHtml() {
           urls: [
             {
               url: "/spec",
-              name: "Oauth api"
+              name: "OAuth api"
             },
             {
               url: "/api/v2/spec",

--- a/src/routes/swagger-ui.ts
+++ b/src/routes/swagger-ui.ts
@@ -52,11 +52,11 @@ function getSwaggerHtml() {
           urls: [
             {
               url: "/spec",
-              name: "TSOA Spec"
+              name: "Oauth api"
             },
             {
-              url: "/u/doc",
-              name: "OpenAPI Spec"
+              url: "/api/v2/spec",
+              name: "Management api"
             }
           ],
           dom_id: "#swagger-ui",

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -30,6 +30,14 @@ export const userSchema = userInsertSchema
     login_count: z.number(),
   });
 
+export const auth0UserResponseSchema = userSchema
+  .extend({
+    user_id: z.string(),
+    // TODO: Type identities
+    identities: z.array(z.any()),
+  })
+  .omit({ id: true });
+
 export interface BaseUser {
   // TODO - Auth0 requires the id OR the email but for our current usage with durable objects and Sesamy's architecture, we need email!
   email: string;

--- a/test/integration/flows/logout.spec.ts
+++ b/test/integration/flows/logout.spec.ts
@@ -4,16 +4,16 @@ import {
   doSilentAuthRequestAndReturnTokens,
 } from "../helpers/silent-auth";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import { AuthorizationResponseType } from "../../../src/types";
 
 describe("logout", () => {
   it("should delete the session if a user logs out", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const loginResponse = await loginClient.co.authenticate.$post({
+    const loginResponse = await oauthClient.co.authenticate.$post({
       json: {
         client_id: "clientId",
         credential_type: "http://auth0.com/oauth/grant-type/password-realm",
@@ -26,7 +26,7 @@ describe("logout", () => {
     const { login_ticket } = await loginResponse.json();
 
     // Trade the ticket for token
-    const tokenResponse = await loginClient.authorize.$get(
+    const tokenResponse = await oauthClient.authorize.$get(
       {
         query: {
           auth0Client: "eyJuYW1lIjoiYXV0aDAuanMiLCJ2ZXJzaW9uIjoiOS4yMy4wIn0=",
@@ -53,7 +53,7 @@ describe("logout", () => {
     const { accessToken: silentAuthAccessTokenPayload } =
       await doSilentAuthRequestAndReturnTokens(
         setCookieHeader,
-        loginClient,
+        oauthClient,
         "nonce",
         "clientId",
       );
@@ -64,7 +64,7 @@ describe("logout", () => {
     const cookies = setCookieHeader.split(";").map((c) => c.trim());
     const authCookie = cookies.find((c) => c.startsWith("auth-token"))!;
 
-    const logoutResponse = await loginClient.v2.logout.$get(
+    const logoutResponse = await oauthClient.v2.logout.$get(
       {
         query: {
           client_id: "clientId",
@@ -85,7 +85,7 @@ describe("logout", () => {
     //--------------------------------------------------------------
     const result = await doSilentAuthRequest(
       setCookieHeader,
-      loginClient,
+      oauthClient,
       "nonce",
       "clientId",
     );

--- a/test/integration/flows/silent-auth.spec.ts
+++ b/test/integration/flows/silent-auth.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { doSilentAuthRequestAndReturnTokens } from "../helpers/silent-auth";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import {
   AuthorizationResponseType,
@@ -24,7 +24,7 @@ function getDefaultSilentAuthSearchParams() {
 describe("silent-auth", () => {
   it("should return a 200 when not logged in, with a login_required error", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const client = testClient(oauthApp, env);
 
     const query = {
       client_id: "clientId",
@@ -53,9 +53,9 @@ describe("silent-auth", () => {
 
   it("should set the used_at property on the session when the token is renewed", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const loginResponse = await loginClient.co.authenticate.$post({
+    const loginResponse = await oauthClient.co.authenticate.$post({
       json: {
         client_id: "clientId",
         credential_type: "http://auth0.com/oauth/grant-type/password-realm",
@@ -77,7 +77,7 @@ describe("silent-auth", () => {
       realm: "Username-Password-Authentication",
     };
     // Trade the ticket for token
-    const tokenResponse = await loginClient.authorize.$get({
+    const tokenResponse = await oauthClient.authorize.$get({
       query,
     });
     expect(tokenResponse.status).toBe(302);
@@ -91,7 +91,7 @@ describe("silent-auth", () => {
     // -------------------------------------------------------------
     const { idToken } = await doSilentAuthRequestAndReturnTokens(
       setCookieHeader,
-      loginClient,
+      oauthClient,
       "nonce",
       "clientId",
     );
@@ -103,9 +103,9 @@ describe("silent-auth", () => {
 
   it("should return a 200 for a valid silent auth request from the same client, same tenant, but not a different tenant", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const loginResponse = await loginClient.co.authenticate.$post({
+    const loginResponse = await oauthClient.co.authenticate.$post({
       json: {
         client_id: "clientId",
         credential_type: "http://auth0.com/oauth/grant-type/password-realm",
@@ -117,7 +117,7 @@ describe("silent-auth", () => {
     expect(loginResponse.status).toBe(200);
     const { login_ticket } = await loginResponse.json();
     // Trade the ticket for token
-    const tokenResponse = await loginClient.authorize.$get(
+    const tokenResponse = await oauthClient.authorize.$get(
       {
         query: {
           auth0Client: "eyJuYW1lIjoiYXV0aDAuanMiLCJ2ZXJzaW9uIjoiOS4yMy4wIn0=",
@@ -144,7 +144,7 @@ describe("silent-auth", () => {
     const { accessToken: silentAuthAccessTokenPayload } =
       await doSilentAuthRequestAndReturnTokens(
         setCookieHeader,
-        loginClient,
+        oauthClient,
         "nonce",
         "clientId",
       );
@@ -156,7 +156,7 @@ describe("silent-auth", () => {
     const { accessToken: silentAuthAccessTokenPayloadOtherClient } =
       await doSilentAuthRequestAndReturnTokens(
         setCookieHeader,
-        loginClient,
+        oauthClient,
         "nonce",
         "otherClientId",
       );
@@ -169,7 +169,7 @@ describe("silent-auth", () => {
       client_id: "otherClientIdOnOtherTenant",
     };
 
-    const silentAuthResponseDifferentTenant = await loginClient.authorize.$get(
+    const silentAuthResponseDifferentTenant = await oauthClient.authorize.$get(
       {
         query: silentAuthSearchParamsDifferentTenant,
       },

--- a/test/integration/helpers/createTestUsers.ts
+++ b/test/integration/helpers/createTestUsers.ts
@@ -3,13 +3,13 @@ import { testClient } from "hono/testing";
 import { getAdminToken } from "./token";
 import { UserResponse } from "../../../src/types/auth0";
 import { EnvType } from "./test-client";
-import { loginApp } from "../../../src/app";
+import { managementApp } from "../../../src/app";
 
 export default async function createTestUsers(env: EnvType, tenantId: string) {
   const token = await getAdminToken();
-  const client = testClient(loginApp, env);
+  const managementClient = testClient(managementApp, env);
 
-  const createUserResponse1 = await client.api.v2.users.$post(
+  const createUserResponse1 = await managementClient.api.v2.users.$post(
     {
       json: {
         email: "test1@example.com",
@@ -22,7 +22,6 @@ export default async function createTestUsers(env: EnvType, tenantId: string) {
     {
       headers: {
         authorization: `Bearer ${token}`,
-        "content-type": "application/json",
       },
     },
   );
@@ -30,7 +29,7 @@ export default async function createTestUsers(env: EnvType, tenantId: string) {
   expect(createUserResponse1.status).toBe(201);
   const newUser1 = (await createUserResponse1.json()) as UserResponse;
 
-  const createUserResponse2 = await client.api.v2.users.$post(
+  const createUserResponse2 = await managementClient.api.v2.users.$post(
     {
       json: {
         email: "test2@example.com",
@@ -43,7 +42,6 @@ export default async function createTestUsers(env: EnvType, tenantId: string) {
     {
       headers: {
         authorization: `Bearer ${token}`,
-        "content-type": "application/json",
       },
     },
   );

--- a/test/integration/helpers/silent-auth.ts
+++ b/test/integration/helpers/silent-auth.ts
@@ -1,13 +1,13 @@
 import { expect } from "vitest";
 import { testClient } from "hono/testing";
 import { parseJwt } from "../../../src/utils/parse-jwt";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import {
   AuthorizationResponseMode,
   AuthorizationResponseType,
 } from "../../../src/types";
 
-const client = testClient(loginApp, {});
+const client = testClient(oauthApp, {});
 type clientAppType = typeof client;
 
 export async function doSilentAuthRequest(

--- a/test/integration/jwks.spec.ts
+++ b/test/integration/jwks.spec.ts
@@ -3,12 +3,12 @@ import { testClient } from "hono/testing";
 import { jwksKeySchema, openIDConfigurationSchema } from "../../src/types/jwks";
 import { getAdminToken } from "./helpers/token";
 import { getEnv } from "./helpers/test-client";
-import { loginApp } from "../../src/app";
+import { managementApp, oauthApp } from "../../src/app";
 
 describe("jwks", () => {
   it("should return a list with the test certificate", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const client = testClient(oauthApp, env);
 
     const response = await client[".well-known"]["jwks.json"].$get(
       {
@@ -30,9 +30,10 @@ describe("jwks", () => {
 
   it("should create a new rsa-key and return it", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
+    const managementClient = testClient(managementApp, env);
 
-    const initialKey = await loginClient[".well-known"]["jwks.json"].$get(
+    const initialKey = await oauthClient[".well-known"]["jwks.json"].$get(
       {
         param: {},
       },
@@ -49,7 +50,7 @@ describe("jwks", () => {
     const token = await getAdminToken();
 
     const createKeyResponse =
-      await loginClient.api.v2.keys.signing.rotate.$post(
+      await managementClient.api.v2.keys.signing.rotate.$post(
         {
           header: {
             tenant_id: "tenantId",
@@ -64,7 +65,7 @@ describe("jwks", () => {
 
     expect(createKeyResponse.status).toBe(201);
 
-    const response = await loginClient[".well-known"]["jwks.json"].$get(
+    const response = await oauthClient[".well-known"]["jwks.json"].$get(
       {
         param: {},
       },
@@ -87,7 +88,7 @@ describe("jwks", () => {
 
   it("should return an openid-configuration with the current issues", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const client = testClient(oauthApp, env);
 
     const response = await client[".well-known"]["openid-configuration"].$get(
       {

--- a/test/integration/keys.spec.ts
+++ b/test/integration/keys.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
-import { loginApp } from "../../src/app";
+import { managementApp } from "../../src/app";
 import { getAdminToken } from "./helpers/token";
 import { getEnv } from "./helpers/test-client";
 
 describe("keys", () => {
   it("should add a new key", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const client = testClient(managementApp, env);
 
     const token = await getAdminToken();
     const response = await client.api.v2.keys.signing.$get(

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import { EmailOptions } from "../../../src/services/email/EmailOptions";
 import { snapshotResponse } from "../helpers/playwrightSnapshots";
@@ -24,9 +24,9 @@ describe("Login with code on liquidjs template", () => {
       vendorSettings: FOKUS_VENDOR_SETTINGS,
       testTenantLanguage: "nb",
     });
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get({
+    const response = await oauthClient.authorize.$get({
       query: {
         client_id: "clientId",
         response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
@@ -46,7 +46,7 @@ describe("Login with code on liquidjs template", () => {
 
     const query = Object.fromEntries(stateParam.entries());
 
-    const codeInputFormResponse = await loginClient.u.code.$get({
+    const codeInputFormResponse = await oauthClient.u.code.$get({
       query: {
         state: query.state,
       },
@@ -56,7 +56,7 @@ describe("Login with code on liquidjs template", () => {
 
     await snapshotResponse(codeInputFormResponse);
 
-    const postSendCodeResponse = await loginClient.u.code.$post({
+    const postSendCodeResponse = await oauthClient.u.code.$post({
       query: { state: query.state },
       form: {
         username: "foo@example.com",
@@ -75,13 +75,13 @@ describe("Login with code on liquidjs template", () => {
       new URLSearchParams(enterCodeParams).entries(),
     );
 
-    const enterCodeForm = await loginClient.u["enter-code"].$get({
+    const enterCodeForm = await oauthClient.u["enter-code"].$get({
       query: { state: enterCodeQuery.state },
     });
     expect(enterCodeForm.status).toBe(200);
     await snapshotResponse(enterCodeForm);
 
-    const authenticateResponse = await loginClient.u["enter-code"].$post({
+    const authenticateResponse = await oauthClient.u["enter-code"].$post({
       query: {
         state: enterCodeQuery.state,
       },
@@ -102,9 +102,9 @@ describe("Login with code on liquidjs template", () => {
 
   it("should reject bad code", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get({
+    const response = await oauthClient.authorize.$get({
       query: {
         client_id: "clientId",
         response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
@@ -120,7 +120,7 @@ describe("Login with code on liquidjs template", () => {
 
     const query = Object.fromEntries(stateParam.entries());
 
-    const postSendCodeResponse = await loginClient.u.code.$post({
+    const postSendCodeResponse = await oauthClient.u.code.$post({
       query: { state: query.state },
       form: {
         username: "foo@example.com",
@@ -133,7 +133,7 @@ describe("Login with code on liquidjs template", () => {
       new URLSearchParams(enterCodeParams).entries(),
     );
 
-    const incorrectCodeResponse = await loginClient.u["enter-code"].$post({
+    const incorrectCodeResponse = await oauthClient.u["enter-code"].$post({
       query: {
         state: enterCodeQuery.state,
       },

--- a/test/integration/login/code-flow.spec.ts
+++ b/test/integration/login/code-flow.spec.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 
 describe("Login with code", () => {
   it("should return a 400 if there's no code", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const incorrectCodeResponse = await loginClient.co.authenticate.$post({
+    const incorrectCodeResponse = await oauthClient.co.authenticate.$post({
       json: {
         client_id: "clientId",
         username: "foo@example.com",

--- a/test/integration/login/forgot-password.spec.ts
+++ b/test/integration/login/forgot-password.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import {
   snapshotResponse,
@@ -12,9 +12,9 @@ describe("Forgot password", () => {
   it("should send forgot password email", async () => {
     const env = await getEnv();
 
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get({
+    const response = await oauthClient.authorize.$get({
       query: {
         client_id: "clientId",
         response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
@@ -33,7 +33,7 @@ describe("Forgot password", () => {
     // Open forgot password page
     // ---------------------
 
-    const forgotPasswordResponse = await loginClient.u["forgot-password"].$get({
+    const forgotPasswordResponse = await oauthClient.u["forgot-password"].$get({
       query: {
         state: query.state,
       },
@@ -47,7 +47,7 @@ describe("Forgot password", () => {
     // now send the password reset email
     // ---------------------
 
-    const forgotPasswordEmailResponse = await loginClient.u[
+    const forgotPasswordEmailResponse = await oauthClient.u[
       "forgot-password"
     ].$post({
       query: {

--- a/test/integration/login/login-password.spec.ts
+++ b/test/integration/login/login-password.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getEnv } from "../helpers/test-client";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import { snapshotResponse } from "../helpers/playwrightSnapshots";
 import { KVARTAL_VENDOR_SETTINGS } from "../../fixtures/vendorSettings";
@@ -12,7 +12,7 @@ describe("Login with password user", () => {
       vendorSettings: KVARTAL_VENDOR_SETTINGS,
       testTenantLanguage: "en",
     });
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
     const searchParams = {
       client_id: "clientId",
@@ -22,7 +22,7 @@ describe("Login with password user", () => {
       state: "state",
     };
 
-    const response = await loginClient.authorize.$get({
+    const response = await oauthClient.authorize.$get({
       query: searchParams,
     });
 
@@ -35,7 +35,7 @@ describe("Login with password user", () => {
     const query = Object.fromEntries(stateParam.entries());
 
     // Open login page
-    const loginFormResponse = await loginClient.u.login.$get({
+    const loginFormResponse = await oauthClient.u.login.$get({
       query: {
         state: query.state,
       },
@@ -49,7 +49,7 @@ describe("Login with password user", () => {
 
     await snapshotResponse(loginFormResponse);
 
-    const postLoginResponse = await loginClient.u.login.$post({
+    const postLoginResponse = await oauthClient.u.login.$post({
       query: {
         state: loginSearchParamsQuery.state,
       },
@@ -76,9 +76,9 @@ describe("Login with password user", () => {
 
   it("should reject bad password", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get({
+    const response = await oauthClient.authorize.$get({
       query: {
         client_id: "clientId",
         response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
@@ -94,7 +94,7 @@ describe("Login with password user", () => {
     const query = Object.fromEntries(stateParam.entries());
 
     // Open login page
-    await loginClient.u.login.$get({
+    await oauthClient.u.login.$get({
       query: {
         state: query.state,
       },
@@ -105,7 +105,7 @@ describe("Login with password user", () => {
       loginSearchParams.entries(),
     );
 
-    const incorrectPasswordResponse = await loginClient.u.login.$post({
+    const incorrectPasswordResponse = await oauthClient.u.login.$post({
       query: {
         state: loginSearchParamsQuery.state,
       },

--- a/test/integration/login/register-password-user.spec.ts
+++ b/test/integration/login/register-password-user.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { loginApp } from "../../../src/app";
+import { oauthApp } from "../../../src/app";
 import { getEnv } from "../helpers/test-client";
 import { testClient } from "hono/testing";
 import { snapshotResponse } from "../helpers/playwrightSnapshots";
@@ -12,9 +12,9 @@ describe("Register password user", () => {
       vendorSettings: BREAKIT_VENDOR_SETTINGS,
       testTenantLanguage: "it",
     });
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get(
+    const response = await oauthClient.authorize.$get(
       {
         query: {
           client_id: "clientId",
@@ -39,7 +39,7 @@ describe("Register password user", () => {
     const query = Object.fromEntries(stateParam.entries());
 
     // Open login page
-    const loginFormResponse = await loginClient.u.login.$get({
+    const loginFormResponse = await oauthClient.u.login.$get({
       query: {
         state: query.state,
       },
@@ -53,7 +53,7 @@ describe("Register password user", () => {
     );
 
     // Open signup page
-    const getSignupResponse = await loginClient.u.signup.$get({
+    const getSignupResponse = await oauthClient.u.signup.$get({
       query: {
         state: loginSearchParamsQuery.state,
       },
@@ -68,7 +68,7 @@ describe("Register password user", () => {
     await snapshotResponse(getSignupResponse);
 
     // Signup
-    const postSignupResponse = await loginClient.u.signup.$post({
+    const postSignupResponse = await oauthClient.u.signup.$post({
       query: { state: signupSearchParamsQuery.state },
       form: {
         username: "test@example.com",
@@ -90,9 +90,9 @@ describe("Register password user", () => {
 
   it("should reject a weak password", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const response = await loginClient.authorize.$get(
+    const response = await oauthClient.authorize.$get(
       {
         query: {
           client_id: "clientId",
@@ -114,7 +114,7 @@ describe("Register password user", () => {
     const stateParam = new URLSearchParams(location.split("?")[1]);
     const query = Object.fromEntries(stateParam.entries());
     // Open login page
-    await loginClient.u.login.$get({
+    await oauthClient.u.login.$get({
       query: {
         state: query.state,
       },
@@ -123,7 +123,7 @@ describe("Register password user", () => {
     const loginSearchParamsQuery = Object.fromEntries(
       loginSearchParams.entries(),
     );
-    await loginClient.u.signup.$get({
+    await oauthClient.u.signup.$get({
       query: {
         state: loginSearchParamsQuery.state,
       },
@@ -133,7 +133,7 @@ describe("Register password user", () => {
       signupSearchParams.entries(),
     );
     // Enter weak passworrd
-    const postSignupResponse = await loginClient.u.signup.$post({
+    const postSignupResponse = await oauthClient.u.signup.$post({
       query: { state: signupSearchParamsQuery.state },
       form: {
         username: "test@example.com",

--- a/test/integration/management-api/logs.spec.ts
+++ b/test/integration/management-api/logs.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
-import { loginApp } from "../../../src/app";
-import { LogsResponse, UserResponse } from "../../../src/types/auth0";
+import { managementApp, oauthApp } from "../../../src/app";
+import { LogsResponse } from "../../../src/types/auth0";
 import { getAdminToken } from "../helpers/token";
 import { getEnv } from "../helpers/test-client";
 import {
@@ -12,10 +12,10 @@ import {
 describe("logs", () => {
   it("should return an empty list of logs for a tenant", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const managementClient = testClient(managementApp, env);
 
     const token = await getAdminToken();
-    const response = await client.api.v2.logs.$get(
+    const response = await managementClient.api.v2.logs.$get(
       {
         query: {},
         header: {
@@ -31,17 +31,18 @@ describe("logs", () => {
 
     expect(response.status).toBe(200);
 
-    const body = (await response.json()) as UserResponse[];
+    const body = (await response.json()) as LogsResponse[];
     expect(body.length).toBe(0);
   });
 
   it("should return a log row for a created user", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
+    const managementClient = testClient(managementApp, env);
 
     const token = await getAdminToken();
 
-    const createUserResponse = await client.api.v2.users.$post(
+    const createUserResponse = await managementClient.api.v2.users.$post(
       {
         json: {
           email: "test@example.com",
@@ -63,7 +64,7 @@ describe("logs", () => {
 
     expect(createUserResponse.status).toBe(201);
 
-    const response = await client.api.v2.logs.$get(
+    const response = await managementClient.api.v2.logs.$get(
       {
         query: {},
         header: {
@@ -97,11 +98,12 @@ describe("logs", () => {
 
   it.skip("should log a failed silent auth request", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
+    const managementClient = testClient(managementApp, env);
 
     const token = await getAdminToken();
 
-    const silentAuthResponse = await loginClient.authorize.$get(
+    const silentAuthResponse = await oauthClient.authorize.$get(
       {
         query: {
           client_id: "clientId",
@@ -126,7 +128,7 @@ describe("logs", () => {
 
     expect(silentAuthResponse.status).toBe(200);
 
-    const response = await loginClient.api.v2.logs.$get(
+    const response = await managementClient.api.v2.logs.$get(
       {
         query: {},
         header: {

--- a/test/integration/management-api/tenants.spec.ts
+++ b/test/integration/management-api/tenants.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
-import { loginApp } from "../../../src/app";
+import { managementApp } from "../../../src/app";
 import { getAdminToken } from "../helpers/token";
 import { getEnv } from "../helpers/test-client";
 import { Tenant } from "../../../src/types";
@@ -8,10 +8,10 @@ import { Tenant } from "../../../src/types";
 describe("tenants", () => {
   it("should add a new tenant", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const managementClient = testClient(managementApp, env);
 
     const token = await getAdminToken();
-    const tenantsResponse1 = await client.api.v2.tenants.$get(
+    const tenantsResponse1 = await managementClient.api.v2.tenants.$get(
       {
         query: {},
       },
@@ -27,7 +27,7 @@ describe("tenants", () => {
     expect(body1.length).toEqual(3);
 
     // now create the tenant
-    const createTenantResponse = await client.api.v2.tenants.$post(
+    const createTenantResponse = await managementClient.api.v2.tenants.$post(
       {
         json: {
           name: "test",
@@ -39,7 +39,6 @@ describe("tenants", () => {
       {
         headers: {
           authorization: `Bearer ${token}`,
-          "content-type": "application/json",
         },
       },
     );
@@ -50,7 +49,7 @@ describe("tenants", () => {
     expect(createdTenant.name).toBe("test");
 
     // now fetch list of tenants again to assert tenant deleted
-    const tenantsResponse2 = await client.api.v2.tenants.$get(
+    const tenantsResponse2 = await managementClient.api.v2.tenants.$get(
       {
         query: {},
       },
@@ -68,10 +67,10 @@ describe("tenants", () => {
 
   it("should remove a tenant", async () => {
     const env = await getEnv();
-    const client = testClient(loginApp, env);
+    const managementClient = testClient(managementApp, env);
 
     const token = await getAdminToken();
-    const tenantsResponse1 = await client.api.v2.tenants.$get(
+    const tenantsResponse1 = await managementClient.api.v2.tenants.$get(
       { query: {} },
       {
         headers: {
@@ -85,7 +84,9 @@ describe("tenants", () => {
     // base tenant + two tenants in test-server
     expect(body1.length).toEqual(3);
 
-    const deleteTenantResponse = await client.api.v2.tenants[":id"].$delete(
+    const deleteTenantResponse = await managementClient.api.v2.tenants[
+      ":id"
+    ].$delete(
       {
         param: {
           id: "otherTenant",
@@ -101,7 +102,7 @@ describe("tenants", () => {
     expect(deleteTenantResponse.status).toBe(200);
 
     // fetch list of tenants again - assert we are one down
-    const tenantsResponse2 = await client.api.v2.tenants.$get(
+    const tenantsResponse2 = await managementClient.api.v2.tenants.$get(
       { query: {} },
       {
         headers: {

--- a/test/integration/userinfo.spec.ts
+++ b/test/integration/userinfo.spec.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { testClient } from "hono/testing";
 import { getEnv } from "./helpers/test-client";
-import { loginApp } from "../../src/app";
+import { oauthApp } from "../../src/app";
 import { AuthorizationResponseType } from "../../src/types";
 
 describe("userinfo", () => {
   it("return the userinfo for a user", async () => {
     const env = await getEnv();
-    const loginClient = testClient(loginApp, env);
+    const oauthClient = testClient(oauthApp, env);
 
-    const loginResponse = await loginClient.co.authenticate.$post({
+    const loginResponse = await oauthClient.co.authenticate.$post({
       json: {
         client_id: "clientId",
         credential_type: "http://auth0.com/oauth/grant-type/password-realm",
@@ -21,7 +21,7 @@ describe("userinfo", () => {
 
     const { login_ticket } = await loginResponse.json();
 
-    const tokenResponse = await loginClient.authorize.$get({
+    const tokenResponse = await oauthClient.authorize.$get({
       query: {
         auth0Client: "eyJuYW1lIjoiYXV0aDAuanMiLCJ2ZXJzaW9uIjoiOS4yMy4wIn0=",
         client_id: "clientId",
@@ -42,7 +42,7 @@ describe("userinfo", () => {
 
     expect(token).toBeTypeOf("string");
 
-    const userinfoResponse = await loginClient.userinfo.$get(
+    const userinfoResponse = await oauthClient.userinfo.$get(
       {},
       {
         headers: {


### PR DESCRIPTION
Split the api's in a separate for the oauth endpoints and the management api.

When doing this I noticed that he user endpoints weren't returning the correct content-type which in turn generated loads of errors. A bit surprising that the code has worked before.. We were doing unsafe typecastings that now are replaced by zod-parsing. There's still a bit of cleanup required to make all the the types match correctly, but think this is a good step on the way.