### PR TITLE
test: only upload snapshots on failure

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,6 @@ jobs:
       - run: yarn type-check
       - run: yarn test:snapshots
       - uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           path: test/**/__diff_output__/*.png

--- a/src/utils/components/LoginEnterCodePage.tsx
+++ b/src/utils/components/LoginEnterCodePage.tsx
@@ -24,6 +24,7 @@ const LoginEnterCodePage: FC<Props> = ({ error, vendorSettings, email }) => {
       <div class="mb-4 text-2xl font-medium">
         {i18next.t("verify_your_email")}
       </div>
+      <p>testing snapshots</p>
       <div class="mb-8 text-gray-300">
         {/* 
           not sure how to do this in i18next. translation string looks like 

--- a/src/utils/components/LoginEnterCodePage.tsx
+++ b/src/utils/components/LoginEnterCodePage.tsx
@@ -24,7 +24,6 @@ const LoginEnterCodePage: FC<Props> = ({ error, vendorSettings, email }) => {
       <div class="mb-4 text-2xl font-medium">
         {i18next.t("verify_your_email")}
       </div>
-      <p>testing snapshots</p>
       <div class="mb-8 text-gray-300">
         {/* 
           not sure how to do this in i18next. translation string looks like 


### PR DESCRIPTION
This is in all the Nextjs repos. I copy-pasted it from a Gleb Bahmutov blog article, but now I understand what it does


If one step failures then I would expect the other steps not to run *unless* we specify e.g. `always()`

#### Proof this works?

See penultimate commit!