### PR TITLE
fix: put exp and iat back into ID tokens

### DIFF
--- a/src/services/oauth2-client.ts
+++ b/src/services/oauth2-client.ts
@@ -81,6 +81,8 @@ export class OAuth2Client implements IOAuth2Client {
         iss: this.params.team_id,
         aud: "https://appleid.apple.com",
         sub: this.params.client_id,
+        exp: now + DAY_IN_SECONDS,
+        iat: now,
       },
       {
         headers: {

--- a/src/services/token-factory.ts
+++ b/src/services/token-factory.ts
@@ -67,13 +67,19 @@ export class TokenFactory {
 
   async getJwt(payload: AccessTokenPayload): Promise<string> {
     const keyBuffer = pemToBuffer(this.privateKeyPEM);
+    const now = Math.floor(Date.now() / 1000);
 
-    return createJWT("RS256", keyBuffer, payload, {
-      headers: {
-        kid: this.keyId,
-        expiresIn: DAY_IN_SECONDS,
+    return createJWT(
+      "RS256",
+      keyBuffer,
+      { ...payload, exp: now + DAY_IN_SECONDS, iat: now },
+      {
+        headers: {
+          kid: this.keyId,
+          expiresIn: DAY_IN_SECONDS,
+        },
       },
-    });
+    );
   }
 
   async createAccessToken({


### PR DESCRIPTION
This should fix the tests on login2. This is me running login2 against auth2 locally and I made fixes until it stopped complaining :smile: 

![image](https://github.com/sesamyab/auth/assets/8496063/793460e3-1163-478f-86cb-7795f3a5e77e)
