### PR TITLE
fix: upgrade to 0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@peculiar/x509": "^1.12.3",
     "@planetscale/database": "1.19.0",
     "arctic": "^2.3.0",
-    "authhero": "^0.21.0",
+    "authhero": "^0.22.0",
     "bcryptjs": "^2.4.3",
     "fast-xml-parser": "^4.5.0",
     "hono": "4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@
   resolved "https://registry.yarnpkg.com/@authhero/adapter-interfaces/-/adapter-interfaces-0.29.1.tgz#69c6d449320094e2a54d4da062b30e1cb96a56be"
   integrity sha512-CPibpdVCQ2yA//guyn0h+JiqGSCb+Hi5wCT+0jzkh4TuFdKBGpI+JX6FZReRs7aO+qIV3DMmcov6zFH3UQln5Q==
 
+"@authhero/adapter-interfaces@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@authhero/adapter-interfaces/-/adapter-interfaces-0.30.0.tgz#5304a1367589e26b2d8e1f2f878d1ca36206a0df"
+  integrity sha512-fauqIGY+UC9i6S2TJpWKojE30SWuvbPXtCh9VgtZjNl0P70PsnfZ55zb6hYprR9yg6+2/EtX9IdoeYiK/SWEPQ==
+
 "@authhero/kysely-adapter@0.24.3":
   version "0.24.3"
   resolved "https://registry.yarnpkg.com/@authhero/kysely-adapter/-/kysely-adapter-0.24.3.tgz#3ae8eb91bf2a148e64cd7bf7a3051cea708fcc4e"
@@ -2208,12 +2213,12 @@ assertion-error@^2.0.1:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
-authhero@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/authhero/-/authhero-0.21.0.tgz#d95917c925566a529ce7db46baedd4cd65df712b"
-  integrity sha512-/upeTwpHkDzOTbCpi0mcecMfXMjwCdrgpbNjXnE6Ux9ePnVlXoXfUN2545LDcXgcGrlBMZB/252xk6SGG8mC9w==
+authhero@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/authhero/-/authhero-0.22.0.tgz#08c66c8ca8d4027847665f05af30605db29c6990"
+  integrity sha512-yub9AAohKPuQ+STcHAAyC11ft8L+egt6JGKmneK3Qx8V7o9xc1OqFS3/vkHViwSZzIYxPkxdBZXM6l1EzgetGQ==
   dependencies:
-    "@authhero/adapter-interfaces" "^0.29.1"
+    "@authhero/adapter-interfaces" "^0.30.0"
     "@peculiar/x509" "^1.12.3"
     bcrypt "^5.1.1"
     bcryptjs "^2.4.3"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `authhero` dependency to version `^0.22.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->