### PR TITLE
fix: return 400s for other error routes

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -265,6 +265,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
               error={i18next.t("invalid_password")}
               state={state}
             />,
+            400,
           );
         }
 
@@ -277,6 +278,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
             error={err.message}
             state={state}
           />,
+          400,
         );
       }
     },
@@ -977,6 +979,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
         );
         return ctx.html(
           <SignupPage vendorSettings={vendorSettings} error={err.message} />,
+          400,
         );
       }
     },

--- a/test/integration/login/register-password-user.spec.ts
+++ b/test/integration/login/register-password-user.spec.ts
@@ -134,7 +134,7 @@ describe("Register password user", () => {
     const signupSearchParamsQuery = Object.fromEntries(
       signupSearchParams.entries(),
     );
-    // Enter weak passworrd
+    // Enter weak password
     const postSignupResponse = await oauthClient.u.signup.$post({
       query: { state: signupSearchParamsQuery.state },
       form: {
@@ -143,7 +143,7 @@ describe("Register password user", () => {
       },
     });
 
-    expect(postSignupResponse.status).toBe(200);
+    expect(postSignupResponse.status).toBe(400);
 
     await snapshotResponse(postSignupResponse);
   });


### PR DESCRIPTION
We should be returning 400s for all JSX error pages (I've gone through manually and checked)