### PR TITLE
feat: use required email inputs

### DIFF
--- a/src/utils/components/ForgotPasswordPage.tsx
+++ b/src/utils/components/ForgotPasswordPage.tsx
@@ -25,10 +25,11 @@ const ForgotPasswordPage: FC<Props> = ({ error, vendorSettings }) => {
       <div class="flex flex-1 flex-col justify-center">
         <form method="post">
           <input
-            type="text"
+            type="email"
             name="username"
             placeholder={i18next.t("email_placeholder")}
             class="mb-2 w-full rounded-lg bg-gray-100 px-4 py-5 text-base placeholder:text-gray-300 dark:bg-gray-600 md:text-base"
+            required
           />
           {error && <ErrorMessage>{error}</ErrorMessage>}
           <DisabledSubmitButton>

--- a/src/utils/components/SignUpPage.tsx
+++ b/src/utils/components/SignUpPage.tsx
@@ -25,10 +25,11 @@ const SignupPage: FC<Props> = ({ error, vendorSettings }) => {
       <div class="flex flex-1 flex-col justify-center">
         <form method="post">
           <input
-            type="text"
+            type="email"
             name="username"
             placeholder={i18next.t("email_placeholder")}
             class="mb-2 w-full rounded-lg bg-gray-100 px-4 py-5 text-base placeholder:text-gray-300 dark:bg-gray-600 md:text-base"
+            required
           />
           <input
             type="password"


### PR DESCRIPTION
Seems pretty low hanging fruit to force the user to enter an email before hitting submit

We're using an email input on the first step