### PR TITLE
fix: add username to state before changing page

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -726,6 +726,10 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
       const { env } = ctx;
       const { client, session } = await initJSXRoute(state, env);
 
+      // Add the username to the state
+      session.authParams.username = params.username;
+      await env.data.universalLoginSessions.update(session.id, session);
+
       const passwordLoginSelection =
         parsePasswordLoginSelectionCookie(
           getCookie(ctx, getPasswordLoginSelectionCookieName(client.id)),
@@ -763,10 +767,6 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
       });
 
       // request.ctx.set("log", `Code: ${code}`);
-
-      // Add the username to the state
-      session.authParams.username = params.username;
-      await env.data.universalLoginSessions.update(session.id, session);
 
       const sendType = getSendParamFromAuth0ClientHeader(session.auth0Client);
 


### PR DESCRIPTION
Fixes this issue

[Screencast from 2024-05-31 17-22-57.webm](https://github.com/sesamyab/auth/assets/8496063/eeee95c5-1758-457f-abe7-923fd52b5fc1)


#### Tests
* sadly they don't actual test a real flow so I can't write a test to show that this flow was broken (although we could inspect the session)


#### Next
* I'll remove the `username` querystring param and I'll always read the `username` from the state