### PR TITLE
chore: rename components

### DIFF
--- a/src/components/EnterCodePage.tsx
+++ b/src/components/EnterCodePage.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 const CODE_LENGTH = 6;
 
-const LoginEnterCodePage: FC<Props> = ({
+const EnterCodePage: FC<Props> = ({
   error,
   vendorSettings,
   email,
@@ -114,4 +114,4 @@ const LoginEnterCodePage: FC<Props> = ({
   );
 };
 
-export default LoginEnterCodePage;
+export default EnterCodePage;

--- a/src/components/EnterEmailPage.tsx
+++ b/src/components/EnterEmailPage.tsx
@@ -21,8 +21,7 @@ type Props = {
   client: Client;
 };
 
-// this page is called enter-email on login2... maybe we should copy those page names
-const LoginWithCodePage: FC<Props> = ({
+const EnterEmailPage: FC<Props> = ({
   error,
   vendorSettings,
   session,
@@ -138,4 +137,4 @@ const LoginWithCodePage: FC<Props> = ({
   );
 };
 
-export default LoginWithCodePage;
+export default EnterEmailPage;

--- a/src/components/EnterPassword.tsx
+++ b/src/components/EnterPassword.tsx
@@ -15,7 +15,7 @@ type Props = {
   state: string;
 };
 
-const LoginPage: FC<Props> = ({ error, vendorSettings, email, state }) => {
+const EnterPassword: FC<Props> = ({ error, vendorSettings, email, state }) => {
   const loginLinkParams = new URLSearchParams({
     state,
   });
@@ -84,4 +84,4 @@ const LoginPage: FC<Props> = ({ error, vendorSettings, email, state }) => {
   );
 };
 
-export default LoginPage;
+export default EnterPassword;

--- a/src/components/EnterPasswordPage.tsx
+++ b/src/components/EnterPasswordPage.tsx
@@ -15,7 +15,12 @@ type Props = {
   state: string;
 };
 
-const EnterPassword: FC<Props> = ({ error, vendorSettings, email, state }) => {
+const EnterPasswordPage: FC<Props> = ({
+  error,
+  vendorSettings,
+  email,
+  state,
+}) => {
   const loginLinkParams = new URLSearchParams({
     state,
   });
@@ -84,4 +89,4 @@ const EnterPassword: FC<Props> = ({ error, vendorSettings, email, state }) => {
   );
 };
 
-export default EnterPassword;
+export default EnterPasswordPage;

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -14,9 +14,9 @@ import en from "../../localesLogin2/en/default.json";
 import it from "../../localesLogin2/it/default.json";
 import nb from "../../localesLogin2/nb/default.json";
 import sv from "../../localesLogin2/sv/default.json";
-import LoginPage from "../../components/LoginPage";
-import LoginWithCodePage from "../../components/LoginWithCodePage";
-import LoginEnterCodePage from "../../components/LoginEnterCodePage";
+import EnterPasswordPage from "../../components/EnterPasswordPage";
+import EnterEmailPage from "../../components/EnterEmailPage";
+import EnterCodePage from "../../components/EnterCodePage";
 import SignupPage from "../../components/SignUpPage";
 import UnverifiedEmail from "../../components/UnverifiedEmailPage";
 import MessagePage from "../../components/Message";
@@ -192,7 +192,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
       }
 
       return ctx.html(
-        <LoginPage
+        <EnterPasswordPage
           vendorSettings={vendorSettings}
           email={session.authParams.username}
           state={state}
@@ -256,7 +256,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
 
       if (!user) {
         return ctx.html(
-          <LoginPage
+          <EnterPasswordPage
             vendorSettings={vendorSettings}
             email={username}
             error={i18next.t("invalid_password")}
@@ -273,7 +273,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
 
       if (!valid) {
         return ctx.html(
-          <LoginPage
+          <EnterPasswordPage
             vendorSettings={vendorSettings}
             email={username}
             error={i18next.t("invalid_password")}
@@ -322,7 +322,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         return handleLogin(env, primaryUser, session, ctx, client);
       } catch (err: any) {
         return ctx.html(
-          <LoginPage
+          <EnterPasswordPage
             vendorSettings={vendorSettings}
             email={username}
             error={err.message}
@@ -655,7 +655,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
       );
 
       return ctx.html(
-        <LoginWithCodePage
+        <EnterEmailPage
           vendorSettings={vendorSettings}
           session={session}
           client={client}
@@ -719,7 +719,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
 
         if (!user) {
           return ctx.html(
-            <LoginWithCodePage
+            <EnterEmailPage
               vendorSettings={vendorSettings}
               session={session}
               error={i18next.t("user_account_does_not_exist")}
@@ -875,7 +875,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
       }
 
       return ctx.html(
-        <LoginEnterCodePage
+        <EnterCodePage
           vendorSettings={vendorSettings}
           email={session.authParams.username}
           state={state}
@@ -951,7 +951,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         });
       } catch (err) {
         return ctx.html(
-          <LoginEnterCodePage
+          <EnterCodePage
             vendorSettings={vendorSettings}
             error={i18next.t("Wrong email or verification code.")}
             email={session.authParams.username}


### PR DESCRIPTION
Seems a sensible thing to do. The names don't bear relation to what the steps do now and it always takes me a moment to remember which is which

I wouldn't mind renaming the routes as well as `/u/code` is the email entry step