### PR TITLE
feat: add user not found page without prefix to allowed callback urls

### DIFF
--- a/src/utils/validate-redirect-url.ts
+++ b/src/utils/validate-redirect-url.ts
@@ -41,19 +41,23 @@ const ALLOWED_CALLBACK_URLS = [
   "http://localhost:3000",
   "http://localhost:3000/callback",
   "http://localhost:3000/link",
+  // TODO - delete these breakit- prefixed pages
   "http://localhost:3000/breakit-user-not-found",
+  "http://localhost:3000/user-not-found",
   // login2 dev
   "https://login2.sesamy.dev/",
   "https://login2.sesamy.dev/enter-code",
   "https://login2.sesamy.dev/callback",
   "https://login2.sesamy.dev/link",
   "https://login2.sesamy.dev/breakit-user-not-found",
+  "https://login2.sesamy.dev/user-not-found",
   // login2 prod
   "https://login2.sesamy.com/",
   "https://login2.sesamy.com/enter-code",
   "https://login2.sesamy.com/callback",
   "https://login2.sesamy.com/link",
   "https://login2.sesamy.com/breakit-user-not-found",
+  "https://login2.sesamy.com/user-not-found",
   // vercel preview deploys
   "https://*.vercel.sesamy.dev",
   "https://*.vercel.sesamy.dev/enter-code",
@@ -61,6 +65,7 @@ const ALLOWED_CALLBACK_URLS = [
   "https://*.vercel.sesamy.dev/enter-code",
   "https://*.vercel.sesamy.dev/link",
   "https://*.vercel.sesamy.dev/breakit-user-not-found",
+  "https://*.vercel.sesamy.dev/user-not-found",
   // example.com
   "http://example.com",
   "http://login.example.com",


### PR DESCRIPTION
This is needed for this PR to pass https://github.com/sesamyab/login2/pull/755

It's an odd flow on login2. The user is logged in when they do an SSO login _but then_ we check if they have any purchases, and if not we log them out

Thus why we're checking allowed callback URLs... they're more like allowed logout URLs though :see_no_evil: 