### PR TITLE
fix: login hint with code

### DIFF
--- a/src/helpers/generate-auth-response.ts
+++ b/src/helpers/generate-auth-response.ts
@@ -73,7 +73,6 @@ async function generateCode({
   }
 
   const code_id = nanoid();
-
   let login_id = sid;
 
   if (!login_id) {

--- a/src/helpers/silent-auth-cookie.ts
+++ b/src/helpers/silent-auth-cookie.ts
@@ -17,7 +17,7 @@ export async function setSilentAuthCookies(
     used_at: new Date().toISOString(),
   };
 
-  await env.data.sessions.create(tenant_id, session);
+  const createdSession = await env.data.sessions.create(tenant_id, session);
 
   return session.session_id;
 }

--- a/src/routes/management-api/prompts.ts
+++ b/src/routes/management-api/prompts.ts
@@ -84,12 +84,8 @@ export const promptsRoutes = new OpenAPIHono<{ Bindings: Env }>()
 
       const promptSettings = ctx.req.valid("json");
 
-      console.log("promptSettings", promptSettings);
-
       const updatedPromptSettings =
         await ctx.env.data.promptSettings.get(tenant_id);
-
-      console.log("updatedPromptSettings", updatedPromptSettings);
 
       Object.assign(updatedPromptSettings, promptSettings);
 

--- a/src/routes/oauth2/authorize.ts
+++ b/src/routes/oauth2/authorize.ts
@@ -124,9 +124,10 @@ export const authorizeRoutes = new OpenAPIHono<{
         client.tenant.id,
         ctx.req.header("cookie"),
       );
+
       const session = authCookie
         ? await env.data.sessions.get(client.tenant.id, authCookie)
-        : null;
+        : undefined;
 
       // Silent authentication with iframe
       if (prompt == "none") {

--- a/src/routes/oauth2/token.ts
+++ b/src/routes/oauth2/token.ts
@@ -68,6 +68,8 @@ export const tokenRoutes = new OpenAPIHono<{
         throw new HTTPException(400, { message: "client_id is required" });
       }
 
+      console.log("grant type", body.grant_type);
+
       switch (body.grant_type) {
         case GrantType.AuthorizationCode:
           if ("client_secret" in body) {

--- a/src/routes/universal-login/routes.tsx
+++ b/src/routes/universal-login/routes.tsx
@@ -605,8 +605,6 @@ export const loginRoutes = new OpenAPIHono<{ Bindings: Env; Variables: Var }>()
         state,
       );
 
-      console.log("test");
-
       return ctx.html(
         <EnterEmailPage
           vendorSettings={vendorSettings}

--- a/src/token-grant-types/authorizationCodeGrant.ts
+++ b/src/token-grant-types/authorizationCodeGrant.ts
@@ -37,7 +37,7 @@ export async function authorizeCodeGrant(
   );
 
   if (!login) {
-    throw new HTTPException(400, { message: "Code not found" });
+    throw new HTTPException(400, { message: "Login not found" });
   }
 
   // Set the response_type to token id_token for the code grant flow

--- a/test/integration/login/ui-locale.spec.ts
+++ b/test/integration/login/ui-locale.spec.ts
@@ -27,8 +27,6 @@ test("Should user the language passed in the authorize call", async () => {
 
   const query = Object.fromEntries(stateParam.entries());
 
-  console.log("state", query.state);
-
   const getSendCodeResponse = await oauthClient.u["enter-email"].$get({
     query: { state: query.state },
   });


### PR DESCRIPTION
Fix so that the login_hint codes are generated with a reference to the universallogin session rather than the token session