### PR TITLE
test: run tests on every push

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@
 
 name: Unit tests
 
-on: pull_request
+on: push
 
 jobs:
   node-test:


### PR DESCRIPTION
We aren't actually running the tests after updating `main`. So we could have situations where `main` has failing tests because we aren't forcing PRs to be up-to-date before merging them (and I don't think we should it can become a nightmare :smile: )

We aren't doing anything here though if main fails, I just keep an eye on it when merging lots of PRs