### PR TITLE
fix: set email input to type email

### DIFF
--- a/src/utils/components/LoginWithCodePage.tsx
+++ b/src/utils/components/LoginWithCodePage.tsx
@@ -35,7 +35,7 @@ const LoginWithCodePage: FC<Props> = ({ error, vendorSettings, session }) => {
       <div class="flex flex-1 flex-col justify-center">
         <form method="post" className="mb-7">
           <input
-            type="text"
+            type="email"
             name="username"
             placeholder={i18next.t("email_placeholder")}
             className={cn(


### PR DESCRIPTION
I get the feeling I never use the native input types because they don't play well with React e.g. the `onChange` event is only fired after a change results in a valid value

*but* we're not using any clientside JS...