### PR TITLE
feat: if email_hint is passed to `/authorize` then go straight to the enter code step

### DIFF
--- a/src/authentication-flows/universal.ts
+++ b/src/authentication-flows/universal.ts
@@ -10,12 +10,14 @@ interface UniversalAuthParams {
   ctx: Context<{ Bindings: Env; Variables: Var }>;
   authParams: AuthParams;
   auth0Client?: string;
+  emailHint?: string;
 }
 
 export async function universalAuth({
   ctx,
   authParams,
   auth0Client,
+  emailHint,
 }: UniversalAuthParams) {
   const client = await getClient(ctx.env, authParams.client_id);
 
@@ -36,6 +38,11 @@ export async function universalAuth({
   };
 
   await ctx.env.data.universalLoginSessions.create(session);
+
+  if (emailHint) {
+    // TODO - need to send a code email here...
+    return ctx.redirect(`/u/enter-code?state=${session.id}`);
+  }
 
   return ctx.redirect(`/u/code?state=${session.id}`);
 }

--- a/src/authentication-flows/universal.ts
+++ b/src/authentication-flows/universal.ts
@@ -5,6 +5,10 @@ import { UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS } from "../constants";
 import { nanoid } from "nanoid";
 import { UniversalLoginSession } from "../adapters/interfaces/UniversalLoginSession";
 import { getClient } from "../services/clients";
+import generateOTP from "../utils/otp";
+import { getSendParamFromAuth0ClientHeader } from "../utils/getSendParamFromAuth0ClientHeader";
+import { waitUntil } from "../utils/wait-until";
+import { sendCode, sendLink } from "../controllers/email";
 
 interface UniversalAuthParams {
   ctx: Context<{ Bindings: Env; Variables: Var }>;
@@ -40,7 +44,81 @@ export async function universalAuth({
   await ctx.env.data.universalLoginSessions.create(session);
 
   if (emailHint) {
-    // TODO - need to send a code email here...
+    const { env } = ctx;
+    // TODO - extract this out as a helper. Duplciated on routes as well
+    // need this code again for when user hits "enter a code instead" button on the password entry page
+    const code = generateOTP();
+
+    const {
+      audience,
+      code_challenge_method,
+      code_challenge,
+      username,
+      vendor_id,
+      ...otpAuthParams
+    } = session.authParams;
+
+    // duplicated in many places under many names
+    const OTP_EXPIRATION_TIME = 30 * 60 * 1000;
+
+    await env.data.OTP.create({
+      id: nanoid(),
+      code,
+      // should we be doing any cleaning here?
+      email: emailHint,
+      client_id: session.authParams.client_id,
+      send: "code",
+      authParams: otpAuthParams,
+      tenant_id: client.tenant_id,
+      created_at: new Date(),
+      expires_at: new Date(Date.now() + OTP_EXPIRATION_TIME),
+    });
+
+    // request.ctx.set("log", `Code: ${code}`);
+
+    const sendType = getSendParamFromAuth0ClientHeader(session.auth0Client);
+
+    // TODO - read cookie here to decide if go to password entry step?
+
+    if (sendType === "link") {
+      const magicLink = new URL(env.ISSUER);
+      magicLink.pathname = "passwordless/verify_redirect";
+      if (session.authParams.scope) {
+        magicLink.searchParams.set("scope", session.authParams.scope);
+      }
+      if (session.authParams.response_type) {
+        magicLink.searchParams.set(
+          "response_type",
+          session.authParams.response_type,
+        );
+      }
+      if (session.authParams.redirect_uri) {
+        magicLink.searchParams.set(
+          "redirect_uri",
+          session.authParams.redirect_uri,
+        );
+      }
+      if (session.authParams.audience) {
+        magicLink.searchParams.set("audience", session.authParams.audience);
+      }
+      if (session.authParams.state) {
+        magicLink.searchParams.set("state", session.authParams.state);
+      }
+      if (session.authParams.nonce) {
+        magicLink.searchParams.set("nonce", session.authParams.nonce);
+      }
+
+      magicLink.searchParams.set("connection", "email");
+      magicLink.searchParams.set("client_id", session.authParams.client_id);
+      magicLink.searchParams.set("email", emailHint);
+      magicLink.searchParams.set("verification_code", code);
+      magicLink.searchParams.set("nonce", "nonce");
+
+      waitUntil(ctx, sendLink(env, client, emailHint, code, magicLink.href));
+    } else {
+      waitUntil(ctx, sendCode(env, client, emailHint, code));
+    }
+
     return ctx.redirect(`/u/enter-code?state=${session.id}`);
   }
 

--- a/src/routes/oauth2/authorize.ts
+++ b/src/routes/oauth2/authorize.ts
@@ -53,7 +53,7 @@ export const authorizeRoutes = new OpenAPIHono<{
           code_challenge: z.string().optional(),
           realm: z.string().optional(),
           auth0Client: z.string().optional(),
-          email_hint: z.string().optional(),
+          login_hint: z.string().optional(),
         }),
       },
       responses: {
@@ -84,7 +84,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         realm,
         auth0Client,
         username,
-        email_hint,
+        login_hint,
       } = ctx.req.valid("query");
 
       const client = await getClient(env, client_id);
@@ -103,7 +103,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         response_type,
         code_challenge,
         code_challenge_method,
-        username: username || email_hint,
+        username: username || login_hint,
       };
 
       const origin = ctx.req.header("origin");
@@ -167,7 +167,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         ctx,
         authParams,
         auth0Client,
-        emailHint: email_hint,
+        emailHint: login_hint,
       });
     },
   );

--- a/src/routes/oauth2/authorize.ts
+++ b/src/routes/oauth2/authorize.ts
@@ -53,6 +53,7 @@ export const authorizeRoutes = new OpenAPIHono<{
           code_challenge: z.string().optional(),
           realm: z.string().optional(),
           auth0Client: z.string().optional(),
+          email_hint: z.string().optional(),
         }),
       },
       responses: {
@@ -83,6 +84,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         realm,
         auth0Client,
         username,
+        email_hint,
       } = ctx.req.valid("query");
 
       const client = await getClient(env, client_id);
@@ -101,7 +103,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         response_type,
         code_challenge,
         code_challenge_method,
-        username,
+        username: username || email_hint,
       };
 
       const origin = ctx.req.header("origin");
@@ -161,6 +163,11 @@ export const authorizeRoutes = new OpenAPIHono<{
         );
       }
 
-      return universalAuth({ ctx, authParams, auth0Client });
+      return universalAuth({
+        ctx,
+        authParams,
+        auth0Client,
+        emailHint: email_hint,
+      });
     },
   );

--- a/test/integration/login/email-hint.spec.ts
+++ b/test/integration/login/email-hint.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "vitest";
+import { getEnv } from "../helpers/test-client";
+import { oauthApp } from "../../../src/app";
+import { testClient } from "hono/testing";
+import { AuthorizationResponseType } from "../../../src/types";
+
+test("Should go to code entry step if email_hint is passed to /authorize", async () => {
+  const env = await getEnv();
+  const oauthClient = testClient(oauthApp, env);
+
+  const response = await oauthClient.authorize.$get({
+    query: {
+      client_id: "clientId",
+      vendor_id: "fokus",
+      response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
+      scope: "openid",
+      redirect_uri: "http://localhost:3000/callback",
+      state: "state",
+      // this is the difference on this test
+      email_hint: "suggested-email@example.com",
+    },
+  });
+
+  expect(response.status).toBe(302);
+
+  const location = response.headers.get("location");
+
+  // ----------------------------------------------
+  // We should have gone straight to the code entry page
+  // ----------------------------------------------
+  expect(location).toContain("/u/enter-code");
+
+  // ----------------------------------------------
+  // Expect a code email to have been sent
+  // ----------------------------------------------
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(env.data.emails.length).toBe(1);
+});

--- a/test/integration/login/email-hint.spec.ts
+++ b/test/integration/login/email-hint.spec.ts
@@ -4,7 +4,7 @@ import { oauthApp } from "../../../src/app";
 import { testClient } from "hono/testing";
 import { AuthorizationResponseType } from "../../../src/types";
 
-test("Should go to code entry step if email_hint is passed to /authorize", async () => {
+test("Should go to code entry step if login_hint is passed to /authorize", async () => {
   const env = await getEnv();
   const oauthClient = testClient(oauthApp, env);
 
@@ -17,7 +17,7 @@ test("Should go to code entry step if email_hint is passed to /authorize", async
       redirect_uri: "http://localhost:3000/callback",
       state: "state",
       // this is the difference on this test
-      email_hint: "suggested-email@example.com",
+      login_hint: "suggested-email@example.com",
     },
   });
 


### PR DESCRIPTION
This replicates `/check-account` on login2 and is already coded in the token service

*but* there's no silent auth in Auth2, so that is a difference to `login2/check-account`