### PR TITLE
fix: explicit log of slo

### DIFF
--- a/src/routes/oauth2/logout.ts
+++ b/src/routes/oauth2/logout.ts
@@ -55,17 +55,22 @@ export const logoutRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
       if (cookie) {
         const tokenState = getStateFromCookie(cookie);
         if (tokenState) {
-          // why was this code previously here that did nothing?
-          // const session = await ctx.env.data.sessions.get(
-          //   client.tenant_id,
-          //   tokenState,
-          // );
-          // if (session) {
-          //   const user = await ctx.env.data.users.get(
-          //     client.tenant_id,
-          //     session.user_id,
-          //   );
-          // }
+          const session = await ctx.env.data.sessions.get(
+            client.tenant_id,
+            tokenState,
+          );
+          if (session) {
+            const user = await ctx.env.data.users.get(
+              client.tenant_id,
+              session.user_id,
+            );
+            if (user) {
+              ctx.set("userName", user.email);
+              ctx.set("userId", user.id);
+              ctx.set("connection", user.connection);
+              ctx.set("client_id", client_id);
+            }
+          }
           await ctx.env.data.sessions.remove(client.tenant_id, tokenState);
         }
       }

--- a/src/routes/oauth2/logout.ts
+++ b/src/routes/oauth2/logout.ts
@@ -1,4 +1,4 @@
-import { Env } from "../../types";
+import { Env, Var } from "../../types";
 import { getClient } from "../../services/clients";
 import {
   getStateFromCookie,
@@ -7,8 +7,9 @@ import {
 import { validateRedirectUrl } from "../../utils/validate-redirect-url";
 import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { createTypeLog } from "../../tsoa-middlewares/logger";
 
-export const logoutRoutes = new OpenAPIHono<{ Bindings: Env }>()
+export const logoutRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
   // --------------------------------
   // GET /logout
   // --------------------------------
@@ -68,6 +69,9 @@ export const logoutRoutes = new OpenAPIHono<{ Bindings: Env }>()
           await ctx.env.data.sessions.remove(client.tenant_id, tokenState);
         }
       }
+      const log = createTypeLog("slo", ctx, "User successfully logged out");
+
+      await ctx.env.data.logs.create(client.tenant_id, log);
 
       return new Response("Redirecting", {
         status: 302,

--- a/test/integration/flows/logout.spec.ts
+++ b/test/integration/flows/logout.spec.ts
@@ -82,6 +82,19 @@ describe("logout", () => {
 
     expect(logoutResponse.status).toBe(302);
 
+    const { logs } = await env.data.logs.list("tenantId", {
+      page: 0,
+      per_page: 100,
+      include_totals: true,
+    });
+    expect(logs[0]).toMatchObject({
+      type: "slo",
+      tenant_id: "tenantId",
+      user_name: "foo@example.com",
+      connection: "Username-Password-Authentication",
+      client_id: "clientId",
+    });
+
     //--------------------------------------------------------------
     // Now reuse the previous auth cookie. This should no longer work because the session is cleared
     //--------------------------------------------------------------


### PR DESCRIPTION
We're not actually using this route on universal login because we aren't checking for silent auth cookies there (at least for now)

Still, logouts from login2 are live on production and tunnelled through the token service I believe!