### PR TITLE
fix: set last login for ticket flow

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -207,6 +207,14 @@ export async function ticketAuth(
 
   const [sessionCookie] = serializeStateInCookie(sessionId);
 
+  // Update the user's last login
+  await env.data.users.update(tenant_id, user.id, {
+    last_login: new Date().toISOString(),
+    login_count: user.login_count + 1,
+    // This is specific to cloudflare
+    last_ip: ctx.req.header("cf-connecting-ip") || "",
+  });
+
   return new Response("Redirecting", {
     status: 302,
     headers: {

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -313,6 +313,7 @@ describe("password-flow", () => {
         {
           headers: {
             referrer: "https://login.example.com",
+            "cf-connecting-ip": "1.2.3.4",
           },
         },
       );
@@ -383,6 +384,13 @@ describe("password-flow", () => {
           },
         },
       ]);
+
+      // Check that the login count and last IP has been updated
+      expect(primaryUser.login_count).toBe(1);
+      expect(primaryUser.last_ip).toBe("1.2.3.4");
+
+      const lastLogin = new Date(primaryUser.last_login!);
+      expect(Date.now() - lastLogin.getTime()).lessThan(1000);
     });
 
     // this test looks like a duplicate of "should create a new user with a password and only allow login after email validation"


### PR DESCRIPTION
Set the last login user info for the ticket flow. A few things I'm not sure about:
- This will probably update the update_at field of the user, which doesn't feel great. Maybe we should have a separate "register login" function in the adapter that only sets the last-ip and the login count? 
- This only applies to the ticket flow. Would be great to have a single point for this code that also applies to social auth flow.