### PR TITLE
fix: return tokens not doc

### DIFF
--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -49,6 +49,5 @@ export async function authorizeCodeGrant(
     responseType: AuthorizationResponseType.TOKEN_ID_TOKEN,
   });
 
-  console.log("tokens", tokens);
   return ctx.json(tokens);
 }

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -7,10 +7,9 @@ import {
   Var,
 } from "../types";
 import { getClient } from "../services/clients";
-import hash from "../utils/hash";
 import { stateDecode } from "../utils/stateEncode";
 import { HTTPException } from "hono/http-exception";
-import { generateAuthResponse } from "../helpers/generate-auth-response";
+import { generateAuthData } from "../helpers/generate-auth-response";
 import { Context } from "hono";
 
 export async function authorizeCodeGrant(
@@ -43,7 +42,7 @@ export async function authorizeCodeGrant(
     throw new HTTPException(403, { message: "Invalid Secret" });
   }
 
-  return generateAuthResponse({
+  return generateAuthData({
     ...state,
     env: ctx.env,
     tenantId: client.tenant_id,

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -42,11 +42,13 @@ export async function authorizeCodeGrant(
     throw new HTTPException(403, { message: "Invalid Secret" });
   }
 
-  const tokens = generateAuthData({
+  const tokens = await generateAuthData({
     ...state,
     env: ctx.env,
     tenantId: client.tenant_id,
     responseType: AuthorizationResponseType.TOKEN_ID_TOKEN,
   });
+
+  console.log("tokens", tokens);
   return ctx.json(tokens);
 }

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -42,10 +42,11 @@ export async function authorizeCodeGrant(
     throw new HTTPException(403, { message: "Invalid Secret" });
   }
 
-  return generateAuthData({
+  const tokens = generateAuthData({
     ...state,
     env: ctx.env,
     tenantId: client.tenant_id,
     responseType: AuthorizationResponseType.TOKEN_ID_TOKEN,
   });
+  return ctx.json(tokens);
 }


### PR DESCRIPTION
`/oauth/token` should return JSON e.g.

![image](https://github.com/sesamyab/auth/assets/8496063/d36aa770-169e-4861-9bef-f745922c2527)


But we were returning a redirect with the tokens appended to the URL e.g. the implicit flow

Looks working locally now :smile: 

![image](https://github.com/sesamyab/auth/assets/8496063/00c3a3c4-5d63-489c-a5ee-32eae7f1d6e1)


I'll force merge this if the tests pass


*AFTER*
we should
* write tests for this
* do the same change on the other token flows