### PR TITLE
feat: success signup dbconnections

### DIFF
--- a/src/routes/oauth2/dbconnections.ts
+++ b/src/routes/oauth2/dbconnections.ts
@@ -12,6 +12,7 @@ import validatePassword from "../../utils/validatePassword";
 import { sendResetPassword } from "../../controllers/email";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Var } from "../../types/Var";
+import { createTypeLog } from "../../tsoa-middlewares/logger";
 
 const CODE_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
 
@@ -109,6 +110,13 @@ export const dbConnectionRoutes = new OpenAPIHono<{
         client,
         user: newUser,
       });
+
+      ctx.set("userName", newUser.email);
+      ctx.set("connection", newUser.connection);
+      ctx.set("client_id", client.id);
+      const log = createTypeLog("ss", ctx, "Successful signup");
+
+      await ctx.env.data.logs.create(client.tenant_id, log);
 
       return ctx.json({
         _id: newUser.id,

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -110,6 +110,21 @@ describe("password-flow", () => {
       expect(login2RedirectUri2.searchParams.get("lang")).toBe("sv");
       expect(await loginBlockedRes.text()).toBe("Redirecting");
 
+      const {
+        logs: [successSignUpLog],
+      } = await env.data.logs.list("tenantId", {
+        page: 0,
+        per_page: 100,
+        include_totals: true,
+      });
+      expect(successSignUpLog).toMatchObject({
+        type: "ss",
+        tenant_id: "tenantId",
+        user_name: "password-login-test@example.com",
+        connection: "Username-Password-Authentication",
+        client_id: "clientId",
+      });
+
       // this is the original email sent after signing up
       const { to, code, state } = getCodeStateTo(env.data.emails[0]);
 


### PR DESCRIPTION
We probably won't ever use this endpoint on production *BUT* Auth0 Universal auth doesn't have code logins, so I'm checking what it logs for code sign ups on the auth0.js endpoints and copying that

Turns out there is no `success signup` event for a new code user. We simply get a `successful login/x-origin login` event