### PR TITLE
fix: if login2 is the caller, then ignore `disable_sign_ups` check

### DIFF
--- a/src/authentication-flows/social.tsx
+++ b/src/authentication-flows/social.tsx
@@ -213,7 +213,9 @@ export async function socialAuthCallback({
   });
 
   if (!user) {
-    if (client.disable_sign_ups) {
+    const callerIsLogin2 = state.authParams.redirect_uri.includes("login2");
+
+    if (client.disable_sign_ups && !callerIsLogin2) {
       ctx.set("userName", email);
       ctx.set("client_id", client.id);
       ctx.set("connection", connection.name);

--- a/test/integration/breakit-customizations.spec.ts
+++ b/test/integration/breakit-customizations.spec.ts
@@ -212,7 +212,9 @@ test("only allows existing breakit users to progress to the enter code step with
 
   const socialStateParamNonExistingUser = osloBtoa({
     authParams: {
-      redirect_uri: "https://login2.sesamy.dev/callback",
+      // With the "fix" on this PR, this need testing... if we do want this approach, I can duplicate this test with this here and check that auth2 doesn't do the existing user check
+      // redirect_uri: "https://login2.sesamy.dev/callback",
+      redirect_uri: "https://example.com/callback",
       scope: "openid profile email",
       state: STATE,
       client_id: "breakit",


### PR DESCRIPTION
~*this is currently deployed to dev*~ Nope! Previous PR merged so now `main` is back on auth2.sesamy.dev :+1: 

[Screencast from 2024-06-14 11-36-59.webm](https://github.com/sesamyab/auth/assets/8496063/1958ef0a-dbfc-4616-b1b4-8a3ba530bcd3)


:smile: I don't actually think we should do this :smile: 
Although I'm convincing myself maybe we should
