### PR TITLE
feat: support login-hint and email connection

### DIFF
--- a/src/routes/oauth2/authorize.ts
+++ b/src/routes/oauth2/authorize.ts
@@ -53,10 +53,7 @@ export const authorizeRoutes = new OpenAPIHono<{
           code_challenge: z.string().optional(),
           realm: z.string().optional(),
           auth0Client: z.string().optional(),
-          // Auth0 way
           login_hint: z.string().optional(),
-          // deprecated: previous token service param
-          email_hint: z.string().optional(),
         }),
       },
       responses: {
@@ -88,8 +85,6 @@ export const authorizeRoutes = new OpenAPIHono<{
         auth0Client,
         username,
         login_hint,
-        // TODO: This is incorrect.. Remove
-        email_hint,
       } = ctx.req.valid("query");
 
       const client = await getClient(env, client_id);
@@ -106,7 +101,7 @@ export const authorizeRoutes = new OpenAPIHono<{
         response_type,
         code_challenge,
         code_challenge_method,
-        username: username || login_hint || email_hint,
+        username: username || login_hint,
       };
 
       const origin = ctx.req.header("origin");
@@ -157,7 +152,7 @@ export const authorizeRoutes = new OpenAPIHono<{
       }
 
       // Social login
-      if (connection) {
+      if (connection && connection !== "email") {
         return socialAuth(ctx, client, connection, authParams);
       } else if (login_ticket) {
         return ticketAuth(
@@ -174,8 +169,9 @@ export const authorizeRoutes = new OpenAPIHono<{
         client,
         authParams,
         auth0Client,
-        login_hint,
         session: session || undefined,
+        connection,
+        login_hint,
       });
     },
   );

--- a/src/utils/getSendParamFromAuth0ClientHeader.ts
+++ b/src/utils/getSendParamFromAuth0ClientHeader.ts
@@ -7,15 +7,15 @@ type Auth0Client = {
 
 const APP_CLIENT_IDS = ["Auth0.swift"];
 
-export type sendParam = "link" | "code";
+export type SendType = "link" | "code";
 
 // copied from login2
 export function getSendParamFromAuth0ClientHeader(
   auth0ClientHeader?: string,
-): sendParam {
+): SendType {
   if (!auth0ClientHeader) return "link";
 
-  const decodedAuth0Client = atob(auth0ClientHeader); // can we use Zod?
+  const decodedAuth0Client = atob(auth0ClientHeader);
 
   const auth0Client = JSON.parse(decodedAuth0Client) as Auth0Client;
 


### PR DESCRIPTION
Add support for setting both the login_hint and connection = email to end up straight on the code verification page. Refactored the code to separate the sendOtpEmail to a flow, but haven't yet replaced the other code-paths.