### PR TITLE
test: have mock vendor settings fetcher return vendor settings based on param

### DIFF
--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -741,7 +741,7 @@ describe("password-flow", () => {
   describe("Password reset", () => {
     it("should send password reset email for existing user, and allow password to be changed", async () => {
       const env = await getEnv({
-        vendorSettings: FOKUS_VENDOR_SETTINGS,
+        vendor_id: "fokus",
         testTenantLanguage: "sv",
       });
       const oauthClient = testClient(oauthApp, env);
@@ -850,7 +850,7 @@ describe("password-flow", () => {
     });
     it("should reject weak passwords", async () => {
       const env = await getEnv({
-        vendorSettings: KVARTAL_VENDOR_SETTINGS,
+        vendor_id: "kvartal",
         testTenantLanguage: "nb",
       });
       const oauthClient = testClient(oauthApp, env);
@@ -891,7 +891,7 @@ describe("password-flow", () => {
     });
     it("should reject non-matching confirmation password", async () => {
       const env = await getEnv({
-        vendorSettings: BREAKIT_VENDOR_SETTINGS,
+        vendor_id: "breakit",
         testTenantLanguage: "it",
       });
 

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -14,15 +14,19 @@ import { mockOAuth2ClientFactory } from "../mockOauth2Client";
 import { Connection } from "../../../src/types/Connection";
 import type { Client } from "../../../src/types";
 import type { EmailOptions } from "../../../src/services/email/EmailOptions";
-import { SESAMY_VENDOR_SETTINGS } from "../../fixtures/vendorSettings";
+import {
+  SESAMY_VENDOR_SETTINGS,
+  KVARTAL_VENDOR_SETTINGS,
+  BREAKIT_VENDOR_SETTINGS,
+  FOKUS_VENDOR_SETTINGS,
+} from "../../fixtures/vendorSettings";
 
 type getEnvParams = {
-  vendorSettings?: VendorSettings;
   testTenantLanguage?: string;
 };
 
 export async function getEnv(args?: getEnvParams) {
-  const vendorSettings = args?.vendorSettings ?? SESAMY_VENDOR_SETTINGS;
+  // const vendorSettings = args?.vendorSettings ?? SESAMY_VENDOR_SETTINGS;
   const testTenantLanguage = args?.testTenantLanguage;
 
   const dialect = new SqliteDialect({
@@ -218,7 +222,23 @@ export async function getEnv(args?: getEnvParams) {
     db,
     oauth2ClientFactory: mockOAuth2ClientFactory,
     fetchVendorSettings: async (tenantName: string) => {
-      return vendorSettings;
+      if (tenantName === "sesamy") {
+        return SESAMY_VENDOR_SETTINGS;
+      }
+
+      if (tenantName === "kvartal") {
+        return KVARTAL_VENDOR_SETTINGS;
+      }
+
+      if (tenantName === "breakit") {
+        return BREAKIT_VENDOR_SETTINGS;
+      }
+
+      if (tenantName === "fokus") {
+        return FOKUS_VENDOR_SETTINGS;
+      }
+
+      return SESAMY_VENDOR_SETTINGS;
     },
   };
 }

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -22,11 +22,12 @@ import {
 } from "../../fixtures/vendorSettings";
 
 type getEnvParams = {
+  // TODO - get this from /authorize params in UniversalLoginSession next
+  vendor_id?: string;
   testTenantLanguage?: string;
 };
 
 export async function getEnv(args?: getEnvParams) {
-  // const vendorSettings = args?.vendorSettings ?? SESAMY_VENDOR_SETTINGS;
   const testTenantLanguage = args?.testTenantLanguage;
 
   const dialect = new SqliteDialect({
@@ -222,19 +223,23 @@ export async function getEnv(args?: getEnvParams) {
     db,
     oauth2ClientFactory: mockOAuth2ClientFactory,
     fetchVendorSettings: async (tenantName: string) => {
-      if (tenantName === "sesamy") {
+      if (!args || !args.vendor_id) {
         return SESAMY_VENDOR_SETTINGS;
       }
 
-      if (tenantName === "kvartal") {
+      if (args.vendor_id === "sesamy") {
+        return SESAMY_VENDOR_SETTINGS;
+      }
+
+      if (args.vendor_id === "kvartal") {
         return KVARTAL_VENDOR_SETTINGS;
       }
 
-      if (tenantName === "breakit") {
+      if (args.vendor_id === "breakit") {
         return BREAKIT_VENDOR_SETTINGS;
       }
 
-      if (tenantName === "fokus") {
+      if (args.vendor_id === "fokus") {
         return FOKUS_VENDOR_SETTINGS;
       }
 

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -39,7 +39,7 @@ describe("Login with code on liquidjs template", () => {
   });
   it("should create new user when email does not exist", async () => {
     const env = await getEnv({
-      vendorSettings: FOKUS_VENDOR_SETTINGS,
+      vendor_id: "fokus",
       testTenantLanguage: "nb",
     });
     const oauthClient = testClient(oauthApp, env);
@@ -640,7 +640,7 @@ describe("Login with code on liquidjs template", () => {
 
   test('snapshot desktop "enter code" form', async () => {
     const env = await getEnv({
-      vendorSettings: FOKUS_VENDOR_SETTINGS,
+      vendor_id: "fokus",
       testTenantLanguage: "nb",
     });
     const oauthClient = testClient(oauthApp, env);
@@ -672,7 +672,7 @@ describe("Login with code on liquidjs template", () => {
 
   test('snapshot mobile "enter code" form', async () => {
     const env = await getEnv({
-      vendorSettings: FOKUS_VENDOR_SETTINGS,
+      vendor_id: "fokus",
       testTenantLanguage: "nb",
     });
     const oauthClient = testClient(oauthApp, env);

--- a/test/integration/login/login-password.spec.ts
+++ b/test/integration/login/login-password.spec.ts
@@ -9,7 +9,7 @@ import { AuthorizationResponseType } from "../../../src/types";
 describe("Login with password user", () => {
   it("should login with password", async () => {
     const env = await getEnv({
-      vendorSettings: KVARTAL_VENDOR_SETTINGS,
+      vendor_id: "kvartal",
       testTenantLanguage: "en",
     });
     const oauthClient = testClient(oauthApp, env);

--- a/test/integration/login/register-password-user.spec.ts
+++ b/test/integration/login/register-password-user.spec.ts
@@ -9,7 +9,7 @@ import { AuthorizationResponseType } from "../../../src/types";
 describe("Register password user", () => {
   it("should register a new user with password", async () => {
     const env = await getEnv({
-      vendorSettings: BREAKIT_VENDOR_SETTINGS,
+      vendor_id: "breakit",
       testTenantLanguage: "it",
     });
     const oauthClient = testClient(oauthApp, env);


### PR DESCRIPTION
I'm doing this first before then getting `vendor_id` from the params passed to `/authorize` on  https://github.com/sesamyab/auth/pull/818 