### PR TITLE
chore: rename routes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,18 +8,18 @@ import swaggerUi from "./routes/swagger-ui";
 import loggerMiddleware from "./middlewares/logger";
 import renderOauthRedirectHtml from "./routes/oauth2-redirect";
 import { validateUrl } from "./utils/validate-redirect-url";
-import { login } from "./routes/tsx/routes";
-import { wellKnown } from "./routes/oauth2/well-known";
-import { users } from "./routes/management-api/users";
+import { loginRoutes } from "./routes/tsx/routes";
+import { wellKnownRoutes } from "./routes/oauth2/well-known";
+import { userRoutes } from "./routes/management-api/users";
 import { registerComponent } from "./middlewares/register-component";
-import { usersByEmail } from "./routes/management-api/users-by-email";
-import { tenants } from "./routes/management-api/tenants";
-import { logs } from "./routes/management-api/logs";
-import { applications } from "./routes/management-api/applications";
-import { callback } from "./routes/oauth2/callback";
-import { connections } from "./routes/management-api/connections";
-import { domains } from "./routes/management-api/domains";
-import { keys } from "./routes/management-api/keys";
+import { usersByEmailRoutes } from "./routes/management-api/users-by-email";
+import { tenantRoutes } from "./routes/management-api/tenants";
+import { logRoutes } from "./routes/management-api/logs";
+import { applicationRoutes } from "./routes/management-api/applications";
+import { callbackRoutes } from "./routes/oauth2/callback";
+import { connectionRoutes } from "./routes/management-api/connections";
+import { domainRoutes } from "./routes/management-api/domains";
+import { keyRoutes } from "./routes/management-api/keys";
 import { tailwindCss } from "./styles/tailwind";
 import { logoutRoutes } from "./routes/oauth2/logout";
 import { dbConnectionRoutes } from "./routes/oauth2/dbconnections";
@@ -89,10 +89,10 @@ const app = rootApp
   });
 
 export const oauthApp = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
-  .route("/u", login)
-  .route("/.well-known", wellKnown)
+  .route("/u", loginRoutes)
+  .route("/.well-known", wellKnownRoutes)
   .route("/authorize", authorizeRoutes)
-  .route("/callback", callback)
+  .route("/callback", callbackRoutes)
   .route("/userinfo", userinfoRoutes)
   .route("/oauth/token", tokenRoutes)
   .route("/dbconnections", dbConnectionRoutes)
@@ -115,14 +115,14 @@ export const managementApp = new OpenAPIHono<{
   Variables: Var;
 }>()
   .route("/api/v2/branding", brandingRoutes)
-  .route("/api/v2/domains", domains)
-  .route("/api/v2/users", users)
-  .route("/api/v2/keys/signing", keys)
-  .route("/api/v2/users-by-email", usersByEmail)
-  .route("/api/v2/applications", applications)
-  .route("/api/v2/tenants", tenants)
-  .route("/api/v2/logs", logs)
-  .route("/api/v2/connections", connections);
+  .route("/api/v2/domains", domainRoutes)
+  .route("/api/v2/users", userRoutes)
+  .route("/api/v2/keys/signing", keyRoutes)
+  .route("/api/v2/users-by-email", usersByEmailRoutes)
+  .route("/api/v2/applications", applicationRoutes)
+  .route("/api/v2/tenants", tenantRoutes)
+  .route("/api/v2/logs", logRoutes)
+  .route("/api/v2/connections", connectionRoutes);
 
 registerComponent(managementApp);
 

--- a/src/routes/management-api/applications.ts
+++ b/src/routes/management-api/applications.ts
@@ -9,7 +9,7 @@ import { auth0QuerySchema } from "../../types/auth0/Query";
 import { parseSort } from "../../utils/sort";
 import authenticationMiddleware from "../../middlewares/authentication";
 
-export const applications = new OpenAPIHono<{ Bindings: Env }>()
+export const applicationRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /applications
   // --------------------------------

--- a/src/routes/management-api/connections.ts
+++ b/src/routes/management-api/connections.ts
@@ -16,7 +16,7 @@ const connectionsWithTotalsSchema = totalsSchema.extend({
   connections: z.array(connectionSchema),
 });
 
-export const connections = new OpenAPIHono<{ Bindings: Env }>()
+export const connectionRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /api/v2/connections
   // --------------------------------

--- a/src/routes/management-api/domains.ts
+++ b/src/routes/management-api/domains.ts
@@ -12,7 +12,7 @@ const domainWithTotalsSchema = totalsSchema.extend({
   domains: z.array(domainSchema),
 });
 
-export const domains = new OpenAPIHono<{ Bindings: Env }>()
+export const domainRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /domains
   // --------------------------------

--- a/src/routes/management-api/keys.ts
+++ b/src/routes/management-api/keys.ts
@@ -6,7 +6,7 @@ import authenticationMiddleware from "../../middlewares/authentication";
 
 const DAY = 1000 * 60 * 60 * 24;
 
-export const keys = new OpenAPIHono<{ Bindings: Env }>()
+export const keyRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /keys
   // --------------------------------

--- a/src/routes/management-api/logs.ts
+++ b/src/routes/management-api/logs.ts
@@ -9,7 +9,7 @@ const logsWithTotalsSchema = totalsSchema.extend({
   logs: z.array(logSchema),
 });
 
-export const logs = new OpenAPIHono<{ Bindings: Env }>()
+export const logRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /logs
   // --------------------------------

--- a/src/routes/management-api/tenants.ts
+++ b/src/routes/management-api/tenants.ts
@@ -10,7 +10,7 @@ const tenantsWithTotalsSchema = totalsSchema.extend({
   tenants: z.array(tenantSchema),
 });
 
-export const tenants = new OpenAPIHono<{ Bindings: Env }>()
+export const tenantRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /tenants
   // --------------------------------

--- a/src/routes/management-api/users-by-email.ts
+++ b/src/routes/management-api/users-by-email.ts
@@ -6,7 +6,10 @@ import { Env, userSchema } from "../../types";
 import { Var } from "../../types/Var";
 import authenticationMiddleware from "../../middlewares/authentication";
 
-export const usersByEmail = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
+export const usersByEmailRoutes = new OpenAPIHono<{
+  Bindings: Env;
+  Variables: Var;
+}>()
   // --------------------------------
   // GET /api/v2/users-by-email
   // --------------------------------

--- a/src/routes/management-api/users.ts
+++ b/src/routes/management-api/users.ts
@@ -22,7 +22,7 @@ const usersWithTotalsSchema = totalsSchema.extend({
   users: z.array(auth0UserResponseSchema),
 });
 
-export const users = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
+export const userRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
   // --------------------------------
   // GET /api/v2/users
   // --------------------------------

--- a/src/routes/oauth2/callback.ts
+++ b/src/routes/oauth2/callback.ts
@@ -6,7 +6,10 @@ import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Var } from "../../types/Var";
 
-export const callback = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
+export const callbackRoutes = new OpenAPIHono<{
+  Bindings: Env;
+  Variables: Var;
+}>()
   // --------------------------------
   // GET /callback
   // --------------------------------

--- a/src/routes/oauth2/well-known.ts
+++ b/src/routes/oauth2/well-known.ts
@@ -7,7 +7,7 @@ import {
 import { Env } from "../../types";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 
-export const wellKnown = new OpenAPIHono<{ Bindings: Env }>()
+export const wellKnownRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /.well-known/jwks.json
   // --------------------------------

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -111,7 +111,7 @@ async function handleLogin(
   );
 }
 
-export const login = new OpenAPIHono<{ Bindings: Env }>()
+export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /u/login
   // --------------------------------


### PR DESCRIPTION
Rename for consistency. Appending the name with routes solves some of the name conflicts we had before.