### PR TITLE
fix: log failed login when email not verified

### DIFF
--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -128,7 +128,15 @@ export async function ticketAuth(
         login2UniverifiedEmailUrl.searchParams.set("connection", connection2);
       }
 
-      ctx.set("logType", LogTypes.FAILED_LOGIN_INCORRECT_PASSWORD);
+      ctx.set("userName", user.email);
+      ctx.set("connection", user.connection);
+      ctx.set("client_id", client.id);
+      const log = createTypeLog(
+        LogTypes.FAILED_LOGIN,
+        ctx,
+        "Email not verified",
+      );
+      await ctx.env.data.logs.create(client.tenant_id, log);
 
       return new Response("Redirecting", {
         status: 302,

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -134,6 +134,7 @@ export async function ticketAuth(
       const log = createTypeLog(
         LogTypes.FAILED_LOGIN,
         ctx,
+        {},
         "Email not verified",
       );
       await ctx.env.data.logs.create(client.tenant_id, log);

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -323,6 +323,7 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         const log = createTypeLog(
           LogTypes.FAILED_LOGIN,
           ctx,
+          {},
           "Email not verified",
         );
         await ctx.env.data.logs.create(client.tenant_id, log);

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -1,6 +1,13 @@
 // TODO - move this file to src/routes/oauth2/login.ts
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { Env, User, AuthorizationResponseType, Client, Var } from "../../types";
+import {
+  Env,
+  User,
+  AuthorizationResponseType,
+  Client,
+  Var,
+  LogTypes,
+} from "../../types";
 import ResetPasswordPage from "../../components/ResetPasswordPage";
 import validatePassword from "../../utils/validatePassword";
 import {
@@ -309,6 +316,16 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
           client,
           user,
         });
+
+        ctx.set("userName", user.email);
+        ctx.set("connection", user.connection);
+        ctx.set("client_id", client.id);
+        const log = createTypeLog(
+          LogTypes.FAILED_LOGIN,
+          ctx,
+          "Email not verified",
+        );
+        await ctx.env.data.logs.create(client.tenant_id, log);
 
         // login2 looks a bit better - https://login2.sesamy.dev/unverified-email
         return ctx.html(

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -61,6 +61,21 @@ describe("password-flow", () => {
       });
       expect(createUserResponse.status).toBe(200);
 
+      const {
+        logs: [successSignUpLog],
+      } = await env.data.logs.list("tenantId", {
+        page: 0,
+        per_page: 100,
+        include_totals: true,
+      });
+      expect(successSignUpLog).toMatchObject({
+        type: "ss",
+        tenant_id: "tenantId",
+        user_name: "password-login-test@example.com",
+        connection: "Username-Password-Authentication",
+        client_id: "clientId",
+      });
+
       const loginResponse = await oauthClient.co.authenticate.$post({
         json: {
           client_id: "clientId",
@@ -111,18 +126,19 @@ describe("password-flow", () => {
       expect(await loginBlockedRes.text()).toBe("Redirecting");
 
       const {
-        logs: [successSignUpLog],
+        logs: [failedLogin],
       } = await env.data.logs.list("tenantId", {
         page: 0,
         per_page: 100,
         include_totals: true,
       });
-      expect(successSignUpLog).toMatchObject({
-        type: "ss",
+      expect(failedLogin).toMatchObject({
+        type: "f",
         tenant_id: "tenantId",
         user_name: "password-login-test@example.com",
         connection: "Username-Password-Authentication",
         client_id: "clientId",
+        description: "Email not verified",
       });
       // get user with this id and check is the correct id
       const user = await env.data.users.get(


### PR DESCRIPTION
I'm making this one up because Auth0 has no built-in email verification functionality (correct me if I'm wrong!)

I'm guessing at which log type https://auth0.com/docs/deploy-monitor/logs/log-event-type-codes

But this seems a reasonable thing to log for visibility