### PR TITLE
fix: log on social sign on errors

### DIFF
--- a/src/authentication-flows/social.tsx
+++ b/src/authentication-flows/social.tsx
@@ -216,12 +216,14 @@ export async function socialAuthCallback({
     if (client.disable_sign_ups) {
       ctx.set("userName", email);
       ctx.set("client_id", client.id);
+      ctx.set("connection", connection.name);
       const log = createTypeLog(
         LogTypes.FAILED_LOGIN,
         ctx,
         {},
         "Public signup is disabled",
       );
+      await ctx.env.data.logs.create(client.tenant_id, log);
 
       const vendorSettings = await fetchVendorSettings(
         env,

--- a/test/integration/breakit-customizations.spec.ts
+++ b/test/integration/breakit-customizations.spec.ts
@@ -142,6 +142,8 @@ test("only allows existing breakit users to progress to the enter code step", as
   await snapshotResponse(loginFormNoSignupResponse);
 });
 
+// this test name isn't correct as there is no "enter code" step with a social login. This test is testing that a new SSO user
+// cannot be redirect back to the callback
 test("only allows existing breakit users to progress to the enter code step with social signon", async () => {
   const testTenantLanguage = "en";
   const env = await getEnv({
@@ -233,6 +235,20 @@ test("only allows existing breakit users to progress to the enter code step with
 
   // This is the error page we expect to see when the user does not exist
   await snapshotResponse(socialCallbackResponse);
+
+  const { logs } = await env.data.logs.list("breakit", {
+    page: 0,
+    per_page: 100,
+    include_totals: true,
+  });
+  expect(logs[0]).toMatchObject({
+    type: "f",
+    tenant_id: "breakit",
+    user_name: "örjan.lindström@example.com",
+    connection: "other-social-provider",
+    client_id: "breakit",
+    description: "Public signup is disabled",
+  });
 
   // ----------------------------
   //  Try going past email address step with existing breakit user


### PR DESCRIPTION
There are a few calls like `ctx.set("logType", "fsa")` which used to log when we had the logging middleware working on tsoa

This PR fixes the social login to explicitly logs