### PR TITLE
fix: waitUntil when sending code/link email on universal auth to improve time to next page

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -43,6 +43,7 @@ import {
   parsePasswordLoginSelectionCookie,
 } from "../../utils/authCookies";
 import { setCookie, getCookie } from "hono/cookie";
+import { waitUntil } from "../../utils/wait-until";
 
 const DEFAULT_SESAMY_VENDOR = {
   name: "sesamy",
@@ -804,9 +805,12 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env }>()
         magicLink.searchParams.set("verification_code", code);
         magicLink.searchParams.set("nonce", "nonce");
 
-        await sendLink(env, client, params.username, code, magicLink.href);
+        waitUntil(
+          ctx,
+          sendLink(env, client, params.username, code, magicLink.href),
+        );
       } else {
-        await sendCode(env, client, params.username, code);
+        waitUntil(ctx, sendCode(env, client, params.username, code));
       }
 
       return ctx.redirect(

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -756,6 +756,7 @@ describe("Login with code on liquidjs template", () => {
       },
     });
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     // this should not have a magic link in it
     await snapshotEmail(env.data.emails[0], true);
   });

--- a/test/integration/login/code-flow-liquidjs.spec.ts
+++ b/test/integration/login/code-flow-liquidjs.spec.ts
@@ -114,6 +114,9 @@ describe("Login with code on liquidjs template", () => {
     expect(postSendCodeResponse.status).toBe(302);
     const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+    // flush pipe
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(env.data.emails.length).toBe(1);
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("test@example.com");
 
@@ -221,6 +224,7 @@ describe("Login with code on liquidjs template", () => {
     });
     const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("bar@example.com");
 
@@ -307,6 +311,7 @@ describe("Login with code on liquidjs template", () => {
     });
     const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("foo@example.com");
 
@@ -372,6 +377,7 @@ describe("Login with code on liquidjs template", () => {
     });
     const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("foo@example.com");
 
@@ -543,6 +549,7 @@ describe("Login with code on liquidjs template", () => {
 
       const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+      await new Promise((resolve) => setTimeout(resolve, 0));
       const { to, code } = getCodeAndTo(env.data.emails[0]);
 
       expect(to).toBe("same-email@example.com");
@@ -786,6 +793,7 @@ describe("Login with code on liquidjs template", () => {
       new URLSearchParams(enterCodeParams).entries(),
     );
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("foo@example.com");
 
@@ -890,6 +898,7 @@ describe("Login with code on liquidjs template", () => {
 
     const enterCodeLocation = postSendCodeResponse.headers.get("location");
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     const { to, code } = getCodeAndTo(env.data.emails[0]);
     expect(to).toBe("john-doe@example.com");
 


### PR DESCRIPTION
As requested on https://github.com/sesamyab/auth/pull/870 - was easier to recreate the PR

We should manually A/B test this before and after merging

This is me running it on wrangler locally... I think it's marginally quicker. I prefer using machines to measure though :smile: 

[Screencast from 2024-06-03 11-41-16.webm](https://github.com/sesamyab/auth/assets/8496063/740fc4ac-7ab2-4e60-b75e-82e49d962a70)
