### PR TITLE
fix: social sign on buttons conditionality

### DIFF
--- a/test/integration/social-sign-on-buttons.spec.ts
+++ b/test/integration/social-sign-on-buttons.spec.ts
@@ -1,0 +1,14 @@
+import { test } from "vitest";
+import { testClient } from "hono/testing";
+import { getEnv } from "./helpers/test-client";
+import { oauthApp } from "../../src/app";
+
+test("should hide social buttons for fokus", () => {
+  // see open PR
+  // seed tenants & clients with fokus id
+});
+
+test("should show social buttons for parcferme", () => {
+  // see open PR
+  // seed tenants & clients with parceferme id
+});


### PR DESCRIPTION
IIRC we decided not to launch parcferme or fokus currently so we'll leave the social buttons always displaying