### PR TITLE
feat: HTML5 form validation required fields

### DIFF
--- a/src/utils/components/LoginEnterCodePage.tsx
+++ b/src/utils/components/LoginEnterCodePage.tsx
@@ -50,15 +50,12 @@ const LoginEnterCodePage: FC<Props> = ({ error, vendorSettings, email }) => {
                 "border-gray-100 dark:border-gray-500": !error,
               },
             )}
+            minLength={CODE_LENGTH}
+            required
           />
           {error && <ErrorMessage>{error}</ErrorMessage>}
           <div class="text-center sm:mt-2">
-            <Button
-            // how to do this without clientside JS?
-            // disabled={when 6 digits are not entered}
-            >
-              {i18next.t("validate_code")}
-            </Button>
+            <Button>{i18next.t("validate_code")}</Button>
           </div>
           <div class="my-4 flex space-x-2 text-sm text-[#B2B2B2]">
             <Icon className="text-base" name="info-bubble" />

--- a/src/utils/components/LoginWithCodePage.tsx
+++ b/src/utils/components/LoginWithCodePage.tsx
@@ -45,6 +45,7 @@ const LoginWithCodePage: FC<Props> = ({ error, vendorSettings, session }) => {
                 "border-gray-100 dark:border-gray-500": !error,
               },
             )}
+            required
           />
           {error && <ErrorMessage>{error}</ErrorMessage>}
           <Button className="text-base sm:mt-4 md:text-base">


### PR DESCRIPTION
There are a few cases where we block the CTA button if something is not filled e.g. code entry, email entry

I'll do the code on this PR *BUT* ~I think I'll need JavaScript~ :smile:   *no actually* :thinking:   This can be done just using HTML5 form validation

This is probably better UX even though it might not be on brand (the validation messages are native to the browser)

Comments welcome. We could ask the other frontenders what they think
This is still an improvement!