### PR TITLE
fix: use correct form element name

### DIFF
--- a/src/utils/components/LoginWithCodePage.tsx
+++ b/src/utils/components/LoginWithCodePage.tsx
@@ -17,7 +17,7 @@ const LoginWithCodePage: FC<Props> = ({ error, vendorSettings }) => {
         <form method="post">
           <input
             type="text"
-            name="email"
+            name="username"
             placeholder="email"
             class="mb-2 w-full rounded-lg bg-gray-100 px-4 py-5 text-base placeholder:text-gray-300 dark:bg-gray-600 md:text-base"
           />


### PR DESCRIPTION
Ouch, we have so many tests but of course none of them actually act like a user and use the web form :smile: 