### PR TITLE
fix: add silent auth for login hint

### DIFF
--- a/src/authentication-flows/silent.ts
+++ b/src/authentication-flows/silent.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
-import { Client, LogTypes } from "@authhero/adapter-interfaces";
-import { getAuthCookie, serializeAuthCookie } from "../services/cookies";
+import { Client, LogTypes, Session } from "@authhero/adapter-interfaces";
+import { serializeAuthCookie } from "../services/cookies";
 import { AuthorizationResponseType, CodeChallengeMethod, Env } from "../types";
 import renderAuthIframe from "../templates/authIframe";
 import { generateAuthData } from "../helpers/generate-auth-response";
@@ -10,7 +10,7 @@ import { createLogMessage } from "../utils/create-log-message";
 interface SilentAuthParams {
   ctx: Context<{ Bindings: Env; Variables: Var }>;
   client: Client;
-  cookie_header?: string;
+  session?: Session;
   redirect_uri: string;
   state: string;
   response_type: AuthorizationResponseType;
@@ -24,7 +24,7 @@ interface SilentAuthParams {
 export async function silentAuth({
   ctx,
   client,
-  cookie_header,
+  session,
   redirect_uri,
   state,
   nonce,
@@ -35,64 +35,59 @@ export async function silentAuth({
 }: SilentAuthParams) {
   const { env } = ctx;
 
-  const tokenState = getAuthCookie(client.tenant_id, cookie_header);
   const redirectURL = new URL(redirect_uri);
 
-  if (tokenState) {
-    const session = await env.data.sessions.get(client.tenant_id, tokenState);
+  if (session) {
+    ctx.set("userId", session.user_id);
 
-    if (session) {
-      ctx.set("userId", session.user_id);
+    // Update the cookie
+    const headers = new Headers();
+    const cookie = serializeAuthCookie(client.tenant_id, session.session_id);
+    headers.set("set-cookie", cookie);
 
-      // Update the cookie
-      const headers = new Headers();
-      const cookie = serializeAuthCookie(client.tenant_id, tokenState);
-      headers.set("set-cookie", cookie);
+    const user = await env.data.users.get(client.tenant_id, session.user_id);
 
-      const user = await env.data.users.get(client.tenant_id, session.user_id);
+    if (user) {
+      ctx.set("userName", user.email);
+      ctx.set("connection", user.connection);
 
-      if (user) {
-        ctx.set("userName", user.email);
-        ctx.set("connection", user.connection);
-
-        const tokenResponse = await generateAuthData({
-          ctx,
-          tenant_id: client.tenant_id,
+      const tokenResponse = await generateAuthData({
+        ctx,
+        tenant_id: client.tenant_id,
+        authParams: {
+          client_id: client.id,
+          audience,
+          code_challenge_method,
+          code_challenge,
+          scope,
           state,
           nonce,
-          authParams: {
-            client_id: client.id,
-            audience,
-            code_challenge_method,
-            code_challenge,
-            scope,
-            // Always set the response type to token id_token for silent auth
-            response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
-          },
-          user,
-          sid: tokenState,
-        });
+          // Always set the response type to token id_token for silent auth
+          response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
+        },
+        user,
+        sid: session.session_id,
+      });
 
-        await env.data.sessions.update(client.tenant_id, tokenState, {
-          used_at: new Date().toISOString(),
-        });
+      await env.data.sessions.update(client.tenant_id, session.session_id, {
+        used_at: new Date().toISOString(),
+      });
 
-        const log = createLogMessage(ctx, {
-          type: LogTypes.SUCCESS_SILENT_AUTH,
-          description: "Successful silent authentication",
-        });
-        await ctx.env.data.logs.create(client.tenant_id, log);
+      const log = createLogMessage(ctx, {
+        type: LogTypes.SUCCESS_SILENT_AUTH,
+        description: "Successful silent authentication",
+      });
+      await ctx.env.data.logs.create(client.tenant_id, log);
 
-        return ctx.html(
-          renderAuthIframe(
-            `${redirectURL.protocol}//${redirectURL.host}`,
-            JSON.stringify(tokenResponse),
-          ),
-          {
-            headers,
-          },
-        );
-      }
+      return ctx.html(
+        renderAuthIframe(
+          `${redirectURL.protocol}//${redirectURL.host}`,
+          JSON.stringify(tokenResponse),
+        ),
+        {
+          headers,
+        },
+      );
     }
   }
 

--- a/src/authentication-flows/social.tsx
+++ b/src/authentication-flows/social.tsx
@@ -250,8 +250,6 @@ export async function socialAuthCallback({
     ctx,
     tenant_id: client.tenant_id,
     sid: sessionId,
-    state: state.authParams.state,
-    nonce: state.authParams.nonce,
     authParams: state.authParams,
     user,
   });

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -1,4 +1,5 @@
-import { Env, AuthParams, AuthorizationResponseType } from "../types";
+import { AuthParams } from "@authhero/adapter-interfaces";
+import { Env } from "../types";
 import userIdGenerate from "../utils/userIdGenerate";
 import { generateAuthResponse } from "../helpers/generate-auth-response";
 import { setSilentAuthCookies } from "../helpers/silent-auth-cookie";
@@ -135,7 +136,6 @@ export async function ticketAuth(
 
   return generateAuthResponse({
     ctx,
-    state: authParams.state,
     authParams: {
       scope: ticket.authParams?.scope,
       ...authParams,

--- a/src/authentication-flows/universal.ts
+++ b/src/authentication-flows/universal.ts
@@ -1,26 +1,51 @@
 import { Context } from "hono";
-import { AuthParams, Env, Var } from "../types";
+import { Env, Var } from "../types";
 import { UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS } from "../constants";
 import { nanoid } from "nanoid";
 import {
+  AuthParams,
   Client,
+  Session,
   UniversalLoginSessionInsert,
 } from "@authhero/adapter-interfaces";
+import { generateAuthResponse } from "../helpers/generate-auth-response";
 
 interface UniversalAuthParams {
   ctx: Context<{ Bindings: Env; Variables: Var }>;
   client: Client;
+  session?: Session;
   authParams: AuthParams;
   auth0Client?: string;
+  login_hint?: string;
 }
 
 export async function universalAuth({
   ctx,
+  session,
   client,
   authParams,
   auth0Client,
+  login_hint,
 }: UniversalAuthParams) {
-  const session: UniversalLoginSessionInsert = {
+  // Check if the user in the login_hint matches the user in the session
+  if (session && login_hint) {
+    const user = await ctx.env.data.users.get(
+      client.tenant_id,
+      session.user_id,
+    );
+
+    if (user?.email === login_hint) {
+      return generateAuthResponse({
+        ctx,
+        tenant_id: client.tenant_id,
+        sid: session.session_id,
+        authParams,
+        user,
+      });
+    }
+  }
+
+  const universalLoginSession: UniversalLoginSessionInsert = {
     id: nanoid(),
     expires_at: new Date(
       Date.now() + UNIVERSAL_AUTH_SESSION_EXPIRES_IN_SECONDS * 1000,
@@ -29,7 +54,10 @@ export async function universalAuth({
     auth0Client,
   };
 
-  await ctx.env.data.universalLoginSessions.create(client.tenant_id, session);
+  await ctx.env.data.universalLoginSessions.create(
+    client.tenant_id,
+    universalLoginSession,
+  );
 
-  return ctx.redirect(`/u/enter-email?state=${session.id}`);
+  return ctx.redirect(`/u/enter-email?state=${universalLoginSession.id}`);
 }

--- a/src/routes/oauth2/callback.ts
+++ b/src/routes/oauth2/callback.ts
@@ -130,8 +130,6 @@ export const callbackRoutes = new OpenAPIHono<{
         throw new HTTPException(400, { message: "State not found" });
       }
 
-      const client = await getClient(ctx.env, loginState.authParams.client_id);
-
       if (error) {
         const { redirect_uri } = loginState.authParams;
 

--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -145,6 +145,7 @@ export const passwordlessRoutes = new OpenAPIHono<{
           client_id,
           redirect_uri,
           state,
+          nonce,
           scope,
           audience,
           response_type,
@@ -161,8 +162,6 @@ export const passwordlessRoutes = new OpenAPIHono<{
           ctx,
           tenant_id: client.tenant_id,
           sid: sessionId,
-          state,
-          nonce,
           user,
           authParams,
         });

--- a/src/services/cookies.ts
+++ b/src/services/cookies.ts
@@ -31,7 +31,7 @@ export function clearAuthCookie(tenant_id: string) {
   });
 }
 
-export function serializeAuthCookie(tenant_id: string, payload: string) {
+export function serializeAuthCookie(tenant_id: string, value: string) {
   const options = {
     path: "/",
     httpOnly: true,
@@ -39,7 +39,7 @@ export function serializeAuthCookie(tenant_id: string, payload: string) {
     maxAge: 60 * 60 * 24 * 7, // 1 mo
   };
 
-  return serializeCookie(getCookieName(tenant_id), payload, {
+  return serializeCookie(getCookieName(tenant_id), value, {
     ...options,
     sameSite: "none",
   });

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -2,7 +2,6 @@ import {
   AuthorizationCodeGrantTypeParams,
   AuthorizationResponseType,
   Env,
-  LogTypes,
   Var,
 } from "../types";
 import { getClient } from "../services/clients";
@@ -10,7 +9,6 @@ import { HTTPException } from "hono/http-exception";
 import { generateAuthData } from "../helpers/generate-auth-response";
 import { Context } from "hono";
 import { nanoid } from "nanoid";
-import { createLogMessage } from "../utils/create-log-message";
 
 export async function authorizeCodeGrant(
   ctx: Context<{ Bindings: Env; Variables: Var }>,
@@ -50,8 +48,7 @@ export async function authorizeCodeGrant(
 
   const tokens = await generateAuthData({
     ctx,
-    authParams,
-    nonce,
+    authParams: { ...authParams, nonce },
     user,
     sid: nanoid(),
     tenant_id: client.tenant_id,

--- a/test/integration/login/code-authorization.spec.ts
+++ b/test/integration/login/code-authorization.spec.ts
@@ -44,6 +44,7 @@ test("code authorization flow should work", async () => {
       password: "Test1234!",
     },
   });
+
   expect(postLoginResponse.status).toBe(302);
   const loginLocation = postLoginResponse.headers.get("location");
   const redirectUrl = new URL(loginLocation!);


### PR DESCRIPTION
The new functionality is that the authorize endpoint checks if the current session matches with the login_hint and in that case it returns to the redirect_url directly.