### PR TITLE
fix: add nonce to magic link on universal auth flow so works

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -636,6 +636,8 @@ export const login = new OpenAPIHono<{ Bindings: Env }>()
       magicLink.searchParams.set("client_id", session.authParams.client_id);
       magicLink.searchParams.set("email", session.authParams.username);
       magicLink.searchParams.set("verification_code", code);
+      // TEMP FIX, NOT CORRECT THOUGH
+      magicLink.searchParams.set("nonce", "nonce");
 
       await sendLink(env, client, params.username, code, magicLink.href);
 

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -570,10 +570,7 @@ export const login = new OpenAPIHono<{ Bindings: Env }>()
       const params = ctx.req.valid("form");
 
       const { env } = ctx;
-      const { vendorSettings, client, session } = await initJSXRoute(
-        state,
-        env,
-      );
+      const { client, session } = await initJSXRoute(state, env);
 
       const code = generateOTP();
 
@@ -636,7 +633,6 @@ export const login = new OpenAPIHono<{ Bindings: Env }>()
       magicLink.searchParams.set("client_id", session.authParams.client_id);
       magicLink.searchParams.set("email", session.authParams.username);
       magicLink.searchParams.set("verification_code", code);
-      // TEMP FIX, NOT CORRECT THOUGH
       magicLink.searchParams.set("nonce", "nonce");
 
       await sendLink(env, client, params.username, code, magicLink.href);


### PR DESCRIPTION
`passwordless/verify_redirect` requires a `nonce` param and we're not adding that to the magic link on the universal auth `POST` `/u/code` (where we send the code email)
