### PR TITLE
fix: back button goes to first step

### DIFF
--- a/src/utils/components/LoginEnterCodePage.tsx
+++ b/src/utils/components/LoginEnterCodePage.tsx
@@ -107,7 +107,8 @@ const LoginEnterCodePage: FC<Props> = ({
           )}
           <a
             className="block text-primary hover:text-primaryHover text-center"
-            href="javascript:history.go(-1)"
+            // TODO - when we release password login, "back" might mean going back to the password login page
+            href={`/u/code?${passwordLoginLinkParams.toString()}`}
           >
             {i18next.t("go_back")}
           </a>


### PR DESCRIPTION
As Markus pointed out, after multiple form submissions, the back button will go back to the browser state in the previous form submission