### PR TITLE
fix: add user_id column

### DIFF
--- a/migrate/migrations/2024-07-15T10:00:00_user_id.ts
+++ b/migrate/migrations/2024-07-15T10:00:00_user_id.ts
@@ -1,0 +1,13 @@
+import { Kysely } from "kysely";
+import { Database } from "../../src/types";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("users")
+    .addColumn("user_id", "varchar(255)")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("users").dropColumn("user_id").execute();
+}

--- a/migrate/migrations/index.ts
+++ b/migrate/migrations/index.ts
@@ -37,6 +37,7 @@ import * as n36_authenticationCodes from "./2024-05-27T23:50:00_authentication_c
 import * as n37_disableSignUps from "./2024-06-03T10:00:00_disable-sign-ups";
 import * as n38_otpIpAddress from "./2024-06-05T10:00:00_otp-ip-address";
 import * as n39_increaseUserAgentLength from "./2024-06-19T10:00:00_increase-user-agent-length";
+import * as n40_userId from "./2024-07-15T10:00:00_user_id";
 
 // These need to be in alphabetic order
 export default {
@@ -79,4 +80,5 @@ export default {
   n37_disableSignUps,
   n38_otpIpAddress,
   n39_increaseUserAgentLength,
+  n40_userId,
 };

--- a/src/adapters/kysely/users/create.ts
+++ b/src/adapters/kysely/users/create.ts
@@ -13,6 +13,7 @@ export function create(db: Kysely<Database>) {
       tenant_id: tenantId,
       email_verified: user.email_verified ? 1 : 0,
       is_social: user.is_social ? 1 : 0,
+      user_id: user.id,
     };
 
     try {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -13,6 +13,7 @@ export const baseUserSchema = z.object({
   locale: z.string().optional(),
   linked_to: z.string().optional(),
   profileData: z.string().optional(),
+  user_id: z.string().optional(),
 });
 
 export type BaseUser = z.infer<typeof baseUserSchema>;


### PR DESCRIPTION
Step one of migrating to using user_id as primary key. Once this is migrated we can copy all the id's and making this field required.