### PR TITLE
fix: ooops need whitespace for button height

### DIFF
--- a/src/components/DisabledSubmitButton.tsx
+++ b/src/components/DisabledSubmitButton.tsx
@@ -20,7 +20,9 @@ const DisabledSubmitButton = ({
         isLoading
         id="loading-btn"
         disabled
-      />
+      >
+        &nbsp;
+      </Button>
     </>
   );
 };


### PR DESCRIPTION
In a previous fix I removed the duplicate text https://github.com/sesamyab/auth/pull/953

But we want whitespace there else the button is reduced in height (very obvious now on dev)

We could snapshot this button state... I could click it when we load the HTML into playwright :thinking: 