### PR TITLE
fix: login flow for authenticate

### DIFF
--- a/src/authentication-flows/password.ts
+++ b/src/authentication-flows/password.ts
@@ -98,7 +98,7 @@ export async function loginWithPassword(
     });
   }
 
-  if (!user.email_verified) {
+  if (!user.email_verified && client.email_validation === "enforced") {
     await sendEmailVerificationEmail({
       env: ctx.env,
       client,

--- a/src/authentication-flows/password.ts
+++ b/src/authentication-flows/password.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { Context } from "hono";
-import { Var, Env, Client, AuthParams } from "../types";
+import { Var, Env, Client, AuthParams, LogTypes } from "../types";
 import {
   getPrimaryUserByEmailAndProvider,
   getUserByEmailAndProvider,
@@ -104,6 +104,14 @@ export async function loginWithPassword(
       client,
       user,
     });
+
+    const log = createTypeLog(
+      LogTypes.FAILED_LOGIN,
+      ctx,
+      {},
+      "Email not verified",
+    );
+    await ctx.env.data.logs.create(client.tenant_id, log);
 
     throw new CustomException(403, {
       message: "Email not verified",

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -294,14 +294,6 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
             400,
           );
         } else if (customException.code === "EMAIL_NOT_VERIFIED") {
-          const log = createTypeLog(
-            LogTypes.FAILED_LOGIN,
-            ctx,
-            {},
-            "Email not verified",
-          );
-          await ctx.env.data.logs.create(client.tenant_id, log);
-
           // login2 looks a bit better - https://login2.sesamy.dev/unverified-email
           return ctx.html(
             <UnverifiedEmail vendorSettings={vendorSettings} />,

--- a/test/integration/flows/password.spec.ts
+++ b/test/integration/flows/password.spec.ts
@@ -48,7 +48,7 @@ describe("password-flow", () => {
 
     it("should create a new user with a password and only allow login after email validation", async () => {
       const password = "Password1234!";
-      const env = await getEnv();
+      const env = await getEnv({ emailValidation: "disabled" });
       const oauthClient = testClient(oauthApp, env);
 
       const createUserResponse = await oauthClient.dbconnections.signup.$post({
@@ -473,7 +473,7 @@ describe("password-flow", () => {
     // this test looks like a duplicate of "should create a new user with a password and only allow login after email validation"
     it("should resend email validation email after login attempts, and this should work", async () => {
       const password = "Password1234!";
-      const env = await getEnv();
+      const env = await getEnv({ emailValidation: "disabled" });
       const oauthClient = testClient(oauthApp, env);
 
       const createUserResponse = await oauthClient.dbconnections.signup.$post({
@@ -741,7 +741,7 @@ describe("password-flow", () => {
       expect(loginResponse.status).toBe(403);
     });
     it("should not allow password of a different user to be used", async () => {
-      const env = await getEnv();
+      const env = await getEnv({ emailValidation: "disabled" });
       const oauthClient = testClient(oauthApp, env);
 
       const signupResponse = await oauthClient.dbconnections.signup.$post({
@@ -786,6 +786,7 @@ describe("password-flow", () => {
 
       expect(rejectedLoginResponse.status).toBe(403);
     });
+
     it("should not allow non-existent user & password to login", async () => {
       const env = await getEnv();
       const oauthClient = testClient(oauthApp, env);

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -15,15 +15,13 @@ import { Connection } from "../../../src/types/Connection";
 import type { Client } from "../../../src/types";
 import type { EmailOptions } from "../../../src/services/email/EmailOptions";
 import { addDataHooks } from "../../../src/hooks";
-import { DataAdapters } from "../../../src/adapters/interfaces";
 
 type getEnvParams = {
   testTenantLanguage?: string;
+  emailValidation?: "enabled" | "enforced" | "disabled";
 };
 
-export async function getEnv(args?: getEnvParams) {
-  const testTenantLanguage = args?.testTenantLanguage;
-
+export async function getEnv(args: getEnvParams = {}) {
   const dialect = new SqliteDialect({
     database: new SQLite(":memory:"),
   });
@@ -97,7 +95,7 @@ export async function getEnv(args?: getEnvParams) {
     support_url: "https://example.com/support",
     created_at: "created_at",
     updated_at: "updated_at",
-    language: testTenantLanguage,
+    language: args.testTenantLanguage,
   };
 
   const testApplication: Application = {
@@ -107,7 +105,7 @@ export async function getEnv(args?: getEnvParams) {
     allowed_callback_urls: "https://example.com/callback",
     allowed_logout_urls: "",
     allowed_web_origins: "example.com",
-    email_validation: "enforced",
+    email_validation: args.emailValidation || "enforced",
     created_at: "created_at",
     updated_at: "updated_at",
     disable_sign_ups: false,
@@ -120,7 +118,7 @@ export async function getEnv(args?: getEnvParams) {
     allowed_callback_urls: "https://example.com/callback2",
     allowed_logout_urls: "",
     allowed_web_origins: "",
-    email_validation: "enforced",
+    email_validation: args.emailValidation || "enforced",
     created_at: "created_at",
     updated_at: "updated_at",
     disable_sign_ups: false,

--- a/test/integration/oauth/authenticate.spec.ts
+++ b/test/integration/oauth/authenticate.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { testClient } from "hono/testing";
+import { oauthApp } from "../../../src/app";
+import { getEnv } from "../helpers/test-client";
+
+describe("authenticate", () => {
+  it("should return a token for a successful login", async () => {
+    const env = await getEnv();
+    const oauthClient = testClient(oauthApp, env);
+
+    const loginResponse = await oauthClient.co.authenticate.$post({
+      json: {
+        client_id: "clientId",
+        credential_type: "http://auth0.com/oauth/grant-type/password-realm",
+        realm: "Username-Password-Authentication",
+        password: "Test1234!",
+        username: "foo@example.com",
+      },
+    });
+
+    expect(loginResponse.status).toEqual(200);
+    const { login_ticket } = (await loginResponse.json()) as {
+      login_ticket: string;
+    };
+
+    expect(login_ticket).toBeTypeOf("string");
+  });
+});

--- a/test/integration/oauth/token.spec.ts
+++ b/test/integration/oauth/token.spec.ts
@@ -3,11 +3,6 @@ import { testClient } from "hono/testing";
 import { oauthApp } from "../../../src/app";
 import { getEnv } from "../helpers/test-client";
 import { AuthorizationResponseType } from "../../../src/types";
-import exp from "constants";
-import { parse } from "path";
-import { parseJWT } from "oslo/jwt";
-import { t } from "i18next";
-import { AnyCnameRecord } from "dns";
 
 describe("token", () => {
   it("should handle a code grant flow", async () => {


### PR DESCRIPTION
Use the same login for the /co/authenticate endpoint which was interesting.. I had to add a param to change the email_validation to "disabled" as our current tests wouldn't work otherwise.
The last step will be to move the logging up to the auth-flow function as well and it will work for both endpoints.