### PR TITLE
feat: extract out magic link helpers

### DIFF
--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,6 +1,6 @@
 import { Liquid } from "liquidjs";
 import { translate } from "../utils/i18n";
-import { Client, Env } from "../types";
+import { AuthParams, Client, Env } from "../types";
 import { getClientLogoPngGreyBg } from "../utils/clientLogos";
 import en from "../locales/en/default.json";
 import sv from "../locales/sv/default.json";
@@ -90,15 +90,17 @@ export async function sendLink(
   client: Client,
   to: string,
   code: string,
-  session: UniversalLoginSession,
+  authParams: AuthParams,
+  email: string,
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
 
   const magicLink = createMagicLink({
     issuer: env.ISSUER,
-    session,
     code,
+    authParams,
+    email,
   });
 
   const logo = getClientLogoPngGreyBg(

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -91,7 +91,6 @@ export async function sendLink(
   to: string,
   code: string,
   authParams: AuthParams,
-  email: string,
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
@@ -100,7 +99,7 @@ export async function sendLink(
     issuer: env.ISSUER,
     code,
     authParams,
-    email,
+    email: to,
   });
 
   const logo = getClientLogoPngGreyBg(

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -12,6 +12,8 @@ import {
   passwordReset,
   verifyEmail,
 } from "../templates/email/ts";
+import { createMagicLink } from "../utils/magicLink";
+import { UniversalLoginSession } from "../adapters/interfaces/UniversalLoginSession";
 
 const SUPPORTED_LOCALES: { [key: string]: object } = {
   en,
@@ -88,10 +90,16 @@ export async function sendLink(
   client: Client,
   to: string,
   code: string,
-  magicLink: string,
+  session: UniversalLoginSession,
 ) {
   const language = client.tenant.language || "sv";
   const locale = getLocale(language);
+
+  const magicLink = createMagicLink({
+    issuer: env.ISSUER,
+    session,
+    code,
+  });
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||

--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -76,33 +76,17 @@ export const passwordlessRoutes = new OpenAPIHono<{
       });
 
       if (send === "link") {
-        const magicLink = new URL(ctx.env.ISSUER);
-        magicLink.pathname = "passwordless/verify_redirect";
-        if (authParams.scope) {
-          magicLink.searchParams.set("scope", authParams.scope);
-        }
-        if (authParams.response_type) {
-          magicLink.searchParams.set("response_type", authParams.response_type);
-        }
-        if (authParams.redirect_uri) {
-          magicLink.searchParams.set("redirect_uri", authParams.redirect_uri);
-        }
-        if (authParams.audience) {
-          magicLink.searchParams.set("audience", authParams.audience);
-        }
-        if (authParams.state) {
-          magicLink.searchParams.set("state", authParams.state);
-        }
-        if (authParams.nonce) {
-          magicLink.searchParams.set("nonce", authParams.nonce);
-        }
-
-        magicLink.searchParams.set("connection", connection);
-        magicLink.searchParams.set("client_id", client_id);
-        magicLink.searchParams.set("email", email);
-        magicLink.searchParams.set("verification_code", code);
-
-        await sendLink(ctx.env, client, email, code, magicLink.href);
+        await sendLink(
+          ctx.env,
+          client,
+          email,
+          code,
+          {
+            ...authParams,
+            client_id,
+          },
+          email,
+        );
       } else {
         await sendCode(ctx.env, client, email, code);
       }

--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -76,17 +76,10 @@ export const passwordlessRoutes = new OpenAPIHono<{
       });
 
       if (send === "link") {
-        await sendLink(
-          ctx.env,
-          client,
-          email,
-          code,
-          {
-            ...authParams,
-            client_id,
-          },
-          email,
-        );
+        await sendLink(ctx.env, client, email, code, {
+          ...authParams,
+          client_id,
+        });
       } else {
         await sendCode(ctx.env, client, email, code);
       }

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -805,14 +805,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
 
         waitUntil(
           ctx,
-          sendLink(
-            env,
-            client,
-            params.username,
-            code,
-            session.authParams,
-            params.username,
-          ),
+          sendLink(env, client, params.username, code, session.authParams),
         );
       } else {
         waitUntil(ctx, sendCode(env, client, params.username, code));

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -805,7 +805,14 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
 
         waitUntil(
           ctx,
-          sendLink(env, client, params.username, code, magicLink.href),
+          sendLink(
+            env,
+            client,
+            params.username,
+            code,
+            session.authParams,
+            params.username,
+          ),
         );
       } else {
         waitUntil(ctx, sendCode(env, client, params.username, code));

--- a/src/utils/magicLink.ts
+++ b/src/utils/magicLink.ts
@@ -1,45 +1,38 @@
-import { UniversalLoginSession } from "../adapters/interfaces/UniversalLoginSession";
+import { AuthParams } from "../types";
 
 type Args = {
   issuer: string;
-  session: UniversalLoginSession;
+  authParams: AuthParams;
   code: string;
+  email: string;
 };
 
-export function createMagicLink({ issuer, session, code }: Args) {
+export function createMagicLink({ issuer, authParams, code, email }: Args) {
   const magicLink = new URL(issuer);
   magicLink.pathname = "passwordless/verify_redirect";
 
-  if (!session.authParams.username) {
-    // this should have been populated on the email entry step
-    throw new Error("username is required in session");
+  if (authParams.scope) {
+    magicLink.searchParams.set("scope", authParams.scope);
   }
-
-  if (session.authParams.scope) {
-    magicLink.searchParams.set("scope", session.authParams.scope);
+  if (authParams.response_type) {
+    magicLink.searchParams.set("response_type", authParams.response_type);
   }
-  if (session.authParams.response_type) {
-    magicLink.searchParams.set(
-      "response_type",
-      session.authParams.response_type,
-    );
+  if (authParams.redirect_uri) {
+    magicLink.searchParams.set("redirect_uri", authParams.redirect_uri);
   }
-  if (session.authParams.redirect_uri) {
-    magicLink.searchParams.set("redirect_uri", session.authParams.redirect_uri);
+  if (authParams.audience) {
+    magicLink.searchParams.set("audience", authParams.audience);
   }
-  if (session.authParams.audience) {
-    magicLink.searchParams.set("audience", session.authParams.audience);
+  if (authParams.state) {
+    magicLink.searchParams.set("state", authParams.state);
   }
-  if (session.authParams.state) {
-    magicLink.searchParams.set("state", session.authParams.state);
-  }
-  if (session.authParams.nonce) {
-    magicLink.searchParams.set("nonce", session.authParams.nonce);
+  if (authParams.nonce) {
+    magicLink.searchParams.set("nonce", authParams.nonce);
   }
 
   magicLink.searchParams.set("connection", "email");
-  magicLink.searchParams.set("client_id", session.authParams.client_id);
-  magicLink.searchParams.set("email", session.authParams.username);
+  magicLink.searchParams.set("client_id", authParams.client_id);
+  magicLink.searchParams.set("email", email);
   magicLink.searchParams.set("verification_code", code);
   magicLink.searchParams.set("nonce", "nonce");
 

--- a/src/utils/magicLink.ts
+++ b/src/utils/magicLink.ts
@@ -1,0 +1,47 @@
+import { UniversalLoginSession } from "../adapters/interfaces/UniversalLoginSession";
+
+type Args = {
+  issuer: string;
+  session: UniversalLoginSession;
+  code: string;
+};
+
+export function createMagicLink({ issuer, session, code }: Args) {
+  const magicLink = new URL(issuer);
+  magicLink.pathname = "passwordless/verify_redirect";
+
+  if (!session.authParams.username) {
+    // this should have been populated on the email entry step
+    throw new Error("username is required in session");
+  }
+
+  if (session.authParams.scope) {
+    magicLink.searchParams.set("scope", session.authParams.scope);
+  }
+  if (session.authParams.response_type) {
+    magicLink.searchParams.set(
+      "response_type",
+      session.authParams.response_type,
+    );
+  }
+  if (session.authParams.redirect_uri) {
+    magicLink.searchParams.set("redirect_uri", session.authParams.redirect_uri);
+  }
+  if (session.authParams.audience) {
+    magicLink.searchParams.set("audience", session.authParams.audience);
+  }
+  if (session.authParams.state) {
+    magicLink.searchParams.set("state", session.authParams.state);
+  }
+  if (session.authParams.nonce) {
+    magicLink.searchParams.set("nonce", session.authParams.nonce);
+  }
+
+  magicLink.searchParams.set("connection", "email");
+  magicLink.searchParams.set("client_id", session.authParams.client_id);
+  magicLink.searchParams.set("email", session.authParams.username);
+  magicLink.searchParams.set("verification_code", code);
+  magicLink.searchParams.set("nonce", "nonce");
+
+  return magicLink.href;
+}


### PR DESCRIPTION
This seems the lowest hanging fruit for de-duplicating repeated code for sending code emails. We have enough code coverage and snapshots of emails that the :heavy_check_mark:s are enough for me :+1: 

I still need to send at least one more code email (when clicking the _use a code_ button on the password page)