### PR TITLE
test: code authorization flow

### DIFF
--- a/test/integration/login/code-authorization.spec.ts
+++ b/test/integration/login/code-authorization.spec.ts
@@ -3,6 +3,7 @@ import { getEnv } from "../helpers/test-client";
 import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import { AuthorizationResponseType } from "../../../src/types";
+import { parseJwt } from "../../../src/utils/parse-jwt";
 
 test("code authorization flow should work", async () => {
   const env = await getEnv({
@@ -51,5 +52,42 @@ test("code authorization flow should work", async () => {
 
   const code = redirectUrl.searchParams.get("code");
 
-  console.log(code);
+  // --------------------------------
+  // exchange code for token
+  // --------------------------------
+
+  const tokenResponse = await oauthClient.oauth.token.$post({
+    form: {
+      grant_type: "authorization_code",
+      code: code!,
+      client_id: "clientId",
+      // this is the client_secret in DEFAULT_CLIENT
+      client_secret: "secret",
+      redirect_uri: "http://localhost:3000/callback",
+    },
+  });
+
+  expect(tokenResponse.status).toBe(200);
+
+  const tokens = (await tokenResponse.json()) as {
+    access_token: string;
+    id_token: string;
+    token_type: string;
+    expires_in: number;
+  };
+
+  const accessTokenPayload = parseJwt(tokens.access_token!);
+
+  expect(accessTokenPayload.sub).toEqual("auth2|userId");
+
+  const idTokenPayload = parseJwt(tokens.id_token!);
+
+  expect(idTokenPayload.sub).toEqual("auth2|userId");
+
+  // TO TEST? more fields on tokens?
 });
+
+// TO TEST
+// invalid secret?
+// invalid code?
+// invalid client_id?

--- a/test/integration/login/pkce.spec.ts
+++ b/test/integration/login/pkce.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, test, expect } from "vitest";
+import { EmailOptions } from "../../../src/services/email/EmailOptions";
+import { getEnv } from "../helpers/test-client";
+import { oauthApp } from "../../../src/app";
+import { testClient } from "hono/testing";
+import {
+  snapshotResponse,
+  snapshotEmail,
+} from "../helpers/playwrightSnapshots";
+import { AuthorizationResponseType } from "../../../src/types";
+
+test("PKCE flow should work", async () => {
+  const env = await getEnv({
+    testTenantLanguage: "en",
+  });
+  const oauthClient = testClient(oauthApp, env);
+  const searchParams = {
+    client_id: "clientId",
+    vendor_id: "kvartal",
+    //   This is the test! Every other test is using TOKEN or ID_TOKEN here
+    response_type: AuthorizationResponseType.CODE,
+    scope: "openid",
+    redirect_uri: "http://localhost:3000/callback",
+    state: "state",
+  };
+  const response = await oauthClient.authorize.$get({
+    query: searchParams,
+  });
+  expect(response.status).toBe(302);
+  const location = response.headers.get("location");
+  expect(location!.startsWith("/u/login")).toBeTruthy;
+  const stateParam = new URLSearchParams(location!.split("?")[1]);
+  const query = Object.fromEntries(stateParam.entries());
+  // Open login page
+  const loginFormResponse = await oauthClient.u.login.$get({
+    query: {
+      state: query.state,
+      username: "foo@example.com",
+    },
+  });
+  expect(loginFormResponse.status).toBe(200);
+  const loginSearchParams = new URLSearchParams(location!.split("?")[1]);
+  const loginSearchParamsQuery = Object.fromEntries(
+    loginSearchParams.entries(),
+  );
+  await snapshotResponse(loginFormResponse);
+  const postLoginResponse = await oauthClient.u.login.$post({
+    query: {
+      state: loginSearchParamsQuery.state,
+      username: "foo@example.com",
+    },
+    form: {
+      password: "Test1234!",
+    },
+  });
+  expect(postLoginResponse.status).toBe(302);
+  const loginLocation = postLoginResponse.headers.get("location");
+  const redirectUrl = new URL(loginLocation!);
+  expect(redirectUrl.pathname).toBe("/callback");
+
+  const code = redirectUrl.searchParams.get("code");
+
+  console.log(code);
+});

--- a/test/integration/login/pkce.spec.ts
+++ b/test/integration/login/pkce.spec.ts
@@ -1,12 +1,7 @@
-import { describe, it, test, expect } from "vitest";
-import { EmailOptions } from "../../../src/services/email/EmailOptions";
+import { test, expect } from "vitest";
 import { getEnv } from "../helpers/test-client";
 import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
-import {
-  snapshotResponse,
-  snapshotEmail,
-} from "../helpers/playwrightSnapshots";
 import { AuthorizationResponseType } from "../../../src/types";
 
 test("PKCE flow should work", async () => {
@@ -43,7 +38,7 @@ test("PKCE flow should work", async () => {
   const loginSearchParamsQuery = Object.fromEntries(
     loginSearchParams.entries(),
   );
-  await snapshotResponse(loginFormResponse);
+
   const postLoginResponse = await oauthClient.u.login.$post({
     query: {
       state: loginSearchParamsQuery.state,


### PR DESCRIPTION
This doesn't look tested anywhere, thus why we had the issue with the token service not being able to read the tokens from the hash fragment :smile: 