### PR TITLE
feat: log disabled signup

### DIFF
--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -727,6 +727,18 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         );
 
         if (!user) {
+          // Auth0 doesn't set this, it's nested inside details
+          ctx.set("userName", params.username);
+          ctx.set("client_id", client.id);
+          const log = createTypeLog(
+            "f",
+            ctx,
+            params,
+            "Public signup is disabled",
+          );
+
+          await ctx.env.data.logs.create(client.tenant_id, log);
+
           return ctx.html(
             <EnterEmailPage
               vendorSettings={vendorSettings}

--- a/test/integration/breakit-customizations.spec.ts
+++ b/test/integration/breakit-customizations.spec.ts
@@ -94,6 +94,20 @@ test("only allows existing breakit users to progress to the enter code step", as
   expect(nonExistingUserEmailResponse.status).toBe(400);
   await snapshotResponse(nonExistingUserEmailResponse);
 
+  const { logs } = await env.data.logs.list("breakit", {
+    page: 0,
+    per_page: 100,
+    include_totals: true,
+  });
+  expect(logs[0]).toMatchObject({
+    type: "f",
+    tenant_id: "breakit",
+    user_name: "not-a-real-breakit-user@example.com",
+    // different to auth0, at this point we don't have a connection
+    connection: "",
+    client_id: "breakit",
+  });
+
   // ----------------------------
   //  Try going past email address step with existing breakit user
   // ----------------------------


### PR DESCRIPTION
Auth0 Universal Auth doesn't have this flow with an email entry on the first step to then go to a code login

Password sign ups are disabled by hiding the button as done on https://github.com/sesamyab/auth/pull/938

The only log I get on auth0 is when trying to use the `/passwordless/start` endpoint after disabling signups for `email` on Auth0, which then gives us this log!