### PR TITLE
feat: log scoa after x-origin code login

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -12,6 +12,8 @@ import {
 } from "../utils/users";
 import { sendEmailVerificationEmail } from "./passwordless";
 import { getClient } from "../services/clients";
+import { createTypeLog } from "../tsoa-middlewares/logger";
+import { waitUntil } from "../utils/wait-until";
 
 function getProviderFromRealm(realm: string) {
   if (realm === "Username-Password-Authentication") {
@@ -195,6 +197,16 @@ export async function ticketAuth(
     // This is specific to cloudflare
     last_ip: ctx.req.header("cf-connecting-ip") || "",
   });
+
+  const log = createTypeLog(
+    "scoa",
+    ctx,
+    // do we want to tunnel the body through?
+    undefined,
+    "Successful cross-origin authentication",
+    { userId: user.id },
+  );
+  waitUntil(ctx, ctx.env.data.logs.create(tenant_id, log));
 
   return generateAuthResponse({
     env,

--- a/src/routes/oauth2/authenticate.ts
+++ b/src/routes/oauth2/authenticate.ts
@@ -1,18 +1,15 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { nanoid } from "nanoid";
 import randomString from "../../utils/random-string";
-import { Env, Ticket, Var } from "../../types";
+import { Env, Ticket } from "../../types";
 import { HTTPException } from "hono/http-exception";
 import { getClient } from "../../services/clients";
 import { getUserByEmailAndProvider } from "../../utils/users";
-import { createTypeLog } from "../../tsoa-middlewares/logger";
-import { waitUntil } from "../../utils/wait-until";
 
 const TICKET_EXPIRATION_TIME = 30 * 60 * 1000;
 
 export const authenticateRoutes = new OpenAPIHono<{
   Bindings: Env;
-  Variables: Var;
 }>()
   // --------------------------------
   // GET /co/authenticate
@@ -49,8 +46,7 @@ export const authenticateRoutes = new OpenAPIHono<{
       },
     }),
     async (ctx) => {
-      const body = ctx.req.valid("json");
-      const { client_id, username, otp, password } = body;
+      const { client_id, username, otp, password } = ctx.req.valid("json");
       const client = await getClient(ctx.env, client_id);
 
       if (!client) {

--- a/src/routes/oauth2/authenticate.ts
+++ b/src/routes/oauth2/authenticate.ts
@@ -124,14 +124,6 @@ export const authenticateRoutes = new OpenAPIHono<{
 
       await ctx.env.data.tickets.create(ticket);
 
-      const log = createTypeLog(
-        "scoa",
-        ctx,
-        body,
-        "Successful cross-origin authentication",
-      );
-      waitUntil(ctx, ctx.env.data.logs.create(client.tenant_id, log));
-
       return ctx.json({
         login_ticket: ticket.id,
         // TODO: I guess these should be validated when accepting the ticket

--- a/src/routes/oauth2/authenticate.ts
+++ b/src/routes/oauth2/authenticate.ts
@@ -8,9 +8,7 @@ import { getUserByEmailAndProvider } from "../../utils/users";
 
 const TICKET_EXPIRATION_TIME = 30 * 60 * 1000;
 
-export const authenticateRoutes = new OpenAPIHono<{
-  Bindings: Env;
-}>()
+export const authenticateRoutes = new OpenAPIHono<{ Bindings: Env }>()
   // --------------------------------
   // GET /co/authenticate
   // --------------------------------

--- a/src/tsoa-middlewares/logger.ts
+++ b/src/tsoa-middlewares/logger.ts
@@ -4,12 +4,19 @@ import { Var } from "../types/Var";
 import instanceToJson from "../utils/instanceToJson";
 import { LogType, Log } from "../types";
 
+type LogParams = {
+  userId?: string;
+};
+
 export function createTypeLog(
   logType: LogType,
   ctx: Context<{ Bindings: Env; Variables: Var }>,
   body: unknown,
   description?: string,
+  logParams?: LogParams,
 ) {
+  const { userId } = logParams || {};
+
   const log: Log = {
     type: logType,
     description: ctx.var.description || description || "",
@@ -28,7 +35,7 @@ export function createTypeLog(
     isMobile: false,
     client_id: ctx.var.client_id,
     client_name: "",
-    user_id: ctx.var.userId || "",
+    user_id: userId || ctx.var.userId || "",
     hostname: ctx.req.header("host") || "",
     user_name: ctx.var.userName || "",
     connection_id: "",

--- a/test/integration/flows/code-flow.spec.ts
+++ b/test/integration/flows/code-flow.spec.ts
@@ -141,6 +141,18 @@ describe("code-flow", () => {
     expect(idTokenPayload.email).toBe("test@example.com");
     expect(idTokenPayload.aud).toBe("clientId");
 
+    const { logs } = await env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 100,
+      include_totals: true,
+    });
+    expect(logs[0]).toMatchObject({
+      type: "scoa",
+      tenant_id: "tenantId",
+      user_id: accessTokenPayload.sub,
+      user_name: "test@example.com",
+    });
+
     // now check silent auth works when logged in with code----------------------------------------
     const setCookiesHeader = tokenResponse.headers.get("set-cookie")!;
 


### PR DESCRIPTION
After doing a code login on login2 pointing to auth0, we get these logs on the user object

![image](https://github.com/sesamyab/auth/assets/8496063/92c06ba8-55df-44a7-a379-12c95351a8fa)



On auth2 currently we get *nothing* it seems :smile: 


I would rather be explicit than go down the middleware approach *BUT* we did have logging working with the middleware approach  :thinking:   Was this a tsoa thing that doesn't work now?
