### PR TITLE
fix: auth2 pages now styled like login2

### DIFF
--- a/build-tailwind.js
+++ b/build-tailwind.js
@@ -5,8 +5,10 @@ const cssContent = fs.readFileSync("src/styles/tailwind.css", "utf8");
 
 const cssContentCleaned = cssContent.replaceAll("`", "'");
 
+const doubleEscaped = cssContentCleaned.replaceAll("\\", "\\\\");
+
 const tsContent = `export const tailwindCss = \`
-    ${cssContentCleaned}\`
+    ${doubleEscaped}\`
 `;
 
 // Write the TypeScript file

--- a/scripts/build-tailwind-css.sh
+++ b/scripts/build-tailwind-css.sh
@@ -1,4 +1,3 @@
 yarn postcss
 node build-tailwind
-# prettier on src/styles/tailwind.ts
 npx prettier --write src/styles/tailwind.ts

--- a/scripts/build-tailwind-css.sh
+++ b/scripts/build-tailwind-css.sh
@@ -1,3 +1,4 @@
 yarn postcss
 node build-tailwind
-yarn format # could be more targeted and just do tailwind.ts
+# prettier on src/styles/tailwind.ts
+npx prettier --write src/styles/tailwind.ts

--- a/src/app.ts
+++ b/src/app.ts
@@ -140,7 +140,7 @@ app.get(
     const css = tailwindCss;
 
     return ctx.text(css, 200, {
-      "content-type": "text/css",
+      "content-type": "text/css; charset=utf-8",
     });
   },
 );

--- a/src/styles/tailwind.ts
+++ b/src/styles/tailwind.ts
@@ -771,19 +771,19 @@ h6{
 .max-h-full{
   max-height: 100%;
 }
-.min-h-\[calc\(100vh-83px\)\]{
+.min-h-\\[calc\\(100vh-83px\\)\\]{
   min-height: calc(100vh - 83px);
 }
 .min-h-full{
   min-height: 100%;
 }
-.w-\[calc\(100\%-theme\(space\.2\)-theme\(space\.2\)\)\]{
+.w-\\[calc\\(100\\%-theme\\(space\\.2\\)-theme\\(space\\.2\\)\\)\\]{
   width: calc(100% - 0.5rem - 0.5rem);
 }
 .w-full{
   width: 100%;
 }
-.max-w-\[1295px\]{
+.max-w-\\[1295px\\]{
   max-width: 1295px;
 }
 .flex-1{
@@ -792,7 +792,7 @@ h6{
 .flex-col{
   flex-direction: column;
 }
-.\!flex-nowrap{
+.\\!flex-nowrap{
   flex-wrap: nowrap !important;
 }
 .items-center{
@@ -981,80 +981,80 @@ input[type="number"] {
   letter-spacing: 0;
 }
 
-.placeholder\:text-gray-300::-moz-placeholder{
+.placeholder\\:text-gray-300::-moz-placeholder{
   --tw-text-opacity: 1;
   color: rgb(136 134 159 / var(--tw-text-opacity));
 }
 
-.placeholder\:text-gray-300::placeholder{
+.placeholder\\:text-gray-300::placeholder{
   --tw-text-opacity: 1;
   color: rgb(136 134 159 / var(--tw-text-opacity));
 }
 
-.hover\:bg-primaryHover:hover{
+.hover\\:bg-primaryHover:hover{
   background-color: var(--primary-hover);
 }
 
-.hover\:underline:hover{
+.hover\\:underline:hover{
   text-decoration-line: underline;
 }
 
-.dark\:bg-gray-600:is(.dark *){
+.dark\\:bg-gray-600:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(40 40 52 / var(--tw-bg-opacity));
 }
 
-.dark\:bg-gray-800:is(.dark *){
+.dark\\:bg-gray-800:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(20 20 26 / var(--tw-bg-opacity));
 }
 
-.dark\:text-white:is(.dark *){
+.dark\\:text-white:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
 @media (min-width: 640px){
 
-  .sm\:min-h-\[700px\]{
+  .sm\\:min-h-\\[700px\\]{
     min-height: 700px;
   }
 
-  .sm\:w-\[calc\(100\%-theme\(space\.16\)-theme\(space\.16\)\)\]{
+  .sm\\:w-\\[calc\\(100\\%-theme\\(space\\.16\\)-theme\\(space\\.16\\)\\)\\]{
     width: calc(100% - 4rem - 4rem);
   }
 
-  .sm\:w-auto{
+  .sm\\:w-auto{
     width: auto;
   }
 
-  .sm\:max-w-md{
+  .sm\\:max-w-md{
     max-width: 28rem;
   }
 
-  .sm\:justify-normal{
+  .sm\\:justify-normal{
     justify-content: normal;
   }
 
-  .sm\:bg-fixed{
+  .sm\\:bg-fixed{
     background-attachment: fixed;
   }
 
-  .sm\:bg-left-top{
+  .sm\\:bg-left-top{
     background-position: left top;
   }
 
-  .sm\:px-14{
+  .sm\\:px-14{
     padding-left: 3.5rem;
     padding-right: 3.5rem;
   }
 
-  .sm\:py-14{
+  .sm\\:py-14{
     padding-top: 3.5rem;
     padding-bottom: 3.5rem;
   }
 
-  .sm\:text-2xl{
+  .sm\\:text-2xl{
     font-size: 1.5rem;
     line-height: 120%;
   }
@@ -1062,16 +1062,16 @@ input[type="number"] {
 
 @media (min-width: 1280px){
 
-  .md\:min-w-\[448px\]{
+  .md\\:min-w-\\[448px\\]{
     min-width: 448px;
   }
 
-  .md\:text-base{
+  .md\\:text-base{
     font-size: 1rem;
     line-height: 120%;
   }
 
-  .md\:text-xs{
+  .md\\:text-xs{
     font-size: 0.75rem;
     line-height: 135%;
   }
@@ -1079,7 +1079,7 @@ input[type="number"] {
 
 @media (max-height: 900px) and (min-width: 640px){
 
-  .short\:min-h-\[558px\]{
+  .short\\:min-h-\\[558px\\]{
     min-height: 558px;
   }
 }

--- a/src/styles/tailwind.ts
+++ b/src/styles/tailwind.ts
@@ -855,6 +855,10 @@ h6{
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
 }
+.py-2{
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
 .py-5{
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
@@ -1052,6 +1056,10 @@ input[type="number"] {
   .sm\\:py-14{
     padding-top: 3.5rem;
     padding-bottom: 3.5rem;
+  }
+
+  .sm\\:pt-16{
+    padding-top: 4rem;
   }
 
   .sm\\:text-2xl{

--- a/src/styles/tailwind.ts
+++ b/src/styles/tailwind.ts
@@ -905,6 +905,27 @@ h6{
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
+.row-up-left{
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  justify-content: flex-start;
+}
+.row{
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: center;
+  align-items: center;
+  justify-content: center;
+}
+.column-left{
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
 @media (min-width: 1280px){
 
   .text-5xl{

--- a/src/utils/components/Layout.tsx
+++ b/src/utils/components/Layout.tsx
@@ -91,7 +91,7 @@ const Layout: FC<LayoutProps> = ({ title, children, vendorSettings }) => {
 
       <body>
         <div
-          class="row min-h-full w-full overflow-hidden bg-cover bg-center text-sm sm:bg-fixed sm:bg-left-top"
+          class="row min-h-full w-full overflow-hidden bg-cover bg-center text-sm sm:bg-fixed sm:bg-left-top sm:pt-16 py-2"
           style={inlineStyles}
         >
           <div class="row-up-left w-[calc(100%-theme(space.2)-theme(space.2))] max-w-[1295px] !flex-nowrap sm:w-[calc(100%-theme(space.16)-theme(space.16))]">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,7 @@
+const tailwindRowsColumns = require("@ape-egg/tailwind-rows-columns");
+
 module.exports = {
+  plugins: [tailwindRowsColumns],
   darkMode: "class",
   content: ["./src/utils/components/*.tsx"],
   theme: {


### PR DESCRIPTION
:partying_face: 

This is what it looks like now when running locally

![image](https://github.com/sesamyab/auth/assets/8496063/d13b1837-8732-48d9-9385-7cfbaffde26d)


*BUT* I'll have to update the snapshots only when this is merged, as in the playwright snapshot helper I'm doing 

```
    const responseBody = responseText.replace(
      "/css/tailwind.css",
      "http://auth2.sesamy.dev/css/tailwind.css",
    );
```

Which will only be updated *after* merging this of course

It's not ideal *BUT* after this we shouldn't have to make any major tailwind CSS changes... so there should only be a few cases of this. 

