### PR TITLE
feat: add a check account page for silent auth

### DIFF
--- a/src/authentication-flows/silent.ts
+++ b/src/authentication-flows/silent.ts
@@ -53,7 +53,7 @@ export async function silentAuth({
 
       const tokenResponse = await generateAuthData({
         ctx,
-        tenant_id: client.tenant_id,
+        client,
         authParams: {
           client_id: client.id,
           audience,

--- a/src/authentication-flows/social.tsx
+++ b/src/authentication-flows/social.tsx
@@ -242,17 +242,9 @@ export async function socialAuthCallback({
     await ctx.env.data.logs.create(client.tenant_id, log);
   }
 
-  const sessionId = await setSilentAuthCookies(
-    env,
-    client.tenant_id,
-    client.id,
-    user,
-  );
-
   return generateAuthResponse({
     ctx,
-    tenant_id: client.tenant_id,
-    sid: sessionId,
+    client,
     authParams: state.authParams,
     user,
   });

--- a/src/authentication-flows/ticket.ts
+++ b/src/authentication-flows/ticket.ts
@@ -41,6 +41,7 @@ export async function ticketAuth(
   if (!ticket) {
     throw new HTTPException(403, { message: "Ticket not found" });
   }
+  const client = await getClient(ctx.env, ticket.client_id);
   ctx.set("client_id", ticket.client_id);
 
   await env.data.tickets.remove(tenant_id, ticketId);
@@ -127,22 +128,14 @@ export async function ticketAuth(
     ctx.set("userName", user.name || user.email);
   }
 
-  const sessionId = await setSilentAuthCookies(
-    env,
-    ticket.tenant_id,
-    ticket.client_id,
-    user,
-  );
-
   return generateAuthResponse({
     ctx,
     authParams: {
       scope: ticket.authParams?.scope,
       ...authParams,
     },
-    sid: sessionId,
     user,
-    tenant_id: ticket.tenant_id,
+    client,
     authFlow: "cross-origin",
   });
 }

--- a/src/authentication-flows/universal.ts
+++ b/src/authentication-flows/universal.ts
@@ -37,7 +37,7 @@ export async function universalAuth({
     if (user?.email === login_hint) {
       return generateAuthResponse({
         ctx,
-        tenant_id: client.tenant_id,
+        client,
         sid: session.session_id,
         authParams,
         user,
@@ -58,6 +58,11 @@ export async function universalAuth({
     client.tenant_id,
     universalLoginSession,
   );
+
+  // If there is a sesion we redirect to the check-account page
+  if (session) {
+    return ctx.redirect(`/u/check-account?state=${universalLoginSession.id}`);
+  }
 
   return ctx.redirect(`/u/enter-email?state=${universalLoginSession.id}`);
 }

--- a/src/components/CheckEmailPage.tsx
+++ b/src/components/CheckEmailPage.tsx
@@ -1,0 +1,54 @@
+import type { FC, JSXNode } from "hono/jsx";
+import Layout from "./Layout";
+import { VendorSettings } from "../types";
+import i18next, { t } from "i18next";
+import Trans from "./Trans";
+import { User } from "@authhero/adapter-interfaces";
+import Form from "./Form";
+import DisabledSubmitButton from "./DisabledSubmitButton";
+
+type Props = {
+  vendorSettings: VendorSettings;
+  state: string;
+  user: User;
+};
+
+const CheckEmailPage: FC<Props> = ({ vendorSettings, state, user }) => {
+  return (
+    <Layout title="Test" vendorSettings={vendorSettings}>
+      <div className="flex flex-1 flex-col justify-center">
+        <div className="mb-8 text-gray-300">
+          <Trans
+            i18nKey="currently_logged_in_as"
+            components={[
+              (
+                <span className="text-black dark:text-white" key="span" />
+              ) as unknown as JSXNode,
+            ]}
+            values={{ email: user.email }}
+          />
+          .<br />
+          {t("continue_with_sso_provider_headline")}
+        </div>
+
+        <div className="space-y-6">
+          <Form>
+            <DisabledSubmitButton className="text-base sm:mt-4 md:text-base">
+              <div className="flex items-center space-x-2">
+                <span>{i18next.t("yes_continue_with_existing_account")}</span>
+              </div>
+            </DisabledSubmitButton>
+          </Form>
+          <a
+            className="mx-auto block text-primary hover:text-primaryHover"
+            href={`/u/enter-email?state=${state}`}
+          >
+            {i18next.t("no_use_another")}
+          </a>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default CheckEmailPage;

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,4 +1,3 @@
-import classNames from "classnames";
 import { PropsWithChildren } from "hono/jsx";
 
 type Props = {

--- a/src/components/Trans.tsx
+++ b/src/components/Trans.tsx
@@ -1,0 +1,37 @@
+// Trans.tsx
+import { FC, JSXNode, cloneElement } from "hono/jsx";
+import i18next from "i18next";
+
+interface TransProps {
+  i18nKey: string;
+  values: Record<string, string>;
+  components: JSXNode[];
+}
+
+const Trans: FC<TransProps> = ({ i18nKey, values, components }) => {
+  const translation = i18next.t(i18nKey, values);
+  const regex = /<(\d+)>(.*?)<\/\d+>/g;
+
+  let result: (string | JSXNode)[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(translation)) !== null) {
+    const [fullMatch, index, content] = match;
+    const precedingText = translation.substring(lastIndex, match.index);
+    if (precedingText) {
+      result.push(precedingText);
+    }
+    const componentIndex = parseInt(index, 10);
+    result.push(cloneElement(components[componentIndex], {}, content));
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < translation.length) {
+    result.push(translation.substring(lastIndex));
+  }
+
+  return <>{result}</>;
+};
+
+export default Trans;

--- a/src/routes/oauth2/authorize.ts
+++ b/src/routes/oauth2/authorize.ts
@@ -180,6 +180,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         authParams,
         auth0Client,
         login_hint,
+        session: session || undefined,
       });
     },
   );

--- a/src/routes/oauth2/passwordless.ts
+++ b/src/routes/oauth2/passwordless.ts
@@ -151,17 +151,9 @@ export const passwordlessRoutes = new OpenAPIHono<{
           response_type,
         };
 
-        const sessionId = await setSilentAuthCookies(
-          env,
-          client.tenant_id,
-          client.id,
-          user,
-        );
-
         return generateAuthResponse({
           ctx,
-          tenant_id: client.tenant_id,
-          sid: sessionId,
+          client,
           user,
           authParams,
         });

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -50,8 +50,7 @@ export async function authorizeCodeGrant(
     ctx,
     authParams: { ...authParams, nonce },
     user,
-    sid: nanoid(),
-    tenant_id: client.tenant_id,
+    client,
     authFlow: "code",
   });
 

--- a/src/token-grant-types/clientCredentialsGrant.ts
+++ b/src/token-grant-types/clientCredentialsGrant.ts
@@ -6,7 +6,6 @@ import {
 } from "../types";
 import { getClient } from "../services/clients";
 import { generateAuthResponse } from "../helpers/generate-auth-response";
-import { nanoid } from "nanoid";
 import { HTTPException } from "hono/http-exception";
 import { Context } from "hono";
 
@@ -28,9 +27,7 @@ export async function clientCredentialsGrant(
 
   return generateAuthResponse({
     ctx,
-    tenant_id: client.tenant_id,
-    user: client,
-    sid: nanoid(),
+    client,
     authParams,
   });
 }

--- a/src/token-grant-types/pkceAuthorizeCodeGrant.ts
+++ b/src/token-grant-types/pkceAuthorizeCodeGrant.ts
@@ -49,6 +49,6 @@ export async function pkceAuthorizeCodeGrant(
   return generateAuthResponse({
     ...state,
     ctx,
-    tenant_id: client.tenant_id,
+    client,
   });
 }

--- a/test/integration/helpers/test-client.ts
+++ b/test/integration/helpers/test-client.ts
@@ -21,6 +21,11 @@ type getEnvParams = {
   emailValidation?: "enabled" | "enforced" | "disabled";
 };
 
+export const testPasswordUser = {
+  user_id: "auth2|userId",
+  password: "Test1234!",
+};
+
 export async function getEnv(args: getEnvParams = {}) {
   const dialect = new SqliteDialect({
     database: new SQLite(":memory:"),
@@ -199,10 +204,7 @@ export async function getEnv(args: getEnvParams = {}) {
     updated_at: new Date().toISOString(),
   });
 
-  await data.passwords.create("tenantId", {
-    user_id: "auth2|userId",
-    password: "Test1234!",
-  });
+  await data.passwords.create("tenantId", testPasswordUser);
 
   return {
     data: { ...addDataHooks(data), emails },

--- a/test/integration/login/silent-auth.spec.ts
+++ b/test/integration/login/silent-auth.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { getEnv, testPasswordUser } from "../helpers/test-client";
+import { oauthApp } from "../../../src/app";
+import { testClient } from "hono/testing";
+import { AuthorizationResponseType } from "../../../src/types";
+
+describe("Silent auth", () => {
+  it("should login using silent auth and the check-account page", async () => {
+    const env = await getEnv();
+    const oauthClient = testClient(oauthApp, env);
+
+    const searchParams = {
+      client_id: "clientId",
+      vendor_id: "kvartal",
+      response_type: AuthorizationResponseType.TOKEN_ID_TOKEN,
+      scope: "openid",
+      redirect_uri: "http://localhost:3000/callback",
+      state: "state",
+      username: "foo@example.com",
+    };
+    const response = await oauthClient.authorize.$get({
+      query: searchParams,
+    });
+    const location = response.headers.get("location");
+    const stateParam = new URLSearchParams(location!.split("?")[1]);
+    const query = Object.fromEntries(stateParam.entries());
+
+    const enterEmailResponse = await oauthClient.u["enter-email"].$post({
+      query: {
+        state: query.state,
+      },
+      form: {
+        username: searchParams.username,
+      },
+    });
+    expect(enterEmailResponse.status).toBe(302);
+
+    const enterPasswordRepsonse = await oauthClient.u["enter-password"].$post({
+      query: {
+        state: query.state,
+      },
+      form: {
+        password: testPasswordUser.password,
+      },
+    });
+
+    expect(enterPasswordRepsonse.status).toBe(302);
+    expect(enterPasswordRepsonse.headers.get("location")).toContain(
+      searchParams.redirect_uri,
+    );
+
+    const cookie = enterPasswordRepsonse.headers.get("set-cookie");
+    expect(cookie).toContain("tenantId-auth-token");
+
+    //--------------------------------------------------------------------------------
+    // Check that the authorize endpoint returns a redirect with the code if the login_hint matches the current user
+    //--------------------------------------------------------------------------------
+    const silentAuthResponseWithLoginHint = await oauthClient.authorize.$get(
+      {
+        query: {
+          ...searchParams,
+          login_hint: searchParams.username,
+        },
+      },
+      {
+        headers: {
+          cookie: cookie!,
+        },
+      },
+    );
+
+    expect(silentAuthResponseWithLoginHint.status).toBe(302);
+    const locationWithLoginHint =
+      silentAuthResponseWithLoginHint.headers.get("location");
+    expect(locationWithLoginHint).toContain("#access_token");
+
+    //--------------------------------------------------------------------------------
+    // Check that the authorize endpoint redirects to the check-account page if the login_hint does not match the current user
+    //--------------------------------------------------------------------------------
+    const silentAuthResponse = await oauthClient.authorize.$get(
+      {
+        query: searchParams,
+      },
+      {
+        headers: {
+          cookie: cookie!,
+        },
+      },
+    );
+
+    expect(silentAuthResponse.status).toBe(302);
+    const locationtionWithSilentAuth =
+      silentAuthResponse.headers.get("location");
+    expect(locationtionWithSilentAuth).toContain("/check-account");
+  });
+});


### PR DESCRIPTION
Added a new check-account page to handle the "do you want to continue with..." dialog. Also add a Trans component similar to what exists in react-i18n, but for hono jsx. 

Refactored a bit in the generateAuthResponse method to take the client instead. Think it makes it easier and we now create the silent auth tokens as part of this function as well.