### PR TITLE
feat: migration universal auth state field to long

### DIFF
--- a/migrate/migrations/2024-05-24T16:25:00_increase-universal-auth-state-length.ts
+++ b/migrate/migrations/2024-05-24T16:25:00_increase-universal-auth-state-length.ts
@@ -1,0 +1,33 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // Uncomment this for planetscale migration
+  //   await db.schema
+  //     .alterTable("universal_login_sessions")
+  //     // column this long working on planetscale on logs column
+  //     .modifyColumn("state", "varchar(8192)")
+  //     .execute();
+
+  // In SQLite we have to drop and recreate the column
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .dropColumn("state")
+    .execute();
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .addColumn("state", "varchar(8192)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .dropColumn("state")
+    .execute();
+
+  await db.schema
+    .alterTable("universal_login_sessions")
+    .addColumn("state", "varchar(1024)")
+    .execute();
+}

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -32,6 +32,7 @@ import * as n31_branding from "./2024-05-09T08:50:00_branding";
 import * as n32_indexesAndNotNull from "./2024-05-14T07:53:00_indexes_and_not_null";
 import * as n33_vendorIdInUniversalLoginSession from "./2024-05-16T10:45:00_vendor_id_in_universal_login_session";
 import * as n34_auth0ClientInUniversalLoginSession from "./2024-05-23T15:53:00_auth0client_in_universal_login_session";
+import * as n35_increaseUniversalSessionStateLength from "./2024-05-24T16:25:00_increase-universal-auth-state-length";
 
 // These need to be in alphabetic order
 export default {
@@ -69,4 +70,5 @@ export default {
   n32_indexesAndNotNull,
   n33_vendorIdInUniversalLoginSession,
   n34_auth0ClientInUniversalLoginSession,
+  n35_increaseUniversalSessionStateLength,
 };


### PR DESCRIPTION
I checked on planetscale and I don't see any other tables with such a short state field