### PR TITLE
test: assert xorigin password logins are also logging scoa

### DIFF
--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -217,6 +217,16 @@ describe("password-flow", () => {
         tenant_id: "tenantId",
         user_id: accessTokenPayload.sub,
         user_name: "password-login-test@example.com",
+        connection: "Username-Password-Authentication",
+        // TODO - we also want these fields populated... maybe we want another test for this?
+        // auth0_client: {
+        //   name: "auth0.js",
+        //   version: "9.26.1",
+        // },
+        // client_id: "0N0wUHXFl0TMTY2L9aDJYvwX7Xy84HkW",
+        // date: "2024-06-10T10:30:50.545Z",
+        // ip: "78.46.40.111",
+        // user_agent: "Mobile Safari 17.4.0 / iOS 14.4.0",
       });
     });
 

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -206,6 +206,18 @@ describe("password-flow", () => {
         nonce: "unique-nonce",
         iss: "https://example.com/",
       });
+
+      const { logs } = await env.data.logs.list("tenantId", {
+        page: 0,
+        per_page: 100,
+        include_totals: true,
+      });
+      expect(logs[0]).toMatchObject({
+        type: "scoa",
+        tenant_id: "tenantId",
+        user_id: accessTokenPayload.sub,
+        user_name: "password-login-test@example.com",
+      });
     });
 
     // maybe this test should be broken up into login tests below... maybe we want more flows like this!


### PR DESCRIPTION
We were already logging this on the last PR (by logging any successful ticket auth as `scoa` ... which is correct I'm sure)

So this PR is just asserting this