### PR TITLE
fix: log user ids for social accounts on success signup & login

### DIFF
--- a/src/authentication-flows/social.tsx
+++ b/src/authentication-flows/social.tsx
@@ -261,6 +261,7 @@ export async function socialAuthCallback({
     ctx.set("userName", user.email);
     ctx.set("connection", user.connection);
     ctx.set("client_id", client.id);
+    ctx.set("userId", user.id);
     const log = createTypeLog("ss", ctx, "Successful signup");
     await ctx.env.data.logs.create(client.tenant_id, log);
   }
@@ -288,6 +289,7 @@ export async function socialAuthCallback({
   ctx.set("userName", user.email);
   ctx.set("connection", user.connection);
   ctx.set("client_id", client.id);
+  ctx.set("userId", user.id);
   const log = createTypeLog("s", ctx, "Successful login");
   await ctx.env.data.logs.create(client.tenant_id, log);
 

--- a/test/integration/flows/social.spec.ts
+++ b/test/integration/flows/social.spec.ts
@@ -163,6 +163,7 @@ describe("social sign on", () => {
           user_name: "örjan.lindström@example.com",
           connection: "demo-social-provider",
           client_id: "clientId",
+          user_id: "demo-social-provider|123456789012345678901",
         });
 
         expect(successLoginLog).toMatchObject({
@@ -171,6 +172,7 @@ describe("social sign on", () => {
           user_name: "örjan.lindström@example.com",
           connection: "demo-social-provider",
           client_id: "clientId",
+          user_id: "demo-social-provider|123456789012345678901",
         });
 
         // ---------------------------------------------


### PR DESCRIPTION
this should fix them appearing for e.g. this user https://auth-admin.sesamy.com/fGsqCfBjXixQrYKCnBIPl/users/google-oauth2%7C108791004671072817794/1

I can QA once merged