### PR TITLE
feat: add focus state to button

### DIFF
--- a/src/styles/tailwind.ts
+++ b/src/styles/tailwind.ts
@@ -1228,6 +1228,17 @@ input[type="number"] {
   text-decoration-line: underline;
 }
 
+.focus\\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\\:ring:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .dark\\:border-gray-400:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(75 74 88 / var(--tw-border-opacity));

--- a/src/utils/components/Button.tsx
+++ b/src/utils/components/Button.tsx
@@ -25,12 +25,18 @@ const Button: FC<Props> = ({
   const hrefProps = Component === "a" ? { href } : {};
   return (
     <Component
-      class={cn("relative w-full rounded-lg text-center px-4 py-5", className, {
-        "bg-primary text-textOnPrimary hover:bg-primaryHover":
-          variant === "primary",
-        "border border-gray-300 bg-white text-black": variant === "secondary",
-        "pointer-events-none cursor-not-allowed opacity-40": disabled,
-      })}
+      class={cn(
+        "relative w-full rounded-lg text-center px-4 py-5",
+        className,
+        {
+          "bg-primary text-textOnPrimary hover:bg-primaryHover":
+            variant === "primary",
+          "border border-gray-300 bg-white text-black": variant === "secondary",
+          "pointer-events-none cursor-not-allowed opacity-40": disabled,
+        },
+        // focus styles
+        "focus:outline-none focus:ring focus:ring-violet-300",
+      )}
       type="submit"
       disabled={disabled}
       {...hrefProps}


### PR DESCRIPTION
This is what Auth0 does on their universal login forms.  This seems fine to me, it gives the impression that something happens, and the requests shouldn't take _that_ long

[Screencast from 2024-05-23 10-17-35.webm](https://github.com/sesamyab/auth/assets/8496063/5e32bd4c-20ab-4b5b-915d-ed5ee590ba89)


The colour isn't on brand though it's just copied from https://tailwindcss.com/docs/hover-focus-and-other-states#hover-focus-and-active