### PR TITLE
fix: do not await sending emails

### DIFF
--- a/src/authentication-flows/passwordless.ts
+++ b/src/authentication-flows/passwordless.ts
@@ -6,11 +6,12 @@ import {
   getPrimaryUserByEmailAndProvider,
   getPrimaryUserByEmail,
 } from "../utils/users";
-import { User, Client, AuthParams } from "../types";
+import { User, Client, AuthParams, Var } from "../types";
 import { UniversalLoginSession } from "../adapters/interfaces/UniversalLoginSession";
 import { nanoid } from "nanoid";
 import generateOTP from "../utils/otp";
 import { UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS } from "../constants";
+import { Context } from "hono";
 import { sendValidateEmailAddress } from "../controllers/email";
 
 // de-dupe
@@ -83,16 +84,17 @@ export async function validateCode(
 // can we mock templates? or even properly use them?
 
 interface sendEmailVerificationEmailParams {
-  env: Env;
+  ctx: Context<{ Bindings: Env; Variables: Var }> | Context<{ Bindings: Env }>;
   client: Client;
   user: User;
 }
 
 export async function sendEmailVerificationEmail({
-  env,
+  ctx,
   client,
   user,
 }: sendEmailVerificationEmailParams) {
+  const { env } = ctx;
   const authParams: AuthParams = {
     client_id: client.id,
     username: user.email,
@@ -125,5 +127,5 @@ export async function sendEmailVerificationEmail({
     expires_at: new Date(Date.now() + CODE_EXPIRATION_TIME).toISOString(),
   });
 
-  await sendValidateEmailAddress(env, client, user.email, code, state);
+  await sendValidateEmailAddress(ctx, client, user.email, code, state);
 }

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -63,7 +63,7 @@ export async function ticketAuth(
       }
 
       await sendEmailVerificationEmail({
-        env,
+        ctx,
         client,
         user,
       });

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,6 +1,6 @@
 import { Liquid } from "liquidjs";
 import { translate } from "../utils/i18n";
-import { Client, Env } from "../types";
+import { Client, Env, Var } from "../types";
 import { getClientLogoPngGreyBg } from "../utils/clientLogos";
 import en from "../locales/en/default.json";
 import sv from "../locales/sv/default.json";
@@ -12,6 +12,8 @@ import {
   passwordReset,
   verifyEmail,
 } from "../templates/email/ts";
+import { waitUntil } from "../utils/wait-until";
+import { Context } from "hono";
 
 const SUPPORTED_LOCALES: { [key: string]: object } = {
   en,
@@ -30,13 +32,15 @@ function getLocale(language: string) {
 const engine = new Liquid();
 
 export async function sendCode(
-  env: Env,
+  ctx: Context<{ Bindings: Env; Variables: Var }> | Context<{ Bindings: Env }>,
   client: Client,
   to: string,
   code: string,
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
+
+  const { env } = ctx;
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||
@@ -65,26 +69,29 @@ export async function sendCode(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  env.sendEmail(client, {
-    to: [{ email: to, name: to }],
-    from: {
-      email: client.tenant.sender_email,
-      name: client.tenant.sender_name,
-    },
-    content: [
-      {
-        type: "text/html",
-        value: codeEmailBody,
+  waitUntil(
+    ctx,
+    env.sendEmail(client, {
+      to: [{ email: to, name: to }],
+      from: {
+        email: client.tenant.sender_email,
+        name: client.tenant.sender_name,
       },
-    ],
-    subject: translate(language, "codeEmailTitle")
-      .replace("{{vendorName}}", client.tenant.name)
-      .replace("{{code}}", code),
-  });
+      content: [
+        {
+          type: "text/html",
+          value: codeEmailBody,
+        },
+      ],
+      subject: translate(language, "codeEmailTitle")
+        .replace("{{vendorName}}", client.tenant.name)
+        .replace("{{code}}", code),
+    }),
+  );
 }
 
 export async function sendLink(
-  env: Env,
+  ctx: Context<{ Bindings: Env; Variables: Var }> | Context<{ Bindings: Env }>,
   client: Client,
   to: string,
   code: string,
@@ -92,6 +99,7 @@ export async function sendLink(
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
+  const { env } = ctx;
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||
@@ -123,26 +131,29 @@ export async function sendLink(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  env.sendEmail(client, {
-    to: [{ email: to, name: to }],
-    from: {
-      email: client.tenant.sender_email,
-      name: client.tenant.sender_name,
-    },
-    content: [
-      {
-        type: "text/html",
-        value: codeEmailBody,
+  waitUntil(
+    ctx,
+    env.sendEmail(client, {
+      to: [{ email: to, name: to }],
+      from: {
+        email: client.tenant.sender_email,
+        name: client.tenant.sender_name,
       },
-    ],
-    subject: translate(language, "codeEmailTitle")
-      .replace("{{vendorName}}", client.tenant.name)
-      .replace("{{code}}", code),
-  });
+      content: [
+        {
+          type: "text/html",
+          value: codeEmailBody,
+        },
+      ],
+      subject: translate(language, "codeEmailTitle")
+        .replace("{{vendorName}}", client.tenant.name)
+        .replace("{{code}}", code),
+    }),
+  );
 }
 
 export async function sendResetPassword(
-  env: Env,
+  ctx: Context<{ Bindings: Env; Variables: Var }> | Context<{ Bindings: Env }>,
   client: Client,
   to: string,
   // auth0 just has a ticket, but we have a code and a state
@@ -151,6 +162,7 @@ export async function sendResetPassword(
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
+  const { env } = ctx;
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||
@@ -184,27 +196,30 @@ export async function sendResetPassword(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  env.sendEmail(client, {
-    to: [{ email: to, name: to }],
-    from: {
-      email: client.tenant.sender_email,
-      name: client.tenant.sender_name,
-    },
-    content: [
-      {
-        type: "text/html",
-        value: passwordResetBody,
+  waitUntil(
+    ctx,
+    env.sendEmail(client, {
+      to: [{ email: to, name: to }],
+      from: {
+        email: client.tenant.sender_email,
+        name: client.tenant.sender_name,
       },
-    ],
-    subject: translate(language, "passwordResetTitle").replace(
-      "{{vendorName}}",
-      client.tenant.name,
-    ),
-  });
+      content: [
+        {
+          type: "text/html",
+          value: passwordResetBody,
+        },
+      ],
+      subject: translate(language, "passwordResetTitle").replace(
+        "{{vendorName}}",
+        client.tenant.name,
+      ),
+    }),
+  );
 }
 
 export async function sendValidateEmailAddress(
-  env: Env,
+  ctx: Context<{ Bindings: Env; Variables: Var }> | Context<{ Bindings: Env }>,
   client: Client,
   to: string,
   code: string,
@@ -213,6 +228,7 @@ export async function sendValidateEmailAddress(
   // const response = await env.AUTH_TEMPLATES.get(
   //   "templates/email/verify-email.liquid",
   // );
+  const { env } = ctx;
 
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
@@ -249,21 +265,24 @@ export async function sendValidateEmailAddress(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  env.sendEmail(client, {
-    to: [{ email: to, name: to }],
-    from: {
-      email: client.tenant.sender_email,
-      name: client.tenant.sender_name,
-    },
-    content: [
-      {
-        type: "text/html",
-        value: emailValidationBody,
+  waitUntil(
+    ctx,
+    env.sendEmail(client, {
+      to: [{ email: to, name: to }],
+      from: {
+        email: client.tenant.sender_email,
+        name: client.tenant.sender_name,
       },
-    ],
-    subject: translate(language, "verifyEmailTitle").replace(
-      "{{vendorName}}",
-      client.tenant.name,
-    ),
-  });
+      content: [
+        {
+          type: "text/html",
+          value: emailValidationBody,
+        },
+      ],
+      subject: translate(language, "verifyEmailTitle").replace(
+        "{{vendorName}}",
+        client.tenant.name,
+      ),
+    }),
+  );
 }

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -65,7 +65,7 @@ export async function sendCode(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  await env.sendEmail(client, {
+  env.sendEmail(client, {
     to: [{ email: to, name: to }],
     from: {
       email: client.tenant.sender_email,
@@ -123,7 +123,7 @@ export async function sendLink(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  await env.sendEmail(client, {
+  env.sendEmail(client, {
     to: [{ email: to, name: to }],
     from: {
       email: client.tenant.sender_email,
@@ -184,7 +184,7 @@ export async function sendResetPassword(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  await env.sendEmail(client, {
+  env.sendEmail(client, {
     to: [{ email: to, name: to }],
     from: {
       email: client.tenant.sender_email,
@@ -249,7 +249,7 @@ export async function sendValidateEmailAddress(
     buttonColor: client.tenant.primary_color || "#7d68f4",
   });
 
-  await env.sendEmail(client, {
+  env.sendEmail(client, {
     to: [{ email: to, name: to }],
     from: {
       email: client.tenant.sender_email,

--- a/src/routes/oauth2/dbconnections.ts
+++ b/src/routes/oauth2/dbconnections.ts
@@ -105,7 +105,7 @@ export const dbConnectionRoutes = new OpenAPIHono<{
       });
 
       await sendEmailVerificationEmail({
-        env: ctx.env,
+        ctx,
         client,
         user: newUser,
       });
@@ -198,7 +198,7 @@ export const dbConnectionRoutes = new OpenAPIHono<{
         expires_at: new Date(Date.now() + CODE_EXPIRATION_TIME).toISOString(),
       });
 
-      await sendResetPassword(ctx.env, client, email, code, state);
+      await sendResetPassword(ctx, client, email, code, state);
 
       return ctx.html("We've just sent you an email to reset your password.");
     },

--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -101,9 +101,9 @@ export const passwordlessRoutes = new OpenAPIHono<{
         magicLink.searchParams.set("email", email);
         magicLink.searchParams.set("verification_code", code);
 
-        await sendLink(ctx.env, client, email, code, magicLink.href);
+        await sendLink(ctx, client, email, code, magicLink.href);
       } else {
-        await sendCode(ctx.env, client, email, code);
+        await sendCode(ctx, client, email, code);
       }
 
       return ctx.html("OK");

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -642,7 +642,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
         // Get typescript errors here but works on the mgmt api users route...
         // ctx.set("log", `Code: ${code}`);
 
-        await sendResetPassword(env, client, username, code, state);
+        await sendResetPassword(ctx, client, username, code, state);
       } else {
         console.log("User not found");
       }
@@ -804,9 +804,9 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
         magicLink.searchParams.set("verification_code", code);
         magicLink.searchParams.set("nonce", "nonce");
 
-        await sendLink(env, client, params.username, code, magicLink.href);
+        await sendLink(ctx, client, params.username, code, magicLink.href);
       } else {
-        await sendCode(env, client, params.username, code);
+        await sendCode(ctx, client, params.username, code);
       }
 
       return ctx.redirect(
@@ -1076,7 +1076,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
         });
 
         await sendEmailVerificationEmail({
-          env: ctx.env,
+          ctx,
           client,
           user: newUser,
         });


### PR DESCRIPTION
As Markus pointed out, we're not actually awaiting sending emails before changing page on login2

I had intended to do that, but I haven't promisified the auth0.js `passwordless/start` handler, so the await was doing nothing :smile: 

![image](https://github.com/sesamyab/auth/assets/8496063/e1ce3f6e-1efc-4dd1-adc2-1bd190aca45d)
