### PR TITLE
fix: code duplication

### DIFF
--- a/src/authentication-flows/password-reset.ts
+++ b/src/authentication-flows/password-reset.ts
@@ -1,0 +1,42 @@
+import { nanoid } from "nanoid";
+import { Context } from "hono";
+import { Var, Env, Client } from "../types";
+import { getPrimaryUserByEmailAndProvider } from "../utils/users";
+import { CODE_EXPIRATION_TIME } from "../constants";
+import generateOTP from "../utils/otp";
+import { sendResetPassword } from "../controllers/email";
+
+export async function requestPasswordReset(
+  ctx: Context<{
+    Bindings: Env;
+    Variables: Var;
+  }>,
+  client: Client,
+  email: string,
+  state: string,
+) {
+  const user = await getPrimaryUserByEmailAndProvider({
+    userAdapter: ctx.env.data.users,
+    tenant_id: client.tenant_id,
+    email,
+    provider: "auth2",
+  });
+
+  // route always returns success
+  if (!user) {
+    return ctx.html("We've just sent you an email to reset your password.");
+  }
+
+  const code = generateOTP();
+
+  await ctx.env.data.codes.create(client.tenant_id, {
+    id: nanoid(),
+    code,
+    type: "password_reset",
+    user_id: user.id,
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + CODE_EXPIRATION_TIME).toISOString(),
+  });
+
+  await sendResetPassword(ctx.env, client, email, code, state);
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,4 +18,6 @@ export const headers = {
 
 export const UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS = 60 * 60 * 24; // 1 day
 
+export const CODE_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+
 export const CLIENT_ID = process.env.CLIENT_ID || "default";


### PR DESCRIPTION
Noticed that we're doing the same thing in multiple places. Think we can keep the actual flows in the same place and reuse between universal auth and the api endpoints.