### PR TITLE
fix: move all init to the same file

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import type { FC } from "hono/jsx";
 import { VendorSettings } from "../types";
 import AppLogo from "./AppLogo";
 import i18next from "i18next";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,6 @@ export const headers = {
 
 export const UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS = 60 * 60 * 24; // 1 day
 
-export const CODE_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+export const CODE_EXPIRATION_TIME = 30 * 60 * 1000;
 
 export const CLIENT_ID = process.env.CLIENT_ID || "default";

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -59,7 +59,7 @@ export async function sendCode(
         value: codeEmailBody,
       },
     ],
-    subject: translate(language, "codeEmailTitle")
+    subject: translate(client.tenant.language, "codeEmailTitle")
       .replace("{{vendorName}}", client.tenant.name)
       .replace("{{code}}", code),
   });

--- a/src/controllers/email.ts
+++ b/src/controllers/email.ts
@@ -1,12 +1,7 @@
 import { Liquid } from "liquidjs";
-import { translate } from "../utils/i18n";
+import { getLocale, translate } from "../utils/i18n";
 import { AuthParams, Client, Env } from "../types";
 import { getClientLogoPngGreyBg } from "../utils/clientLogos";
-import en from "../locales/en/default.json";
-import sv from "../locales/sv/default.json";
-import nb from "../locales/nb/default.json";
-import it from "../locales/it/default.json";
-import pl from "../locales/pl/default.json";
 import {
   codeV2,
   linkV2,
@@ -14,21 +9,6 @@ import {
   verifyEmail,
 } from "../templates/email/ts";
 import { createMagicLink } from "../utils/magicLink";
-
-const SUPPORTED_LOCALES: { [key: string]: object } = {
-  en,
-  sv,
-  nb,
-  it,
-  pl,
-};
-
-function getLocale(language: string) {
-  if (SUPPORTED_LOCALES[language]) {
-    return SUPPORTED_LOCALES[language];
-  }
-  return en;
-}
 
 const engine = new Liquid();
 
@@ -38,8 +18,7 @@ export async function sendCode(
   to: string,
   code: string,
 ) {
-  const language = client.tenant.language || "sv";
-  const locale = getLocale(language);
+  const locale = getLocale(client.tenant.language);
 
   const logo = getClientLogoPngGreyBg(
     client.tenant.logo ||

--- a/src/routes/oauth2/callback.ts
+++ b/src/routes/oauth2/callback.ts
@@ -5,23 +5,6 @@ import { getClient } from "../../services/clients";
 import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { Var } from "../../types/Var";
-import i18next from "i18next";
-import en from "../../localesLogin2/en/default.json";
-import it from "../../localesLogin2/it/default.json";
-import nb from "../../localesLogin2/nb/default.json";
-import sv from "../../localesLogin2/sv/default.json";
-
-function initI18n(lng: string) {
-  i18next.init({
-    lng,
-    resources: {
-      en: { translation: en },
-      it: { translation: it },
-      nb: { translation: nb },
-      sv: { translation: sv },
-    },
-  });
-}
 
 export const callbackRoutes = new OpenAPIHono<{
   Bindings: Env;
@@ -76,8 +59,6 @@ export const callbackRoutes = new OpenAPIHono<{
       if (!tenant) {
         throw new HTTPException(400, { message: "Tenant not found" });
       }
-
-      initI18n(tenant.language || "sv");
 
       if (error) {
         const { redirect_uri } = loginState.authParams;

--- a/src/routes/tsx/routes.tsx
+++ b/src/routes/tsx/routes.tsx
@@ -17,10 +17,6 @@ import {
 import { getClient } from "../../services/clients";
 import { HTTPException } from "hono/http-exception";
 import i18next from "i18next";
-import en from "../../localesLogin2/en/default.json";
-import it from "../../localesLogin2/it/default.json";
-import nb from "../../localesLogin2/nb/default.json";
-import sv from "../../localesLogin2/sv/default.json";
 import EnterPasswordPage from "../../components/EnterPasswordPage";
 import EnterEmailPage from "../../components/EnterEmailPage";
 import EnterCodePage from "../../components/EnterCodePage";
@@ -53,6 +49,8 @@ import {
   requestPasswordReset,
 } from "../../authentication-flows/password";
 import { CustomException } from "../../models/CustomError";
+import { initI18n } from "../../utils/i18n";
+import { CODE_EXPIRATION_TIME } from "../../constants";
 
 async function initJSXRoute(state: string, env: Env) {
   const session = await env.data.universalLoginSessions.get(state);
@@ -76,24 +74,9 @@ async function initJSXRoute(state: string, env: Env) {
     session.authParams.vendor_id,
   );
 
-  initI18n(tenant.language || "sv");
+  initI18n(tenant.language);
 
   return { vendorSettings, client, tenant, session };
-}
-
-// duplicated from /passwordless route
-const CODE_EXPIRATION_TIME = 30 * 60 * 1000;
-
-function initI18n(lng: string) {
-  i18next.init({
-    lng,
-    resources: {
-      en: { translation: en },
-      it: { translation: it },
-      nb: { translation: nb },
-      sv: { translation: sv },
-    },
-  });
 }
 
 async function handleLogin(

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -3,6 +3,7 @@ import sv from "../locales/sv/default.json";
 import nb from "../locales/nb/default.json";
 import it from "../locales/it/default.json";
 import pl from "../locales/it/default.json";
+import i18next from "i18next";
 
 type Labels = { [lang: string]: { [key: string]: string } };
 
@@ -24,4 +25,25 @@ export function translate(language: string, label: LabelIds): string {
   }
 
   return labels[language]?.[label] ?? "missing label";
+}
+
+export function getLocale(language = "en") {
+  if (!labels[language]) {
+    throw new Error(`Language ${language} is not supported`);
+  }
+
+  return labels[language];
+}
+
+export function initI18n(lanaguage = "en") {
+  i18next.init({
+    lng: lanaguage,
+    resources: {
+      en: { translation: en },
+      it: { translation: it },
+      nb: { translation: nb },
+      sv: { translation: sv },
+      pl: { translation: pl },
+    },
+  });
 }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -18,7 +18,7 @@ const labels: Labels = {
 // This type is used for type checking and IDE auto-completion
 type LabelIds = keyof typeof en | keyof typeof sv;
 
-export function translate(language: string, label: LabelIds): string {
+export function translate(language = "sv", label: LabelIds): string {
   // or we could fallback to en
   if (!labels[language]) {
     throw new Error(`Language ${language} is not supported`);
@@ -27,7 +27,7 @@ export function translate(language: string, label: LabelIds): string {
   return labels[language]?.[label] ?? "missing label";
 }
 
-export function getLocale(language = "en") {
+export function getLocale(language = "sv") {
   if (!labels[language]) {
     throw new Error(`Language ${language} is not supported`);
   }
@@ -35,7 +35,7 @@ export function getLocale(language = "en") {
   return labels[language];
 }
 
-export function initI18n(lanaguage = "en") {
+export function initI18n(lanaguage = "sv") {
   i18next.init({
     lng: lanaguage,
     resources: {


### PR DESCRIPTION
Noticed that the language config was a bit spread out, so moved it all into the utils/i18n file.

Looked a bit a the i18next library and it seems to be doing a few interesting things.. Maybe we should try to migrate all code to use this rather than our homebrewed solution?